### PR TITLE
feat(bump): add VersionFile trait and refactor Cargo.toml engine

### DIFF
--- a/crates/standard-version/Cargo.toml
+++ b/crates/standard-version/Cargo.toml
@@ -12,3 +12,6 @@ categories = ["development-tools"]
 [dependencies]
 semver = "1"
 standard-commit = { version = "0.1.0", path = "../standard-commit" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/standard-version/src/cargo.rs
+++ b/crates/standard-version/src/cargo.rs
@@ -1,0 +1,194 @@
+//! Cargo.toml version file engine.
+//!
+//! Implements [`VersionFile`] for Rust's `Cargo.toml` manifest, detecting and
+//! rewriting the `version` field inside the `[package]` section while
+//! preserving formatting.
+
+use crate::version_file::{VersionFile, VersionFileError};
+
+/// Version file engine for `Cargo.toml`.
+#[derive(Debug, Clone, Copy)]
+pub struct CargoVersionFile;
+
+impl VersionFile for CargoVersionFile {
+    fn name(&self) -> &str {
+        "Cargo.toml"
+    }
+
+    fn filenames(&self) -> &[&str] {
+        &["Cargo.toml"]
+    }
+
+    fn detect(&self, content: &str) -> bool {
+        let mut in_package = false;
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed == "[package]" {
+                in_package = true;
+            } else if trimmed.starts_with('[') {
+                in_package = false;
+            }
+            if in_package && trimmed.starts_with("version") && trimmed.contains('=') {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn read_version(&self, content: &str) -> Option<String> {
+        let mut in_package = false;
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed == "[package]" {
+                in_package = true;
+            } else if trimmed.starts_with('[') {
+                in_package = false;
+            }
+            if in_package
+                && trimmed.starts_with("version")
+                && let Some(eq_pos) = trimmed.find('=')
+            {
+                let value = trimmed[eq_pos + 1..].trim();
+                // Strip surrounding quotes.
+                let version = value.trim_matches('"');
+                return Some(version.to_string());
+            }
+        }
+        None
+    }
+
+    fn write_version(&self, content: &str, new_version: &str) -> Result<String, VersionFileError> {
+        let mut in_package = false;
+        let mut result = String::new();
+        let mut replaced = false;
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed == "[package]" {
+                in_package = true;
+            } else if trimmed.starts_with('[') {
+                in_package = false;
+            }
+
+            if in_package
+                && !replaced
+                && trimmed.starts_with("version")
+                && let Some(eq_pos) = line.find('=')
+            {
+                let prefix = &line[..=eq_pos];
+                result.push_str(prefix);
+                result.push_str(&format!(" \"{new_version}\""));
+                result.push('\n');
+                replaced = true;
+                continue;
+            }
+
+            result.push_str(line);
+            result.push('\n');
+        }
+
+        if !replaced {
+            return Err(VersionFileError::NoVersionField);
+        }
+
+        // Preserve original trailing-newline behaviour.
+        if !content.ends_with('\n') && result.ends_with('\n') {
+            result.pop();
+        }
+
+        Ok(result)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASIC_TOML: &str = r#"[package]
+name = "my-crate"
+version = "0.1.0"
+edition = "2021"
+"#;
+
+    const MULTI_SECTION_TOML: &str = r#"[package]
+name = "my-crate"
+version = "0.1.0"
+
+[dependencies]
+foo = { version = "1.0" }
+"#;
+
+    // --- detect ---
+
+    #[test]
+    fn detect_with_package_version() {
+        assert!(CargoVersionFile.detect(BASIC_TOML));
+    }
+
+    #[test]
+    fn detect_without_package_section() {
+        let content = "[dependencies]\nfoo = \"1\"\n";
+        assert!(!CargoVersionFile.detect(content));
+    }
+
+    #[test]
+    fn detect_version_only_in_deps() {
+        let content = "[package]\nname = \"x\"\n\n[dependencies]\nfoo = { version = \"1\" }\n";
+        assert!(!CargoVersionFile.detect(content));
+    }
+
+    // --- read_version ---
+
+    #[test]
+    fn read_version_basic() {
+        assert_eq!(
+            CargoVersionFile.read_version(BASIC_TOML),
+            Some("0.1.0".to_string()),
+        );
+    }
+
+    #[test]
+    fn read_version_no_package() {
+        let content = "[dependencies]\nfoo = \"1\"\n";
+        assert_eq!(CargoVersionFile.read_version(content), None);
+    }
+
+    // --- write_version ---
+
+    #[test]
+    fn write_version_basic() {
+        let result = CargoVersionFile.write_version(BASIC_TOML, "1.0.0").unwrap();
+        assert!(result.contains("version = \"1.0.0\""));
+        assert!(result.contains("name = \"my-crate\""));
+        assert!(result.contains("edition = \"2021\""));
+    }
+
+    #[test]
+    fn write_version_only_in_package_section() {
+        let result = CargoVersionFile
+            .write_version(MULTI_SECTION_TOML, "2.0.0")
+            .unwrap();
+        assert!(result.contains("version = \"2.0.0\""));
+        // Dependency version untouched.
+        assert!(result.contains("foo = { version = \"1.0\" }"));
+    }
+
+    #[test]
+    fn write_version_no_field_returns_error() {
+        let content = "[package]\nname = \"x\"\n";
+        let err = CargoVersionFile.write_version(content, "1.0.0");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn write_version_preserves_no_trailing_newline() {
+        let content = "[package]\nname = \"x\"\nversion = \"0.1.0\"";
+        let result = CargoVersionFile.write_version(content, "0.2.0").unwrap();
+        assert!(!result.ends_with('\n'));
+        assert!(result.contains("version = \"0.2.0\""));
+    }
+}

--- a/crates/standard-version/src/lib.rs
+++ b/crates/standard-version/src/lib.rs
@@ -1,7 +1,9 @@
 //! Semantic version bump calculation from conventional commits.
 //!
-//! Pure library — computes the next version from a list of parsed conventional
-//! commits and bump rules. No I/O, no git operations.
+//! Computes the next version from a list of parsed conventional commits and
+//! bump rules. Also provides the [`VersionFile`] trait for ecosystem-specific
+//! version file detection and updating, with built-in support for
+//! `Cargo.toml` via [`CargoVersionFile`].
 //!
 //! # Main entry points
 //!
@@ -9,6 +11,7 @@
 //! - [`apply_bump`] — apply a bump level to a semver version
 //! - [`apply_prerelease`] — bump with a pre-release tag (e.g. `rc.0`)
 //! - [`replace_version_in_toml`] — update the version in a `Cargo.toml` string
+//! - [`update_version_files`] — discover and update version files at a repo root
 //!
 //! # Example
 //!
@@ -27,6 +30,14 @@
 //! let next = apply_bump(&current, level);
 //! assert_eq!(next, semver::Version::new(1, 3, 0));
 //! ```
+
+pub mod cargo;
+pub mod version_file;
+
+pub use cargo::CargoVersionFile;
+pub use version_file::{
+    CustomVersionFile, UpdateResult, VersionFile, VersionFileError, update_version_files,
+};
 
 use standard_commit::ConventionalCommit;
 
@@ -211,45 +222,9 @@ pub fn replace_version_in_toml(
     content: &str,
     new_version: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let mut in_package = false;
-    let mut result = String::new();
-    let mut replaced = false;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed == "[package]" {
-            in_package = true;
-        } else if trimmed.starts_with('[') {
-            in_package = false;
-        }
-
-        if in_package
-            && !replaced
-            && trimmed.starts_with("version")
-            && let Some(eq_pos) = line.find('=')
-        {
-            let prefix = &line[..=eq_pos];
-            result.push_str(prefix);
-            result.push_str(&format!(" \"{new_version}\""));
-            result.push('\n');
-            replaced = true;
-            continue;
-        }
-
-        result.push_str(line);
-        result.push('\n');
-    }
-
-    if !replaced {
-        return Err("could not find version field in [package] section".into());
-    }
-
-    // Remove trailing extra newline if the original didn't end with one.
-    if !content.ends_with('\n') && result.ends_with('\n') {
-        result.pop();
-    }
-
-    Ok(result)
+    CargoVersionFile
+        .write_version(content, new_version)
+        .map_err(|e| e.to_string().into())
 }
 
 #[cfg(test)]

--- a/crates/standard-version/src/version_file.rs
+++ b/crates/standard-version/src/version_file.rs
@@ -1,0 +1,232 @@
+//! Version file detection and updating.
+//!
+//! Provides the [`VersionFile`] trait for ecosystem-specific version file
+//! engines, and the [`update_version_files`] function that discovers and
+//! updates version files at a repository root.
+
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::cargo::CargoVersionFile;
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+/// Errors that can occur when reading or writing version files.
+#[derive(Debug)]
+pub enum VersionFileError {
+    /// The expected file was not found on disk.
+    FileNotFound(PathBuf),
+    /// The file does not contain a version field this engine can handle.
+    NoVersionField,
+    /// Writing the updated content back to disk failed.
+    WriteFailed(std::io::Error),
+    /// Reading the file from disk failed.
+    ReadFailed(std::io::Error),
+}
+
+impl fmt::Display for VersionFileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FileNotFound(p) => write!(f, "file not found: {}", p.display()),
+            Self::NoVersionField => write!(f, "no version field found"),
+            Self::WriteFailed(e) => write!(f, "write failed: {e}"),
+            Self::ReadFailed(e) => write!(f, "read failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for VersionFileError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::WriteFailed(e) | Self::ReadFailed(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Trait
+// ---------------------------------------------------------------------------
+
+/// A version file engine that can detect, read, and write a version field
+/// inside a specific file format (e.g. `Cargo.toml`, `package.json`).
+pub trait VersionFile {
+    /// Human-readable name (e.g. `"Cargo.toml"`).
+    fn name(&self) -> &str;
+
+    /// Filenames to look for at the repository root.
+    fn filenames(&self) -> &[&str];
+
+    /// Check if `content` contains a version field this engine handles.
+    fn detect(&self, content: &str) -> bool;
+
+    /// Extract the current version string from file content.
+    fn read_version(&self, content: &str) -> Option<String>;
+
+    /// Return updated file content with `new_version` replacing the old value.
+    fn write_version(&self, content: &str, new_version: &str) -> Result<String, VersionFileError>;
+}
+
+// ---------------------------------------------------------------------------
+// UpdateResult
+// ---------------------------------------------------------------------------
+
+/// The outcome of updating a single version file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateResult {
+    /// Absolute path to the file that was updated.
+    pub path: PathBuf,
+    /// Human-readable engine name (e.g. `"Cargo.toml"`).
+    pub name: String,
+    /// Version string before the update.
+    pub old_version: String,
+    /// Version string after the update.
+    pub new_version: String,
+    /// Optional extra info (e.g. `"VERSION_CODE: 42 → 43"`).
+    pub extra: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// CustomVersionFile (placeholder for story #103)
+// ---------------------------------------------------------------------------
+
+/// A user-defined version file matched by path and regex.
+///
+/// The regex engine itself will be implemented in story #103. This struct
+/// is defined now so that the public API signature of
+/// [`update_version_files`] is stable.
+#[derive(Debug, Clone)]
+pub struct CustomVersionFile {
+    /// Path to the file, relative to the repository root.
+    pub path: PathBuf,
+    /// Regex pattern whose first capture group contains the version string.
+    pub pattern: String,
+}
+
+// ---------------------------------------------------------------------------
+// update_version_files
+// ---------------------------------------------------------------------------
+
+/// Discover and update version files at `root`.
+///
+/// Iterates all built-in version file engines (currently only
+/// [`CargoVersionFile`]) and, for each file that is detected, replaces the
+/// version string with `new_version`. Updated content is written back to
+/// disk.
+///
+/// `_custom_files` is accepted for forward compatibility (story #103) but
+/// is not yet processed.
+///
+/// # Errors
+///
+/// Returns a [`VersionFileError`] if a detected file cannot be read or
+/// written.
+pub fn update_version_files(
+    root: &Path,
+    new_version: &str,
+    _custom_files: &[CustomVersionFile],
+) -> Result<Vec<UpdateResult>, VersionFileError> {
+    let engines: Vec<Box<dyn VersionFile>> = vec![Box::new(CargoVersionFile)];
+
+    let mut results = Vec::new();
+
+    for engine in &engines {
+        for filename in engine.filenames() {
+            let path = root.join(filename);
+            if !path.exists() {
+                continue;
+            }
+
+            let content = fs::read_to_string(&path).map_err(VersionFileError::ReadFailed)?;
+
+            if !engine.detect(&content) {
+                continue;
+            }
+
+            let old_version = match engine.read_version(&content) {
+                Some(v) => v,
+                None => continue,
+            };
+
+            let updated = engine.write_version(&content, new_version)?;
+            fs::write(&path, &updated).map_err(VersionFileError::WriteFailed)?;
+
+            results.push(UpdateResult {
+                path,
+                name: engine.name().to_string(),
+                old_version,
+                new_version: new_version.to_string(),
+                extra: None,
+            });
+        }
+    }
+
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn update_version_files_updates_cargo_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let cargo_toml = dir.path().join("Cargo.toml");
+        fs::write(
+            &cargo_toml,
+            r#"[package]
+name = "example"
+version = "0.1.0"
+edition = "2024"
+"#,
+        )
+        .unwrap();
+
+        let results = update_version_files(dir.path(), "2.0.0", &[]).unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].old_version, "0.1.0");
+        assert_eq!(results[0].new_version, "2.0.0");
+        assert_eq!(results[0].name, "Cargo.toml");
+        assert_eq!(results[0].path, cargo_toml);
+
+        let on_disk = fs::read_to_string(&cargo_toml).unwrap();
+        assert!(on_disk.contains("version = \"2.0.0\""));
+    }
+
+    #[test]
+    fn update_version_files_skips_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        // No Cargo.toml present.
+        let results = update_version_files(dir.path(), "1.0.0", &[]).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn update_version_files_skips_undetected() {
+        let dir = tempfile::tempdir().unwrap();
+        let cargo_toml = dir.path().join("Cargo.toml");
+        // File exists but has no [package] section.
+        fs::write(&cargo_toml, "[dependencies]\nfoo = \"1\"\n").unwrap();
+
+        let results = update_version_files(dir.path(), "1.0.0", &[]).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn error_display() {
+        let err = VersionFileError::NoVersionField;
+        assert_eq!(err.to_string(), "no version field found");
+
+        let err = VersionFileError::FileNotFound(PathBuf::from("/tmp/gone"));
+        assert!(err.to_string().contains("/tmp/gone"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `VersionFile` trait with `detect()`, `read_version()`, `write_version()` methods
- Extract Cargo.toml logic into `CargoVersionFile` implementing the trait
- Add `update_version_files(root, new_version, custom_files)` entry point with file I/O
- Define `UpdateResult`, `VersionFileError`, `CustomVersionFile` (placeholder for #103)
- `replace_version_in_toml` preserved for backward compat, delegates to `CargoVersionFile`
- 34 unit tests + 2 doc-tests

Closes #97

## Test plan

- [x] All existing `standard-version` tests pass (no regression)
- [x] `CargoVersionFile` detect/read/write unit tests
- [x] `update_version_files` integration tests with tempdir
- [x] `just lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)