### PR TITLE
feat(hooks): parse .githooks/<hook>.hooks file format

### DIFF
--- a/crates/standard-githooks/src/lib.rs
+++ b/crates/standard-githooks/src/lib.rs
@@ -3,3 +3,24 @@
 //! Owns the `.githooks/<hook>.hooks` file format. Can read/write hook files
 //! and generate shim scripts. Does not execute commands, run git operations,
 //! or produce terminal output.
+//!
+//! # Main entry point
+//!
+//! - [`parse`] — parse the text content of a `.hooks` file into a list of
+//!   [`HookCommand`]s
+//!
+//! # Example
+//!
+//! ```
+//! use standard_githooks::{parse, HookCommand, Prefix};
+//!
+//! let commands = parse("!cargo test *.rs\n? detekt *.kt\n");
+//! assert_eq!(commands.len(), 2);
+//! assert_eq!(commands[0].prefix, Prefix::FailFast);
+//! assert_eq!(commands[0].command, "cargo test");
+//! assert_eq!(commands[0].glob, Some("*.rs".to_string()));
+//! ```
+
+mod parse;
+
+pub use parse::{HookCommand, Prefix, parse};

--- a/crates/standard-githooks/src/parse.rs
+++ b/crates/standard-githooks/src/parse.rs
@@ -1,0 +1,311 @@
+/// The execution mode for a hook command.
+///
+/// Controls what happens when the command exits with a non-zero status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Prefix {
+    /// No explicit prefix — uses the hook's default execution mode.
+    Default,
+    /// `!` prefix — abort the hook immediately on failure.
+    FailFast,
+    /// `?` prefix — report as a warning, never cause the hook to fail.
+    Advisory,
+}
+
+/// A single command parsed from a `.githooks/<hook>.hooks` file.
+///
+/// Each non-blank, non-comment line in a hooks file produces one
+/// `HookCommand`. The line format is:
+///
+/// ```text
+/// [prefix]command [arguments] [glob]
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookCommand {
+    /// The execution mode prefix (`!`, `?`, or none).
+    pub prefix: Prefix,
+    /// The command text (executable and arguments, without prefix or glob).
+    pub command: String,
+    /// Optional trailing glob pattern that restricts the command to matching
+    /// staged or tracked files.
+    pub glob: Option<String>,
+}
+
+/// Parse the text content of a `.githooks/<hook>.hooks` file.
+///
+/// Blank lines and comment lines (starting with `#`) are skipped.
+/// Each remaining line is parsed into a [`HookCommand`] with its
+/// prefix, command text, and optional trailing glob pattern.
+///
+/// # Example
+///
+/// ```
+/// use standard_githooks::{parse, Prefix};
+///
+/// let input = "# Formatting\ndprint check\n!cargo clippy --workspace -- -D warnings *.rs\n? detekt --input modules/ *.kt\n";
+///
+/// let commands = parse(input);
+/// assert_eq!(commands.len(), 3);
+/// assert_eq!(commands[0].prefix, Prefix::Default);
+/// assert_eq!(commands[0].command, "dprint check");
+/// assert_eq!(commands[0].glob, None);
+///
+/// assert_eq!(commands[1].prefix, Prefix::FailFast);
+/// assert_eq!(commands[1].command, "cargo clippy --workspace -- -D warnings");
+/// assert_eq!(commands[1].glob, Some("*.rs".to_string()));
+///
+/// assert_eq!(commands[2].prefix, Prefix::Advisory);
+/// assert_eq!(commands[2].command, "detekt --input modules/");
+/// assert_eq!(commands[2].glob, Some("*.kt".to_string()));
+/// ```
+pub fn parse(content: &str) -> Vec<HookCommand> {
+    content
+        .lines()
+        .filter_map(|line| parse_line(line.trim()))
+        .collect()
+}
+
+/// Parse a single trimmed line into a `HookCommand`, or `None` if the
+/// line is blank or a comment.
+fn parse_line(line: &str) -> Option<HookCommand> {
+    if line.is_empty() || line.starts_with('#') {
+        return None;
+    }
+
+    let (prefix, rest) = extract_prefix(line);
+    let rest = rest.trim();
+
+    let (command, glob) = extract_glob(rest);
+
+    Some(HookCommand {
+        prefix,
+        command: command.to_string(),
+        glob,
+    })
+}
+
+/// Extract the prefix character and return the remaining text.
+fn extract_prefix(line: &str) -> (Prefix, &str) {
+    if let Some(rest) = line.strip_prefix('!') {
+        (Prefix::FailFast, rest)
+    } else if let Some(rest) = line.strip_prefix('?') {
+        (Prefix::Advisory, rest)
+    } else {
+        (Prefix::Default, line)
+    }
+}
+
+/// Extract an optional trailing glob pattern from the command text.
+///
+/// A glob is the last whitespace-separated token on the line, but only
+/// if it looks like a file-matching pattern (contains `*`, `[`, or
+/// brace expansion like `*.{js,ts}`). Quoted tokens and substitution
+/// tokens like `{msg}` are not treated as globs.
+fn extract_glob(text: &str) -> (&str, Option<String>) {
+    // Split at the last whitespace boundary
+    if let Some(pos) = text.rfind(|c: char| c.is_ascii_whitespace()) {
+        let last_token = &text[pos + 1..];
+        if !last_token.starts_with('"') && is_glob(last_token) {
+            let command = text[..pos].trim_end();
+            return (command, Some(last_token.to_string()));
+        }
+    }
+    (text, None)
+}
+
+/// Check whether a token looks like a glob pattern.
+///
+/// Recognises `*` and `[` as glob metacharacters. Brace expansion
+/// (`{a,b}`) counts only when the braces contain a comma, so that
+/// substitution tokens like `{msg}` are not mistaken for globs.
+fn is_glob(token: &str) -> bool {
+    if token.contains('*') || token.contains('[') {
+        return true;
+    }
+    // Brace expansion requires a comma inside braces
+    if let Some(open) = token.find('{')
+        && let Some(close) = token[open..].find('}')
+    {
+        let inner = &token[open + 1..open + close];
+        return inner.contains(',');
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blank_lines_are_skipped() {
+        let commands = parse("\n\n  \n");
+        assert!(commands.is_empty());
+    }
+
+    #[test]
+    fn comment_lines_are_skipped() {
+        let commands = parse("# This is a comment\n  # indented comment\n");
+        assert!(commands.is_empty());
+    }
+
+    #[test]
+    fn simple_command_no_prefix_no_glob() {
+        let commands = parse("dprint check\n");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].prefix, Prefix::Default);
+        assert_eq!(commands[0].command, "dprint check");
+        assert_eq!(commands[0].glob, None);
+    }
+
+    #[test]
+    fn fail_fast_prefix() {
+        let commands = parse("!cargo build --workspace\n");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].prefix, Prefix::FailFast);
+        assert_eq!(commands[0].command, "cargo build --workspace");
+        assert_eq!(commands[0].glob, None);
+    }
+
+    #[test]
+    fn advisory_prefix() {
+        let commands = parse("? detekt --input modules/ *.kt\n");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].prefix, Prefix::Advisory);
+        assert_eq!(commands[0].command, "detekt --input modules/");
+        assert_eq!(commands[0].glob, Some("*.kt".to_string()));
+    }
+
+    #[test]
+    fn advisory_prefix_no_space() {
+        let commands = parse("?detekt --input modules/ *.kt\n");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].prefix, Prefix::Advisory);
+        assert_eq!(commands[0].command, "detekt --input modules/");
+        assert_eq!(commands[0].glob, Some("*.kt".to_string()));
+    }
+
+    #[test]
+    fn trailing_glob_pattern() {
+        let commands = parse("cargo clippy --workspace -- -D warnings *.rs\n");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(
+            commands[0].command,
+            "cargo clippy --workspace -- -D warnings"
+        );
+        assert_eq!(commands[0].glob, Some("*.rs".to_string()));
+    }
+
+    #[test]
+    fn command_with_arguments_no_glob() {
+        let commands = parse("prettier --check \"**/*.md\"\n");
+        assert_eq!(commands.len(), 1);
+        // The quoted glob is part of the command arguments, not a trailing glob
+        // because it's in quotes as an argument to prettier
+        assert_eq!(commands[0].command, "prettier --check \"**/*.md\"");
+    }
+
+    #[test]
+    fn command_with_msg_substitution() {
+        let commands = parse("! git std check --file {msg}\n");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].prefix, Prefix::FailFast);
+        assert_eq!(commands[0].command, "git std check --file {msg}");
+        assert_eq!(commands[0].glob, None);
+    }
+
+    #[test]
+    fn mixed_content() {
+        let input = "\
+# ── Formatting ────────────────────────────
+dprint check
+prettier --check \"**/*.md\"
+
+# ── Rust ──────────────────────────────────
+cargo clippy --workspace -- -D warnings *.rs
+cargo test --workspace --lib *.rs
+
+# ── Android ───────────────────────────────
+? detekt --input modules/ *.kt
+";
+        let commands = parse(input);
+        assert_eq!(commands.len(), 5);
+
+        assert_eq!(commands[0].prefix, Prefix::Default);
+        assert_eq!(commands[0].command, "dprint check");
+        assert_eq!(commands[0].glob, None);
+
+        assert_eq!(commands[1].prefix, Prefix::Default);
+        assert_eq!(commands[1].command, "prettier --check \"**/*.md\"");
+        assert_eq!(commands[1].glob, None);
+
+        assert_eq!(commands[2].prefix, Prefix::Default);
+        assert_eq!(
+            commands[2].command,
+            "cargo clippy --workspace -- -D warnings"
+        );
+        assert_eq!(commands[2].glob, Some("*.rs".to_string()));
+
+        assert_eq!(commands[3].prefix, Prefix::Default);
+        assert_eq!(commands[3].command, "cargo test --workspace --lib");
+        assert_eq!(commands[3].glob, Some("*.rs".to_string()));
+
+        assert_eq!(commands[4].prefix, Prefix::Advisory);
+        assert_eq!(commands[4].command, "detekt --input modules/");
+        assert_eq!(commands[4].glob, Some("*.kt".to_string()));
+    }
+
+    #[test]
+    fn commit_msg_hooks_file() {
+        let input = "! git std check --file {msg}\n";
+        let commands = parse(input);
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].prefix, Prefix::FailFast);
+        assert_eq!(commands[0].command, "git std check --file {msg}");
+        assert_eq!(commands[0].glob, None);
+    }
+
+    #[test]
+    fn glob_with_brackets() {
+        let commands = parse("lint src/[a-z]*.rs\n");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].command, "lint");
+        assert_eq!(commands[0].glob, Some("src/[a-z]*.rs".to_string()));
+    }
+
+    #[test]
+    fn glob_with_braces() {
+        let commands = parse("check *.{js,ts}\n");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].command, "check");
+        assert_eq!(commands[0].glob, Some("*.{js,ts}".to_string()));
+    }
+
+    #[test]
+    fn single_word_command() {
+        let commands = parse("lint\n");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].command, "lint");
+        assert_eq!(commands[0].glob, None);
+    }
+
+    #[test]
+    fn whitespace_handling() {
+        let commands = parse("  cargo test  \n");
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].command, "cargo test");
+        assert_eq!(commands[0].glob, None);
+    }
+
+    #[test]
+    fn empty_input() {
+        let commands = parse("");
+        assert!(commands.is_empty());
+    }
+
+    #[test]
+    fn prefix_display_coverage() {
+        // Verify all prefix variants are distinct
+        assert_ne!(Prefix::Default, Prefix::FailFast);
+        assert_ne!(Prefix::Default, Prefix::Advisory);
+        assert_ne!(Prefix::FailFast, Prefix::Advisory);
+    }
+}


### PR DESCRIPTION
## Summary

- Implement the hooks file parser in the `standard-githooks` crate (#22)
- Handles blank lines, `#` comments, prefix extraction (`!` fail-fast, `?` advisory), command text, and trailing glob patterns
- 17 unit tests + 2 doctests covering all cases (mixed content, `{msg}` substitution, brace/bracket globs, quoted args)

## Test plan

- [x] `cargo test -p standard-githooks` — 17 unit tests + 2 doctests pass
- [x] `cargo clippy -p standard-githooks -- -D warnings` — zero warnings
- [x] `cargo fmt -p standard-githooks -- --check` — formatted

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)