### PR TITLE
ci: add GitHub Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+      - name: Install musl tools
+        if: contains(matrix.target, 'musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
+            sudo apt-get install -y gcc-aarch64-linux-gnu
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+          fi
+      - run: cargo build --release --target ${{ matrix.target }}
+      - name: Rename binary
+        shell: bash
+        run: |
+          src="target/${{ matrix.target }}/release/git-std${{ contains(matrix.target, 'windows') && '.exe' || '' }}"
+          dst="git-std-${{ matrix.target }}${{ contains(matrix.target, 'windows') && '.exe' || '' }}"
+          cp "$src" "$dst"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: git-std-${{ matrix.target }}
+          path: git-std-${{ matrix.target }}${{ contains(matrix.target, 'windows') && '.exe' || '' }}
+
+  release:
+    name: Create release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum git-std-* > sha256sums.txt
+          cat sha256sums.txt
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts/git-std-*
+            artifacts/sha256sums.txt
+            install.sh


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` triggered on `v*` tag push
- Cross-compiles all 5 targets (same matrix as CI)
- Creates GitHub Release with binaries, SHA256 checksums, and install script
- Uses `softprops/action-gh-release@v2` for release creation

## Test plan

- [ ] Tag push triggers the workflow
- [ ] All 5 binaries are built and uploaded
- [ ] SHA256 checksums file is generated and attached
- [ ] install.sh is attached to the release

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)