### PR TITLE
chore(infra): add repofolio compliance files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.{toml,yml,yaml,json,md}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[justfile]
+indent_style = space
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+*.rs text diff=rust
+*.toml text
+*.md text
+*.yml text
+*.yaml text
+*.json text
+*.sh text eol=lf
+*.lock linguist-generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]

--- a/bootstrap
+++ b/bootstrap
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap the development environment for git-std.
+# Installs Rust toolchain if missing and sets up git hooks.
+
+check_rust() {
+  if ! command -v rustup >/dev/null 2>&1; then
+    printf 'installing Rust toolchain via rustup...\n'
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    # shellcheck source=/dev/null
+    source "$HOME/.cargo/env"
+  else
+    printf 'Rust toolchain: %s\n' "$(rustc --version)"
+  fi
+}
+
+install_tools() {
+  if ! command -v dprint >/dev/null 2>&1; then
+    printf 'installing dprint...\n'
+    cargo install dprint
+  fi
+
+  if ! command -v just >/dev/null 2>&1; then
+    printf 'installing just...\n'
+    cargo install just
+  fi
+}
+
+setup_hooks() {
+  if command -v git-std >/dev/null 2>&1; then
+    printf 'installing git hooks via git-std...\n'
+    git std hooks install
+  else
+    printf 'note: git-std not found — skipping hooks install (run after first build)\n'
+  fi
+}
+
+main() {
+  printf '=== git-std bootstrap ===\n'
+  check_rust
+  install_tools
+  setup_hooks
+  printf '\nbootstrap complete. Run "just build" to build the project.\n'
+}
+
+main "$@"

--- a/runw
+++ b/runw
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wrapper to run just recipes from any subdirectory.
+# Usage: ./runw <recipe> [args...]
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+exec just --justfile "$REPO_ROOT/justfile" --working-directory "$REPO_ROOT" "$@"


### PR DESCRIPTION
## Summary

- Add `.editorconfig` with settings for Rust, TOML, YAML, Markdown
- Add `.gitattributes` with LF line endings and linguist hints
- Add `CHANGELOG.md` stub (Keep a Changelog format)
- Add `bootstrap` script: installs Rust toolchain, dprint, just, and git hooks
- Add `runw` wrapper to run just recipes from any subdirectory

## Test plan

- [ ] `.editorconfig` is picked up by editors
- [ ] `./bootstrap` installs missing tools
- [ ] `./runw build` works from a subdirectory
- [ ] `.gitattributes` normalizes line endings

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)