### PR TITLE
feat(check): implement inline commit message validation

### DIFF
--- a/crates/git-std/src/check.rs
+++ b/crates/git-std/src/check.rs
@@ -1,0 +1,18 @@
+use git_std::commit;
+
+/// Run the `check` subcommand with an inline message. Returns the exit code.
+pub fn run(message: &str) -> i32 {
+    match commit::parse(message) {
+        Ok(_) => 0,
+        Err(e) => {
+            eprintln!("\u{2717} invalid: {e}");
+            eprintln!("  Expected: <type>(<scope>): <description>");
+            eprintln!("  Got:      {}", first_line(message));
+            1
+        }
+    }
+}
+
+fn first_line(s: &str) -> &str {
+    s.lines().next().unwrap_or(s)
+}

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -1,5 +1,7 @@
 use clap::{Parser, Subcommand};
 
+mod check;
+
 /// Standard git workflow — commits, versioning, hooks.
 #[derive(Parser)]
 #[command(name = "git-std", version, about)]
@@ -14,7 +16,10 @@ enum Command {
     /// Interactive conventional commit builder.
     Commit,
     /// Validate commit messages.
-    Check,
+    Check {
+        /// Commit message to validate.
+        message: String,
+    },
     /// Version bump, changelog, commit, and tag.
     Bump,
     /// Generate a changelog.
@@ -28,15 +33,21 @@ enum Command {
 fn main() {
     let cli = Cli::parse();
 
-    let name = match cli.command {
-        Command::Commit => "commit",
-        Command::Check => "check",
-        Command::Bump => "bump",
-        Command::Changelog => "changelog",
-        Command::Hooks => "hooks",
-        Command::SelfUpdate => "self-update",
-    };
-
-    eprintln!("git-std {name}: not yet implemented");
-    std::process::exit(1);
+    match cli.command {
+        Command::Check { message } => {
+            std::process::exit(check::run(&message));
+        }
+        other => {
+            let name = match other {
+                Command::Commit => "commit",
+                Command::Check { .. } => unreachable!(),
+                Command::Bump => "bump",
+                Command::Changelog => "changelog",
+                Command::Hooks => "hooks",
+                Command::SelfUpdate => "self-update",
+            };
+            eprintln!("git-std {name}: not yet implemented");
+            std::process::exit(1);
+        }
+    }
 }

--- a/crates/git-std/tests/check.rs
+++ b/crates/git-std/tests/check.rs
@@ -1,0 +1,107 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+
+fn git_std() -> Command {
+    Command::cargo_bin("git-std").unwrap()
+}
+
+// ── Valid messages exit 0 ────────────────────────────────────────
+
+#[test]
+fn valid_simple_message() {
+    git_std()
+        .args(["check", "feat: add login"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn valid_scoped_message() {
+    git_std()
+        .args(["check", "feat(auth): add PKCE"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn valid_breaking_bang() {
+    git_std()
+        .args(["check", "feat!: remove legacy API"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn valid_with_body() {
+    git_std()
+        .args(["check", "fix(core): handle nil pointer\n\nAdded nil check before dereferencing the config pointer."])
+        .assert()
+        .success();
+}
+
+#[test]
+fn valid_with_breaking_change_footer() {
+    git_std()
+        .args([
+            "check",
+            "feat: change token format\n\nBREAKING CHANGE: tokens are now opaque strings",
+        ])
+        .assert()
+        .success();
+}
+
+// ── Invalid messages exit 1 with diagnostic ─────────────────────
+
+#[test]
+fn invalid_missing_type() {
+    git_std()
+        .args(["check", "bad message"])
+        .assert()
+        .code(1)
+        .stderr(contains("invalid"));
+}
+
+#[test]
+fn invalid_missing_description() {
+    git_std()
+        .args(["check", "feat: "])
+        .assert()
+        .code(1)
+        .stderr(contains("invalid"));
+}
+
+#[test]
+fn invalid_no_colon() {
+    git_std()
+        .args(["check", "feat add login"])
+        .assert()
+        .code(1)
+        .stderr(contains("invalid"));
+}
+
+#[test]
+fn invalid_uppercase_type() {
+    git_std()
+        .args(["check", "FEAT: add login"])
+        .assert()
+        .code(1)
+        .stderr(contains("invalid"));
+}
+
+#[test]
+fn diagnostic_shows_expected_format() {
+    git_std()
+        .args(["check", "not a valid commit"])
+        .assert()
+        .code(1)
+        .stderr(contains("Expected: <type>(<scope>): <description>"));
+}
+
+#[test]
+fn diagnostic_shows_got_line() {
+    git_std()
+        .args(["check", "not a valid commit"])
+        .assert()
+        .code(1)
+        .stderr(contains("Got:"));
+}

--- a/crates/git-std/tests/cli.rs
+++ b/crates/git-std/tests/cli.rs
@@ -45,14 +45,7 @@ fn unknown_subcommand_exits_2() {
 
 #[test]
 fn stub_subcommands_are_recognized() {
-    for sub in [
-        "commit",
-        "check",
-        "bump",
-        "changelog",
-        "hooks",
-        "self-update",
-    ] {
+    for sub in ["commit", "bump", "changelog", "hooks", "self-update"] {
         Command::cargo_bin("git-std")
             .unwrap()
             .arg(sub)


### PR DESCRIPTION
## Summary
- Wire up `git std check "<message>"` subcommand with clap positional arg
- Valid messages exit 0, invalid messages exit 1 with diagnostic (expected format, got line)
- 11 acceptance tests covering valid/invalid messages and diagnostic output

## Test plan
- [x] 11 acceptance tests in `tests/check.rs`
- [x] Updated `tests/cli.rs` stub test (removed `check` from stubs since it is now implemented)
- [x] `cargo clippy` clean, `cargo fmt` clean

Stacked on #82. Closes #10.

Generated with [Claude Code](https://claude.com/claude-code)