### PR TITLE
docs: add README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,13 @@
-# Contributing guidelines
+# Contributing to git-std
 
 ## Reporting issues
 
 Open bugs and feature requests at
 <https://github.com/driftsys/git-std/issues>.
 
-## Prerequisites
+## Dev setup
+
+You need the Rust toolchain and a few extra tools:
 
 - **Rust**: stable toolchain (install via [rustup](https://rustup.rs))
 - **[just]**: command runner
@@ -13,26 +15,72 @@ Open bugs and feature requests at
 - **[cargo-audit]**: dependency auditor
 
 ```bash
-just build    # Compile + run all checks
-just test     # Run tests
-just lint     # Lint + format check
-just fmt      # Format Rust + Markdown
-just verify   # Full pre-PR gate (commitlint + build)
+# Clone and build
+git clone https://github.com/driftsys/git-std.git
+cd git-std
+just build
 ```
 
 [just]: https://github.com/casey/just
 [dprint]: https://dprint.dev
 [cargo-audit]: https://github.com/rustsec/rustsec
 
-## Coding style
+## Architecture
 
-Rust code must pass `cargo fmt` and `cargo clippy` with no warnings. Markdown
-files must pass `dprint check`. Run `just fmt` to auto-format everything.
+The project is a Cargo workspace with one binary crate and four library crates:
+
+```text
+git-std/
+├── crates/
+│   ├── git-std/              # CLI binary — arg parsing, I/O, config loading
+│   ├── standard-commit/      # Conventional commit parsing, linting, formatting
+│   ├── standard-version/     # Semver and calver bump calculation
+│   ├── standard-changelog/   # Changelog generation from parsed commits
+│   └── standard-githooks/    # Hook file format, shim generation, execution model
+├── docs/
+│   └── SPEC.md               # Full specification
+└── .githooks/                # Hook definitions
+```
+
+**Design principle:** library crates are pure domain logic — strings in, data
+out. They have no dependency on git, the filesystem, or the terminal. The
+`git-std` binary crate is the orchestrator that wires libraries together with
+CLI dispatch, config loading, git operations (via `git2`), and terminal I/O.
+
+Read [docs/SPEC.md](docs/SPEC.md) for the full specification.
+
+## Testing
+
+```bash
+just test               # Run all tests
+cargo test <test_name>  # Run a specific test
+just check              # Tests + lint + audit
+just verify             # Full pre-PR gate (commit lint + build)
+```
+
+### Test conventions
+
+- **Acceptance tests** go in `crates/git-std/tests/` — these test the CLI
+  binary end-to-end.
+- **Unit tests** go inline in `#[cfg(test)]` modules alongside the code they
+  test.
+- Follow ATDD + TDD: write acceptance tests from the story's acceptance
+  criteria first, then TDD the implementation.
+
+## Code style
+
+```bash
+just fmt    # Format Rust + Markdown
+just lint   # Lint + format check
+```
+
+- Rust code must pass `cargo fmt` and `cargo clippy` with no warnings.
+- Markdown files must pass `dprint check`.
+- Always run `just fmt` before committing.
 
 ### Meaningful names
 
-Consistency across the codebase is the law. Follow the "Clean Code" naming
-rules:
+Follow the "Clean Code" naming rules:
 
 - Use intention-revealing names.
 - Avoid disinformation — don't call something a `list` if it isn't one.
@@ -60,6 +108,12 @@ Follow the [Conventional Commits](https://www.conventionalcommits.org/)
 specification. Write the description in imperative mood — e.g., "add support
 for X" instead of "added support for X".
 
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `build`,
+`perf`, `style`.
+
+Squash work into one conventional commit per task. Body is optional and must not
+exceed 10 lines.
+
 ## Branches and pull requests
 
 Create a feature branch from `main` with a short, descriptive name — e.g.,
@@ -68,10 +122,11 @@ applicable: `42-fix-tag-detection`.
 
 Pull request guidelines:
 
-- Prefer a single commit per pull request addressing one concern.
-- Include a brief description of the changes and a reference to the related
-  issue.
-- Code must be reviewed and approved before merge.
+1. Create a branch from `main`.
+2. Implement the feature or fix with tests.
+3. Run `just verify` — all checks must pass.
+4. Open a PR with a clear description referencing the issue.
+5. Every PR ships implementation, tests, and updated documentation together.
 
 ## Code review
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,253 @@ From commit to release. One tool for [conventional commits][cc], [versioning][se
 
 Invoked as `git std` via git's subcommand discovery.
 
+## Install
+
+**Install script (recommended):**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/driftsys/git-std/main/install.sh | bash
+```
+
+The script detects your OS and architecture, downloads the matching binary from the latest GitHub release, and installs it to `~/.local/bin/git-std`. Set `GIT_STD_INSTALL_DIR` to override the install location.
+
+**From source:**
+
+```bash
+cargo install git-std
+```
+
+**Verify:**
+
+```bash
+git std --version
+```
+
+## Quick start
+
+```bash
+# Set up hooks (if your repo has .githooks/*.hooks files)
+git std hooks install
+
+# Stage changes and make a conventional commit interactively
+git add .
+git std commit
+
+# Check commit messages on your branch
+git std check --range main..HEAD
+
+# Generate a changelog
+git std changelog --stdout
+
+# Bump version, update changelog, commit, and tag
+git std bump
+git push --follow-tags
+```
+
 ## Subcommands
 
-| Command          | Purpose                                 |
-| ---------------- | --------------------------------------- |
-| `git std commit` | Interactive conventional commit builder |
-| `git std check`  | Commit message validation               |
-| `git std bump`   | Version bump + changelog + commit + tag |
-| `git std hooks`  | Git hooks management (install/run/list) |
+| Command               | Purpose                                 |
+| --------------------- | --------------------------------------- |
+| `git std commit`      | Interactive conventional commit builder |
+| `git std check`       | Commit message validation               |
+| `git std bump`        | Version bump + changelog + commit + tag |
+| `git std changelog`   | Generate or update the changelog        |
+| `git std hooks`       | Git hooks management (install/run/list) |
+| `git std self-update` | Update git-std to the latest version    |
+
+### `git std commit`
+
+Build a conventional commit message interactively or non-interactively.
+
+```bash
+# Interactive — prompts for type, scope, subject, body, breaking change
+git std commit
+
+# Non-interactive
+git std commit -a --type fix --scope auth -m "fix(auth): handle expired tokens"
+
+# Preview without committing
+git std commit --dry-run
+```
+
+| Flag              | Description                            |
+| ----------------- | -------------------------------------- |
+| `--type <type>`   | Pre-fill commit type, skip type prompt |
+| `--scope <scope>` | Pre-fill scope, skip scope prompt      |
+| `-m <msg>`        | Non-interactive mode with full message |
+| `--breaking`      | Add a `BREAKING CHANGE` footer         |
+| `--dry-run`       | Print the message without committing   |
+| `--amend`         | Amend the previous commit              |
+| `-S` / `--sign`   | GPG-sign the commit                    |
+| `-a` / `--all`    | Stage all tracked modified files first |
+
+### `git std check`
+
+Validate commit messages against the conventional commit spec.
+
+```bash
+# Single message
+git std check "feat: add feature"
+
+# From a file (e.g., commit-msg hook)
+git std check --file .git/COMMIT_EDITMSG
+
+# All commits on a branch
+git std check --range main..HEAD
+
+# Strict mode — reject unknown types/scopes
+git std check --strict "feat(auth): add login"
+```
+
+| Flag              | Description                                |
+| ----------------- | ------------------------------------------ |
+| `--file <path>`   | Read message from a file                   |
+| `--range <range>` | Validate all commits in a revision range   |
+| `--strict`        | Enforce known types and scopes from config |
+| `--format <fmt>`  | Output format: `text` (default) or `json`  |
+
+### `git std bump`
+
+Calculate the next version from conventional commits, update version files, generate changelog, commit, and tag.
+
+```bash
+# Preview what would happen
+git std bump --dry-run
+
+# Execute the bump
+git std bump
+
+# Pre-release
+git std bump --prerelease
+
+# Force a specific version
+git std bump --release-as 3.0.0
+```
+
+### `git std changelog`
+
+Generate or update the changelog from commit history.
+
+```bash
+# Preview unreleased changes
+git std changelog --unreleased --stdout
+
+# Regenerate the full changelog
+git std changelog --full
+
+# Write to a specific file
+git std changelog --output CHANGES.md
+```
+
+### `git std hooks`
+
+Manage git hooks defined in `.githooks/*.hooks` files.
+
+```bash
+# Install hook shims
+git std hooks install
+
+# List configured hooks
+git std hooks list
+
+# Run a hook manually (useful for debugging)
+git std hooks run pre-commit
+```
+
+## Configuration
+
+`git-std` reads `.git-std.toml` from the project root. All fields are optional — sensible defaults apply when the file is absent.
+
+```toml
+# Versioning scheme: "semver" (default), "calver", or "patch"
+scheme = "semver"
+
+# Allowed commit types (defaults to the conventional commit standard set)
+types = ["feat", "fix", "docs", "style", "refactor", "perf", "test",
+         "chore", "ci", "build"]
+
+# Scope validation: omit for no validation, "auto" to discover from
+# workspace layout, or an explicit list
+scopes = ["auth", "api", "cli", "deps"]
+
+# Enforce types/scopes without the --strict flag
+strict = true
+
+[versioning]
+tag_prefix = "v"                  # Git tag prefix (default: "v")
+prerelease_tag = "rc"             # Default pre-release identifier
+calver_format = "YYYY.MM.PATCH"   # Only used when scheme = "calver"
+
+[changelog]
+hidden = ["chore", "ci", "build", "style", "test"]
+
+[changelog.sections]
+feat = "Features"
+fix = "Bug Fixes"
+perf = "Performance"
+refactor = "Refactoring"
+docs = "Documentation"
+```
+
+Hook definitions live in `.githooks/*.hooks` files (plain text, one command per line). See the [specification](docs/SPEC.md) for the full hooks file format.
+
+## Git hooks
+
+Create `.githooks/<hook-name>.hooks` files and run `git std hooks install` to activate them.
+
+**Example `.githooks/commit-msg.hooks`:**
+
+```sh
+! git std check --file {msg}
+```
+
+**Example `.githooks/pre-commit.hooks`:**
+
+```sh
+# Formatting
+dprint check
+
+# Rust
+cargo clippy --workspace -- -D warnings *.rs
+cargo test --workspace --lib *.rs
+```
+
+**Prefixes:** `!` = fail fast (abort on failure), `?` = advisory (warn only), none = hook default mode.
+
+**Globs** at the end of a line restrict the command to matching staged files. No match means the command is skipped.
+
+## CI integration
+
+### GitHub Actions
+
+```yaml
+name: Validate commits
+on: pull_request
+
+jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install git-std
+        run: curl -fsSL https://raw.githubusercontent.com/driftsys/git-std/main/install.sh | bash
+
+      - name: Check commit messages
+        run: git std check --range ${{ github.event.pull_request.base.sha }}..${{ github.sha }}
+```
+
+### GitLab CI
+
+```yaml
+lint:commits:
+  stage: build
+  script:
+    - curl -fsSL https://raw.githubusercontent.com/driftsys/git-std/main/install.sh | bash
+    - git std check --range $CI_MERGE_REQUEST_DIFF_BASE_SHA..HEAD
+```
 
 ## Workspace crates
 
@@ -21,50 +260,10 @@ Invoked as `git std` via git's subcommand discovery.
 
 ```text
 git-std (binary)
-├── standard-commit
-├── standard-version
-│   └── standard-commit
-├── standard-githooks
-└── standard-changelog
-    └── standard-commit
-```
-
-### standard-commit
-
-[![crates.io](https://img.shields.io/crates/v/standard-commit)](https://crates.io/crates/standard-commit)
-
-[Conventional Commits][cc] parsing, linting, and formatting. Pure library — strings in, data out.
-
-- **Parse** a raw commit message into type, scope, description, body, footers, and breaking status
-- **Lint** against configurable rules (allowed types/scopes, header length, required scope)
-- **Format** a structured commit back to a well-formed message string
-
-### standard-version
-
-[![crates.io](https://img.shields.io/crates/v/standard-version)](https://crates.io/crates/standard-version)
-
-[Semantic][semver] and [calendar][calver] version bump calculation. Pure library — computes the next version from parsed conventional commits and bump rules.
-
-### standard-changelog
-
-[![crates.io](https://img.shields.io/crates/v/standard-changelog)](https://crates.io/crates/standard-changelog)
-
-[Changelog][keep-changelog] generation from conventional commits. Groups commits by type, renders markdown sections, and manages `CHANGELOG.md` files.
-
-### standard-githooks
-
-[![crates.io](https://img.shields.io/crates/v/standard-githooks)](https://crates.io/crates/standard-githooks)
-
-[Git hooks][githooks] file format parsing, shim generation, and execution model. Owns the `.githooks/<hook>.hooks` file format — can read/write hook definitions and generate shim scripts.
-
-## Configuration
-
-`git-std` reads `.git-std.toml` for project-level configuration. Hook definitions live in `.githooks/*.hooks` (plain text, one command per line). The CLI reads the config and passes the relevant settings to each library crate's own config types.
-
-## Install
-
-```bash
-cargo install git-std
+├── standard-commit      — conventional commit parsing, linting, formatting
+├── standard-version     — semantic and calendar version bump calculation
+├── standard-changelog   — changelog generation from conventional commits
+└── standard-githooks    — hook file format parsing, shim generation
 ```
 
 ## License
@@ -73,6 +272,7 @@ MIT
 
 ## Specs and references
 
+- [Full specification](docs/SPEC.md)
 - [Conventional Commits v1.0.0][cc]
 - [Semantic Versioning v2.0.0][semver]
 - [Calendar Versioning][calver]


### PR DESCRIPTION
## Summary

- Add comprehensive README with install, quick start, subcommand reference, `.git-std.toml` config example, hooks examples, and CI integration (GitHub Actions + GitLab CI)
- Add CONTRIBUTING with dev setup, architecture overview, test instructions, commit conventions, branch naming, and PR process

Closes #68

## Test plan

- [x] `dprint check` passes on both files
- [ ] Review content accuracy against current CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)