### PR TITLE
feat(check): add --format json and coloured output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,9 +364,12 @@ dependencies = [
  "git2",
  "inquire",
  "predicates",
+ "serde",
+ "serde_json",
  "standard-commit",
  "tempfile",
  "toml",
+ "yansi",
 ]
 
 [[package]]
@@ -866,6 +869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1357,6 +1361,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/crates/git-std/Cargo.toml
+++ b/crates/git-std/Cargo.toml
@@ -16,10 +16,14 @@ path = "src/main.rs"
 clap = { version = "4.6.0", features = ["derive"] }
 inquire = "0.9"
 git2 = { version = "0.20", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 standard-commit = { path = "../standard-commit" }
 toml = "0.8"
+yansi = "1"
 
 [dev-dependencies]
 assert_cmd = "2.2.0"
 predicates = "3.1.4"
+serde_json = "1"
 tempfile = "3"

--- a/crates/git-std/src/check.rs
+++ b/crates/git-std/src/check.rs
@@ -1,16 +1,49 @@
 use std::path::Path;
 
+use clap::ValueEnum;
+use serde::Serialize;
+use yansi::Paint;
+
 use standard_commit::LintConfig;
 
+/// Output format for the check subcommand.
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
+pub enum OutputFormat {
+    /// Human-readable text (default).
+    Text,
+    /// Machine-readable JSON.
+    Json,
+}
+
+/// JSON output schema for a single commit check.
+#[derive(Serialize)]
+struct CheckResult {
+    valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    r#type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scope: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    breaking: Option<bool>,
+    errors: Vec<String>,
+}
+
 /// Run the `check` subcommand with an inline message. Returns the exit code.
-pub fn run(message: &str, lint_config: Option<&LintConfig>) -> i32 {
+pub fn run(message: &str, lint_config: Option<&LintConfig>, format: OutputFormat) -> i32 {
+    if format == OutputFormat::Json {
+        return run_json(message, lint_config);
+    }
+
     if let Some(config) = lint_config {
         let errors = standard_commit::lint(message, config);
         if errors.is_empty() {
+            eprintln!("{} {}", "\u{2713}".green(), "valid".green());
             return 0;
         }
         for error in &errors {
-            eprintln!("\u{2717} {error}");
+            eprintln!("{} {}", "\u{2717}".red(), error.to_string().red());
         }
         eprintln!("  Expected: <type>(<scope>): <description>");
         eprintln!("  Got:      {}", first_line(message));
@@ -18,7 +51,10 @@ pub fn run(message: &str, lint_config: Option<&LintConfig>) -> i32 {
     }
 
     match standard_commit::parse(message) {
-        Ok(_) => 0,
+        Ok(_) => {
+            eprintln!("{} {}", "\u{2713}".green(), "valid".green());
+            0
+        }
         Err(e) => {
             print_diagnostic(message, &e);
             1
@@ -26,8 +62,65 @@ pub fn run(message: &str, lint_config: Option<&LintConfig>) -> i32 {
     }
 }
 
+/// Run check with JSON output.
+fn run_json(message: &str, lint_config: Option<&LintConfig>) -> i32 {
+    let result = if let Some(config) = lint_config {
+        let errors = standard_commit::lint(message, config);
+        if errors.is_empty() {
+            build_valid_result(message)
+        } else {
+            CheckResult {
+                valid: false,
+                r#type: None,
+                scope: None,
+                description: None,
+                breaking: None,
+                errors: errors.iter().map(|e| e.to_string()).collect(),
+            }
+        }
+    } else {
+        match standard_commit::parse(message) {
+            Ok(_) => build_valid_result(message),
+            Err(e) => CheckResult {
+                valid: false,
+                r#type: None,
+                scope: None,
+                description: None,
+                breaking: None,
+                errors: vec![e.to_string()],
+            },
+        }
+    };
+
+    let code = if result.valid { 0 } else { 1 };
+    println!("{}", serde_json::to_string(&result).unwrap());
+    code
+}
+
+/// Build a valid CheckResult by parsing the commit message.
+fn build_valid_result(message: &str) -> CheckResult {
+    match standard_commit::parse(message) {
+        Ok(commit) => CheckResult {
+            valid: true,
+            r#type: Some(commit.r#type),
+            scope: commit.scope,
+            description: Some(commit.description),
+            breaking: Some(commit.is_breaking),
+            errors: vec![],
+        },
+        Err(_) => CheckResult {
+            valid: true,
+            r#type: None,
+            scope: None,
+            description: None,
+            breaking: None,
+            errors: vec![],
+        },
+    }
+}
+
 /// Read a commit message from a file, strip comment lines, and validate.
-pub fn run_file(path: &Path, lint_config: Option<&LintConfig>) -> i32 {
+pub fn run_file(path: &Path, lint_config: Option<&LintConfig>, format: OutputFormat) -> i32 {
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(e) => {
@@ -36,11 +129,11 @@ pub fn run_file(path: &Path, lint_config: Option<&LintConfig>) -> i32 {
         }
     };
     let message = strip_comments(&content);
-    run(&message, lint_config)
+    run(&message, lint_config, format)
 }
 
 /// Validate all commits in a git revision range. Returns 0 if all valid, 1 if any invalid.
-pub fn run_range(range: &str, lint_config: Option<&LintConfig>) -> i32 {
+pub fn run_range(range: &str, lint_config: Option<&LintConfig>, format: OutputFormat) -> i32 {
     let repo = match git2::Repository::discover(".") {
         Ok(r) => r,
         Err(e) => {
@@ -62,6 +155,10 @@ pub fn run_range(range: &str, lint_config: Option<&LintConfig>) -> i32 {
         return 2;
     }
 
+    if format == OutputFormat::Json {
+        return run_range_json(&commits, lint_config);
+    }
+
     let mut failures = 0;
     for (oid, message) in &commits {
         let short = &oid.to_string()[..7];
@@ -70,9 +167,14 @@ pub fn run_range(range: &str, lint_config: Option<&LintConfig>) -> i32 {
             if errors.is_empty() {
                 true
             } else {
-                eprintln!("\u{2717} {short} {}", first_line(message));
+                eprintln!(
+                    "{} {} {}",
+                    "\u{2717}".red(),
+                    short,
+                    first_line(message).red()
+                );
                 for error in &errors {
-                    eprintln!("  {error}");
+                    eprintln!("  {}", error.to_string().red());
                 }
                 false
             }
@@ -80,21 +182,75 @@ pub fn run_range(range: &str, lint_config: Option<&LintConfig>) -> i32 {
             match standard_commit::parse(message) {
                 Ok(_) => true,
                 Err(e) => {
-                    eprintln!("\u{2717} {short} {}", first_line(message));
-                    eprintln!("  {e}");
+                    eprintln!(
+                        "{} {} {}",
+                        "\u{2717}".red(),
+                        short,
+                        first_line(message).red()
+                    );
+                    eprintln!("  {}", e.to_string().red());
                     false
                 }
             }
         };
 
         if valid {
-            eprintln!("\u{2713} {short} {}", first_line(message));
+            eprintln!(
+                "{} {} {}",
+                "\u{2713}".green(),
+                short,
+                first_line(message).green()
+            );
         } else {
             failures += 1;
         }
     }
 
     if failures > 0 { 1 } else { 0 }
+}
+
+/// Run range check with JSON output — outputs a JSON array.
+fn run_range_json(commits: &[(git2::Oid, String)], lint_config: Option<&LintConfig>) -> i32 {
+    let mut results = Vec::new();
+    let mut any_invalid = false;
+
+    for (_oid, message) in commits {
+        let result = if let Some(config) = lint_config {
+            let errors = standard_commit::lint(message, config);
+            if errors.is_empty() {
+                build_valid_result(message)
+            } else {
+                CheckResult {
+                    valid: false,
+                    r#type: None,
+                    scope: None,
+                    description: None,
+                    breaking: None,
+                    errors: errors.iter().map(|e| e.to_string()).collect(),
+                }
+            }
+        } else {
+            match standard_commit::parse(message) {
+                Ok(_) => build_valid_result(message),
+                Err(e) => CheckResult {
+                    valid: false,
+                    r#type: None,
+                    scope: None,
+                    description: None,
+                    breaking: None,
+                    errors: vec![e.to_string()],
+                },
+            }
+        };
+
+        if !result.valid {
+            any_invalid = true;
+        }
+        results.push(result);
+    }
+
+    println!("{}", serde_json::to_string(&results).unwrap());
+    if any_invalid { 1 } else { 0 }
 }
 
 /// Strip lines starting with `#` (git comment convention).
@@ -125,7 +281,7 @@ fn walk_range(
 }
 
 fn print_diagnostic(message: &str, error: &standard_commit::ParseError) {
-    eprintln!("\u{2717} invalid: {error}");
+    eprintln!("{} {}", "\u{2717}".red(), format!("invalid: {error}").red());
     eprintln!("  Expected: <type>(<scope>): <description>");
     eprintln!("  Got:      {}", first_line(message));
 }

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -1,4 +1,6 @@
-use clap::{Parser, Subcommand};
+use std::io::IsTerminal;
+
+use clap::{Parser, Subcommand, ValueEnum};
 
 mod check;
 mod commit;
@@ -8,8 +10,23 @@ mod config;
 #[derive(Parser)]
 #[command(name = "git-std", version, about)]
 struct Cli {
+    /// When to use coloured output.
+    #[arg(long, global = true, default_value = "auto")]
+    color: ColorWhen,
+
     #[command(subcommand)]
     command: Command,
+}
+
+/// When to enable coloured output.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ColorWhen {
+    /// Colour if stdout is a TTY.
+    Auto,
+    /// Always use colour.
+    Always,
+    /// Never use colour.
+    Never,
 }
 
 /// Available subcommands.
@@ -30,6 +47,9 @@ enum Command {
         /// Reject types/scopes not in `.git-std.toml` and require scope if scopes are defined.
         #[arg(long)]
         strict: bool,
+        /// Output format.
+        #[arg(long, default_value = "text")]
+        format: check::OutputFormat,
     },
     /// Version bump, changelog, commit, and tag.
     Bump,
@@ -44,12 +64,24 @@ enum Command {
 fn main() {
     let cli = Cli::parse();
 
+    // Configure yansi colour output based on --color flag.
+    match cli.color {
+        ColorWhen::Always => yansi::enable(),
+        ColorWhen::Never => yansi::disable(),
+        ColorWhen::Auto => {
+            if !std::io::stdout().is_terminal() {
+                yansi::disable();
+            }
+        }
+    }
+
     match cli.command {
         Command::Check {
             message,
             file,
             range,
             strict,
+            format,
         } => {
             let project_config = config::load(&std::env::current_dir().unwrap_or_default());
             let effective_strict = strict || project_config.strict;
@@ -61,11 +93,11 @@ fn main() {
             };
 
             let code = if let Some(path) = file {
-                check::run_file(&path, lint_ref)
+                check::run_file(&path, lint_ref, format)
             } else if let Some(range) = range {
-                check::run_range(&range, lint_ref)
+                check::run_range(&range, lint_ref, format)
             } else if let Some(message) = message {
-                check::run(&message, lint_ref)
+                check::run(&message, lint_ref, format)
             } else {
                 eprintln!("error: provide a message, --file, or --range");
                 2

--- a/crates/git-std/tests/check.rs
+++ b/crates/git-std/tests/check.rs
@@ -416,3 +416,105 @@ fn strict_file_validates_against_config() {
         .code(1)
         .stderr(contains("not in the allowed list"));
 }
+
+// ── --format json (#20) ─────────────────────────────────────────
+
+#[test]
+fn json_valid_simple() {
+    let output = git_std()
+        .args(["check", "--format", "json", "feat: add login"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["valid"], true);
+    assert_eq!(v["type"], "feat");
+    assert_eq!(v["scope"], serde_json::Value::Null);
+    assert_eq!(v["description"], "add login");
+    assert_eq!(v["breaking"], false);
+    assert!(v["errors"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn json_valid_scoped_breaking() {
+    let output = git_std()
+        .args([
+            "check",
+            "--format",
+            "json",
+            "refactor(runtime)!: drop Python 2 support",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["valid"], true);
+    assert_eq!(v["type"], "refactor");
+    assert_eq!(v["scope"], "runtime");
+    assert_eq!(v["breaking"], true);
+}
+
+#[test]
+fn json_invalid_message() {
+    let output = git_std()
+        .args(["check", "--format", "json", "bad message"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["valid"], false);
+    assert!(!v["errors"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn json_invalid_strict() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = git_std()
+        .args(["check", "--strict", "--format", "json", "yolo: do things"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["valid"], false);
+    assert!(
+        v["errors"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e.as_str().unwrap().contains("not in the allowed list"))
+    );
+}
+
+// ── --color never (#21) ─────────────────────────────────────────
+
+#[test]
+fn color_never_no_ansi_codes_valid() {
+    let output = git_std()
+        .args(["--color", "never", "check", "feat: add login"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // ANSI escape sequences start with ESC (0x1B)
+    assert!(
+        !stderr.contains('\x1b'),
+        "stderr should not contain ANSI escape codes with --color never"
+    );
+    assert!(stderr.contains("\u{2713}"));
+}
+
+#[test]
+fn color_never_no_ansi_codes_invalid() {
+    let output = git_std()
+        .args(["--color", "never", "check", "bad message"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains('\x1b'),
+        "stderr should not contain ANSI escape codes with --color never"
+    );
+    assert!(stderr.contains("\u{2717}"));
+}


### PR DESCRIPTION
## Summary
- Adds `--format json` to `git std check` outputting `{"valid", "type", "scope", "description", "breaking", "errors"}`
- Adds `--color <always|never|auto>` top-level flag with TTY detection via `std::io::IsTerminal`
- Green checkmark for valid messages, red cross for errors when colour is enabled
- New dependencies: `serde`, `serde_json`, `yansi`

## Test plan
- [x] Integration tests: `json_valid_simple`, `json_valid_scoped_breaking`, `json_invalid_message`, `json_invalid_strict`, `color_never_no_ansi_codes_valid`, `color_never_no_ansi_codes_invalid`
- [x] `just check` passes (all tests, clippy, fmt, audit)

Closes #20, closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)