### PR TITLE
docs: allow standard-version crate to perform file I/O

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,15 +33,17 @@ The full specification lives in `docs/SPEC.md`.
 
 **Workspace structure — five crates:**
 
-| Crate                | Role                                                 |
-| -------------------- | ---------------------------------------------------- |
-| `git-std`            | CLI binary — orchestrates I/O, git, config, dispatch |
-| `standard-commit`    | Conventional commit parsing, linting, formatting     |
-| `standard-version`   | Semantic version bump calculation, TOML rewriting    |
-| `standard-changelog` | Changelog generation from conventional commits       |
-| `standard-githooks`  | Hook file format parsing, shim generation            |
+| Crate                | Role                                                                 |
+| -------------------- | -------------------------------------------------------------------- |
+| `git-std`            | CLI binary — orchestrates I/O, git, config, dispatch                 |
+| `standard-commit`    | Conventional commit parsing, linting, formatting                     |
+| `standard-version`   | Semantic version bump calculation, version file detection and update |
+| `standard-changelog` | Changelog generation from conventional commits                       |
+| `standard-githooks`  | Hook file format parsing, shim generation                            |
 
-Library crates are pure — no git2, no I/O, no terminal output.
+Library crates are pure — no git2, no I/O, no terminal
+output — except `standard-version`, which performs file
+I/O for version file detection and updates.
 
 **Four subcommands**, each a separate concern:
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -95,15 +95,17 @@ list of built-in version files.
 
 **Workspace crates:**
 
-| Crate                | Role                                                 |
-| -------------------- | ---------------------------------------------------- |
-| `git-std`            | CLI binary — orchestrates I/O, git, config, dispatch |
-| `standard-commit`    | Conventional commit parsing, linting, formatting     |
-| `standard-version`   | Semantic version bump calculation, TOML rewriting    |
-| `standard-changelog` | Changelog generation from conventional commits       |
-| `standard-githooks`  | Hook file format parsing, shim generation            |
+| Crate                | Role                                                                                 |
+| -------------------- | ------------------------------------------------------------------------------------ |
+| `git-std`            | CLI binary — orchestrates I/O, git, config, dispatch                                 |
+| `standard-commit`    | Conventional commit parsing, linting, formatting                                     |
+| `standard-version`   | Semantic version bump calculation, version file detection and update (with file I/O) |
+| `standard-changelog` | Changelog generation from conventional commits                                       |
+| `standard-githooks`  | Hook file format parsing, shim generation                                            |
 
-Library crates are pure — no git2, no I/O, no terminal output.
+Library crates are pure — no git2, no I/O, no terminal
+output — except `standard-version`, which performs file
+I/O for version file detection and updates.
 
 **Key dependencies:**
 


### PR DESCRIPTION
## Summary

- Relax the pure-library constraint for `standard-version` only
- Version file detection and updates will live in `standard-version` with file I/O, rather than splitting logic between library and binary crate
- Updated `docs/SPEC.md` §1.5 and `AGENTS.md` architecture section

## Test plan

- [ ] Verify SPEC.md and AGENTS.md purity statements include the exception
- [ ] Verify `standard-version` table row reflects new role
- [ ] `just lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)