### PR TITLE
ci: add cross-compilation matrix for 5 targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,42 @@ jobs:
       - run: convco check ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
 
   build-release:
-    name: Build (release)
+    name: Build (${{ matrix.target }})
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --release
+        with:
+          key: ${{ matrix.target }}
+      - name: Install musl tools
+        if: contains(matrix.target, 'musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
+            sudo apt-get install -y gcc-aarch64-linux-gnu
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+          fi
+      - run: cargo build --release --target ${{ matrix.target }}
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-std-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/git-std${{ contains(matrix.target, 'windows') && '.exe' || '' }}


### PR DESCRIPTION
## Summary

- Replace single `build-release` job with a 5-target matrix
- Targets: `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`
- Install musl-tools and cross-linker for Linux targets
- Upload release binaries as CI artifacts via `upload-artifact@v4`
- Only runs on push to main

## Test plan

- [ ] CI matrix produces 5 separate build jobs
- [ ] Linux musl targets install musl-tools
- [ ] aarch64 linux target sets cross-linker
- [ ] Artifacts uploaded for each target

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)