### PR TITLE
feat(bump): add text-based version file engines

### DIFF
--- a/crates/standard-version/src/gradle.rs
+++ b/crates/standard-version/src/gradle.rs
@@ -1,0 +1,249 @@
+//! `gradle.properties` version file engine.
+//!
+//! Implements [`VersionFile`] for Android/Gradle projects that store version
+//! information as `VERSION_NAME=` in `gradle.properties`. When a
+//! `VERSION_CODE=N` line is also present, the integer value is incremented
+//! automatically.
+
+use crate::version_file::{VersionFile, VersionFileError};
+
+/// Version file engine for `gradle.properties`.
+#[derive(Debug, Clone, Copy)]
+pub struct GradleVersionFile;
+
+impl VersionFile for GradleVersionFile {
+    fn name(&self) -> &str {
+        "gradle.properties"
+    }
+
+    fn filenames(&self) -> &[&str] {
+        &["gradle.properties"]
+    }
+
+    fn detect(&self, content: &str) -> bool {
+        content
+            .lines()
+            .any(|line| line.starts_with("VERSION_NAME="))
+    }
+
+    fn read_version(&self, content: &str) -> Option<String> {
+        for line in content.lines() {
+            if let Some(value) = line.strip_prefix("VERSION_NAME=") {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    return Some(trimmed.to_string());
+                }
+            }
+        }
+        None
+    }
+
+    fn write_version(&self, content: &str, new_version: &str) -> Result<String, VersionFileError> {
+        let mut result = String::new();
+        let mut replaced = false;
+
+        for line in content.lines() {
+            if !replaced && line.starts_with("VERSION_NAME=") {
+                result.push_str(&format!("VERSION_NAME={new_version}"));
+                result.push('\n');
+                replaced = true;
+                continue;
+            }
+
+            if let Some(old_code) = line.strip_prefix("VERSION_CODE=") {
+                let old_code = old_code.trim();
+                let code_num: u64 = old_code.parse().unwrap_or(0);
+                result.push_str(&format!("VERSION_CODE={}", code_num + 1));
+                result.push('\n');
+                continue;
+            }
+
+            result.push_str(line);
+            result.push('\n');
+        }
+
+        if !replaced {
+            return Err(VersionFileError::NoVersionField);
+        }
+
+        // Preserve original trailing-newline behaviour.
+        if !content.ends_with('\n') && result.ends_with('\n') {
+            result.pop();
+        }
+
+        Ok(result)
+    }
+
+    fn extra_info(&self, old_content: &str, new_content: &str) -> Option<String> {
+        let old_code = extract_version_code(old_content);
+        let new_code = extract_version_code(new_content);
+
+        match (old_code, new_code) {
+            (Some(old), Some(new)) => Some(format!("VERSION_CODE: {old} \u{2192} {new}")),
+            _ => None,
+        }
+    }
+}
+
+/// Extract the `VERSION_CODE` integer value from file content.
+fn extract_version_code(content: &str) -> Option<u64> {
+    for line in content.lines() {
+        if let Some(value) = line.strip_prefix("VERSION_CODE=") {
+            return value.trim().parse().ok();
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASIC_GRADLE: &str = "\
+VERSION_NAME=1.2.3
+VERSION_CODE=42
+org.gradle.jvmargs=-Xmx2048m
+";
+
+    const GRADLE_NO_CODE: &str = "\
+VERSION_NAME=1.2.3
+org.gradle.jvmargs=-Xmx2048m
+";
+
+    // --- detect ---
+
+    #[test]
+    fn detect_positive() {
+        assert!(GradleVersionFile.detect(BASIC_GRADLE));
+    }
+
+    #[test]
+    fn detect_negative() {
+        let content = "org.gradle.jvmargs=-Xmx2048m\n";
+        assert!(!GradleVersionFile.detect(content));
+    }
+
+    #[test]
+    fn detect_negative_version_name_in_comment() {
+        let content = "# VERSION_NAME=1.0.0\norg.gradle.jvmargs=-Xmx2048m\n";
+        assert!(!GradleVersionFile.detect(content));
+    }
+
+    // --- read_version ---
+
+    #[test]
+    fn read_version_basic() {
+        assert_eq!(
+            GradleVersionFile.read_version(BASIC_GRADLE),
+            Some("1.2.3".to_string()),
+        );
+    }
+
+    #[test]
+    fn read_version_missing() {
+        let content = "org.gradle.jvmargs=-Xmx2048m\n";
+        assert_eq!(GradleVersionFile.read_version(content), None);
+    }
+
+    // --- write_version ---
+
+    #[test]
+    fn write_version_updates_name_and_code() {
+        let result = GradleVersionFile
+            .write_version(BASIC_GRADLE, "2.0.0")
+            .unwrap();
+        assert!(result.contains("VERSION_NAME=2.0.0"));
+        assert!(result.contains("VERSION_CODE=43"));
+        assert!(result.contains("org.gradle.jvmargs=-Xmx2048m"));
+    }
+
+    #[test]
+    fn write_version_no_code_stays_without() {
+        let result = GradleVersionFile
+            .write_version(GRADLE_NO_CODE, "2.0.0")
+            .unwrap();
+        assert!(result.contains("VERSION_NAME=2.0.0"));
+        assert!(!result.contains("VERSION_CODE"));
+    }
+
+    #[test]
+    fn write_version_no_field_returns_error() {
+        let content = "org.gradle.jvmargs=-Xmx2048m\n";
+        let err = GradleVersionFile.write_version(content, "1.0.0");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn write_version_preserves_no_trailing_newline() {
+        let content = "VERSION_NAME=0.1.0";
+        let result = GradleVersionFile.write_version(content, "0.2.0").unwrap();
+        assert!(!result.ends_with('\n'));
+        assert!(result.contains("VERSION_NAME=0.2.0"));
+    }
+
+    // --- extra_info ---
+
+    #[test]
+    fn extra_info_reports_version_code_change() {
+        let old = BASIC_GRADLE;
+        let new_content = GradleVersionFile.write_version(old, "2.0.0").unwrap();
+        let info = GradleVersionFile.extra_info(old, &new_content);
+        assert_eq!(info, Some("VERSION_CODE: 42 \u{2192} 43".to_string()));
+    }
+
+    #[test]
+    fn extra_info_none_when_no_version_code() {
+        let old = GRADLE_NO_CODE;
+        let new_content = GradleVersionFile.write_version(old, "2.0.0").unwrap();
+        let info = GradleVersionFile.extra_info(old, &new_content);
+        assert_eq!(info, None);
+    }
+
+    // --- integration ---
+
+    #[test]
+    fn integration_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gradle.properties");
+        std::fs::write(&path, BASIC_GRADLE).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(GradleVersionFile.detect(&content));
+        assert_eq!(
+            GradleVersionFile.read_version(&content),
+            Some("1.2.3".to_string()),
+        );
+
+        let updated = GradleVersionFile.write_version(&content, "3.0.0").unwrap();
+        std::fs::write(&path, &updated).unwrap();
+
+        let final_content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            GradleVersionFile.read_version(&final_content),
+            Some("3.0.0".to_string()),
+        );
+        assert!(final_content.contains("VERSION_CODE=43"));
+    }
+
+    #[test]
+    fn integration_roundtrip_no_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gradle.properties");
+        std::fs::write(&path, GRADLE_NO_CODE).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let updated = GradleVersionFile.write_version(&content, "3.0.0").unwrap();
+        std::fs::write(&path, &updated).unwrap();
+
+        let final_content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            GradleVersionFile.read_version(&final_content),
+            Some("3.0.0".to_string()),
+        );
+        assert!(!final_content.contains("VERSION_CODE"));
+    }
+}

--- a/crates/standard-version/src/lib.rs
+++ b/crates/standard-version/src/lib.rs
@@ -5,7 +5,9 @@
 //! version file detection and updating, with built-in support for
 //! `Cargo.toml` via [`CargoVersionFile`], `pyproject.toml` via
 //! [`PyprojectVersionFile`], `package.json` via [`JsonVersionFile`],
-//! and `deno.json`/`deno.jsonc` via [`DenoVersionFile`].
+//! `deno.json`/`deno.jsonc` via [`DenoVersionFile`], `pubspec.yaml` via
+//! [`PubspecVersionFile`], `gradle.properties` via [`GradleVersionFile`],
+//! and plain `VERSION` files via [`PlainVersionFile`].
 //!
 //! # Main entry points
 //!
@@ -34,16 +36,22 @@
 //! ```
 
 pub mod cargo;
+pub mod gradle;
 pub mod json;
+pub mod pubspec;
 pub mod pyproject;
 pub mod version_file;
+pub mod version_plain;
 
 pub use cargo::CargoVersionFile;
+pub use gradle::GradleVersionFile;
 pub use json::{DenoVersionFile, JsonVersionFile};
+pub use pubspec::PubspecVersionFile;
 pub use pyproject::PyprojectVersionFile;
 pub use version_file::{
     CustomVersionFile, UpdateResult, VersionFile, VersionFileError, update_version_files,
 };
+pub use version_plain::PlainVersionFile;
 
 use standard_commit::ConventionalCommit;
 

--- a/crates/standard-version/src/pubspec.rs
+++ b/crates/standard-version/src/pubspec.rs
@@ -1,0 +1,223 @@
+//! `pubspec.yaml` version file engine.
+//!
+//! Implements [`VersionFile`] for Flutter/Dart's `pubspec.yaml` manifest,
+//! detecting and rewriting the top-level `version:` field. When the existing
+//! version carries a `+N` build number suffix, the suffix is incremented
+//! automatically.
+
+use crate::version_file::{VersionFile, VersionFileError};
+
+/// Version file engine for `pubspec.yaml`.
+#[derive(Debug, Clone, Copy)]
+pub struct PubspecVersionFile;
+
+impl VersionFile for PubspecVersionFile {
+    fn name(&self) -> &str {
+        "pubspec.yaml"
+    }
+
+    fn filenames(&self) -> &[&str] {
+        &["pubspec.yaml"]
+    }
+
+    fn detect(&self, content: &str) -> bool {
+        content
+            .lines()
+            .any(|line| line.starts_with("version:") && line.len() > "version:".len())
+    }
+
+    fn read_version(&self, content: &str) -> Option<String> {
+        for line in content.lines() {
+            if let Some(value) = line.strip_prefix("version:") {
+                let value = value.trim();
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+        None
+    }
+
+    fn write_version(&self, content: &str, new_version: &str) -> Result<String, VersionFileError> {
+        let mut result = String::new();
+        let mut replaced = false;
+
+        for line in content.lines() {
+            if !replaced && let Some(old_value) = line.strip_prefix("version:") {
+                let old_value = old_value.trim();
+                let new_value = if let Some(pos) = old_value.find('+') {
+                    // Existing build number — increment it.
+                    let build_str = &old_value[pos + 1..];
+                    let build_num: u64 = build_str.parse().unwrap_or(0);
+                    format!("{new_version}+{}", build_num + 1)
+                } else {
+                    new_version.to_string()
+                };
+                result.push_str(&format!("version: {new_value}"));
+                result.push('\n');
+                replaced = true;
+                continue;
+            }
+            result.push_str(line);
+            result.push('\n');
+        }
+
+        if !replaced {
+            return Err(VersionFileError::NoVersionField);
+        }
+
+        // Preserve original trailing-newline behaviour.
+        if !content.ends_with('\n') && result.ends_with('\n') {
+            result.pop();
+        }
+
+        Ok(result)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASIC_PUBSPEC: &str = "\
+name: my_app
+version: 1.2.3
+description: A sample app
+";
+
+    const PUBSPEC_WITH_BUILD: &str = "\
+name: my_app
+version: 1.2.3+42
+description: A sample app
+";
+
+    // --- detect ---
+
+    #[test]
+    fn detect_positive() {
+        assert!(PubspecVersionFile.detect(BASIC_PUBSPEC));
+    }
+
+    #[test]
+    fn detect_positive_with_build_number() {
+        assert!(PubspecVersionFile.detect(PUBSPEC_WITH_BUILD));
+    }
+
+    #[test]
+    fn detect_negative_no_version() {
+        let content = "name: my_app\ndescription: A sample app\n";
+        assert!(!PubspecVersionFile.detect(content));
+    }
+
+    #[test]
+    fn detect_negative_version_in_middle_of_line() {
+        let content = "name: my_app\n# version: 1.0.0\ndescription: foo\n";
+        assert!(!PubspecVersionFile.detect(content));
+    }
+
+    // --- read_version ---
+
+    #[test]
+    fn read_version_basic() {
+        assert_eq!(
+            PubspecVersionFile.read_version(BASIC_PUBSPEC),
+            Some("1.2.3".to_string()),
+        );
+    }
+
+    #[test]
+    fn read_version_with_build_number() {
+        assert_eq!(
+            PubspecVersionFile.read_version(PUBSPEC_WITH_BUILD),
+            Some("1.2.3+42".to_string()),
+        );
+    }
+
+    #[test]
+    fn read_version_missing() {
+        let content = "name: my_app\n";
+        assert_eq!(PubspecVersionFile.read_version(content), None);
+    }
+
+    // --- write_version ---
+
+    #[test]
+    fn write_version_basic() {
+        let result = PubspecVersionFile
+            .write_version(BASIC_PUBSPEC, "2.0.0")
+            .unwrap();
+        assert!(result.contains("version: 2.0.0"));
+        assert!(!result.contains('+'));
+        assert!(result.contains("name: my_app"));
+    }
+
+    #[test]
+    fn write_version_increments_build_number() {
+        let result = PubspecVersionFile
+            .write_version(PUBSPEC_WITH_BUILD, "2.0.0")
+            .unwrap();
+        assert!(result.contains("version: 2.0.0+43"));
+        assert!(result.contains("name: my_app"));
+    }
+
+    #[test]
+    fn write_version_no_field_returns_error() {
+        let content = "name: my_app\n";
+        let err = PubspecVersionFile.write_version(content, "1.0.0");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn write_version_preserves_no_trailing_newline() {
+        let content = "name: my_app\nversion: 0.1.0";
+        let result = PubspecVersionFile.write_version(content, "0.2.0").unwrap();
+        assert!(!result.ends_with('\n'));
+        assert!(result.contains("version: 0.2.0"));
+    }
+
+    // --- integration ---
+
+    #[test]
+    fn integration_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pubspec.yaml");
+        std::fs::write(&path, BASIC_PUBSPEC).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(PubspecVersionFile.detect(&content));
+        assert_eq!(
+            PubspecVersionFile.read_version(&content),
+            Some("1.2.3".to_string()),
+        );
+
+        let updated = PubspecVersionFile.write_version(&content, "3.0.0").unwrap();
+        std::fs::write(&path, &updated).unwrap();
+
+        let final_content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            PubspecVersionFile.read_version(&final_content),
+            Some("3.0.0".to_string()),
+        );
+    }
+
+    #[test]
+    fn integration_roundtrip_with_build_number() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pubspec.yaml");
+        std::fs::write(&path, PUBSPEC_WITH_BUILD).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let updated = PubspecVersionFile.write_version(&content, "3.0.0").unwrap();
+        std::fs::write(&path, &updated).unwrap();
+
+        let final_content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            PubspecVersionFile.read_version(&final_content),
+            Some("3.0.0+43".to_string()),
+        );
+    }
+}

--- a/crates/standard-version/src/version_file.rs
+++ b/crates/standard-version/src/version_file.rs
@@ -9,8 +9,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::cargo::CargoVersionFile;
+use crate::gradle::GradleVersionFile;
 use crate::json::{DenoVersionFile, JsonVersionFile};
+use crate::pubspec::PubspecVersionFile;
 use crate::pyproject::PyprojectVersionFile;
+use crate::version_plain::PlainVersionFile;
 
 // ---------------------------------------------------------------------------
 // Error
@@ -70,6 +73,14 @@ pub trait VersionFile {
 
     /// Return updated file content with `new_version` replacing the old value.
     fn write_version(&self, content: &str, new_version: &str) -> Result<String, VersionFileError>;
+
+    /// Compare old and new file content and return optional extra information
+    /// about side-effects (e.g. `VERSION_CODE` increment in gradle).
+    ///
+    /// The default implementation returns `None`.
+    fn extra_info(&self, _old_content: &str, _new_content: &str) -> Option<String> {
+        None
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -115,10 +126,10 @@ pub struct CustomVersionFile {
 /// Discover and update version files at `root`.
 ///
 /// Iterates all built-in version file engines ([`CargoVersionFile`],
-/// [`PyprojectVersionFile`], [`JsonVersionFile`], [`DenoVersionFile`])
-/// and, for each file that is detected, replaces the
-/// version string with `new_version`. Updated content is written back to
-/// disk.
+/// [`PyprojectVersionFile`], [`JsonVersionFile`], [`DenoVersionFile`],
+/// [`PubspecVersionFile`], [`GradleVersionFile`], [`PlainVersionFile`])
+/// and, for each file that is detected, replaces the version string with
+/// `new_version`. Updated content is written back to disk.
 ///
 /// `_custom_files` is accepted for forward compatibility (story #103) but
 /// is not yet processed.
@@ -137,6 +148,9 @@ pub fn update_version_files(
         Box::new(PyprojectVersionFile),
         Box::new(JsonVersionFile),
         Box::new(DenoVersionFile),
+        Box::new(PubspecVersionFile),
+        Box::new(GradleVersionFile),
+        Box::new(PlainVersionFile),
     ];
 
     let mut results = Vec::new();
@@ -160,6 +174,7 @@ pub fn update_version_files(
             };
 
             let updated = engine.write_version(&content, new_version)?;
+            let extra = engine.extra_info(&content, &updated);
             fs::write(&path, &updated).map_err(VersionFileError::WriteFailed)?;
 
             results.push(UpdateResult {
@@ -167,7 +182,7 @@ pub fn update_version_files(
                 name: engine.name().to_string(),
                 old_version,
                 new_version: new_version.to_string(),
-                extra: None,
+                extra,
             });
         }
     }
@@ -253,6 +268,79 @@ requires-python = ">=3.8"
 
         let on_disk = fs::read_to_string(&pyproject).unwrap();
         assert!(on_disk.contains("version = \"2.0.0\""));
+    }
+
+    #[test]
+    fn update_version_files_updates_pubspec_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        let pubspec = dir.path().join("pubspec.yaml");
+        fs::write(
+            &pubspec,
+            "name: my_app\nversion: 1.0.0\ndescription: test\n",
+        )
+        .unwrap();
+
+        let results = update_version_files(dir.path(), "2.0.0", &[]).unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].old_version, "1.0.0");
+        assert_eq!(results[0].new_version, "2.0.0");
+        assert_eq!(results[0].name, "pubspec.yaml");
+
+        let on_disk = fs::read_to_string(&pubspec).unwrap();
+        assert!(on_disk.contains("version: 2.0.0"));
+    }
+
+    #[test]
+    fn update_version_files_updates_gradle_properties() {
+        let dir = tempfile::tempdir().unwrap();
+        let gradle = dir.path().join("gradle.properties");
+        fs::write(&gradle, "VERSION_NAME=1.0.0\nVERSION_CODE=10\n").unwrap();
+
+        let results = update_version_files(dir.path(), "2.0.0", &[]).unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].old_version, "1.0.0");
+        assert_eq!(results[0].name, "gradle.properties");
+        assert_eq!(
+            results[0].extra,
+            Some("VERSION_CODE: 10 \u{2192} 11".to_string()),
+        );
+
+        let on_disk = fs::read_to_string(&gradle).unwrap();
+        assert!(on_disk.contains("VERSION_NAME=2.0.0"));
+        assert!(on_disk.contains("VERSION_CODE=11"));
+    }
+
+    #[test]
+    fn update_version_files_updates_version_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let version = dir.path().join("VERSION");
+        fs::write(&version, "1.0.0\n").unwrap();
+
+        let results = update_version_files(dir.path(), "2.0.0", &[]).unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].old_version, "1.0.0");
+        assert_eq!(results[0].name, "VERSION");
+
+        let on_disk = fs::read_to_string(&version).unwrap();
+        assert_eq!(on_disk, "2.0.0\n");
+    }
+
+    #[test]
+    fn update_version_files_updates_multiple_files() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"x\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        fs::write(dir.path().join("pubspec.yaml"), "name: x\nversion: 1.0.0\n").unwrap();
+        fs::write(dir.path().join("VERSION"), "1.0.0\n").unwrap();
+
+        let results = update_version_files(dir.path(), "2.0.0", &[]).unwrap();
+        assert_eq!(results.len(), 3);
     }
 
     #[test]

--- a/crates/standard-version/src/version_plain.rs
+++ b/crates/standard-version/src/version_plain.rs
@@ -1,0 +1,169 @@
+//! Plain `VERSION` file engine.
+//!
+//! Implements [`VersionFile`] for projects that store the version string as
+//! the sole content of a `VERSION` file.
+
+use crate::version_file::{VersionFile, VersionFileError};
+
+/// Version file engine for plain `VERSION` files.
+///
+/// Expects the file to contain nothing but a version string (optionally
+/// followed by a trailing newline).
+#[derive(Debug, Clone, Copy)]
+pub struct PlainVersionFile;
+
+/// Maximum length (in bytes) for a `VERSION` file to be considered valid.
+const MAX_VERSION_LEN: usize = 64;
+
+impl VersionFile for PlainVersionFile {
+    fn name(&self) -> &str {
+        "VERSION"
+    }
+
+    fn filenames(&self) -> &[&str] {
+        &["VERSION"]
+    }
+
+    fn detect(&self, content: &str) -> bool {
+        let trimmed = content.trim();
+        if trimmed.is_empty() || trimmed.len() > MAX_VERSION_LEN {
+            return false;
+        }
+        // Reject content with multiple lines (not a plain version file).
+        if trimmed.contains('\n') {
+            return false;
+        }
+        // Reject content with characters unlikely in a version string.
+        trimmed
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '+')
+    }
+
+    fn read_version(&self, content: &str) -> Option<String> {
+        let trimmed = content.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        Some(trimmed.to_string())
+    }
+
+    fn write_version(&self, _content: &str, new_version: &str) -> Result<String, VersionFileError> {
+        Ok(format!("{new_version}\n"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- detect ---
+
+    #[test]
+    fn detect_positive_semver() {
+        assert!(PlainVersionFile.detect("1.2.3\n"));
+    }
+
+    #[test]
+    fn detect_positive_prerelease() {
+        assert!(PlainVersionFile.detect("1.0.0-rc.1\n"));
+    }
+
+    #[test]
+    fn detect_positive_build_metadata() {
+        assert!(PlainVersionFile.detect("1.0.0+build.42\n"));
+    }
+
+    #[test]
+    fn detect_negative_empty() {
+        assert!(!PlainVersionFile.detect(""));
+        assert!(!PlainVersionFile.detect("  \n"));
+    }
+
+    #[test]
+    fn detect_negative_multiline() {
+        assert!(!PlainVersionFile.detect("1.0.0\nsome other stuff\n"));
+    }
+
+    #[test]
+    fn detect_negative_binary_garbage() {
+        assert!(!PlainVersionFile.detect("\x00\x01\x02\x03"));
+    }
+
+    #[test]
+    fn detect_negative_too_long() {
+        let long = "a".repeat(MAX_VERSION_LEN + 1);
+        assert!(!PlainVersionFile.detect(&long));
+    }
+
+    #[test]
+    fn detect_negative_special_characters() {
+        assert!(!PlainVersionFile.detect("1.0.0; rm -rf /\n"));
+    }
+
+    // --- read_version ---
+
+    #[test]
+    fn read_version_basic() {
+        assert_eq!(
+            PlainVersionFile.read_version("1.2.3\n"),
+            Some("1.2.3".to_string()),
+        );
+    }
+
+    #[test]
+    fn read_version_with_whitespace() {
+        assert_eq!(
+            PlainVersionFile.read_version("  1.2.3  \n"),
+            Some("1.2.3".to_string()),
+        );
+    }
+
+    #[test]
+    fn read_version_empty() {
+        assert_eq!(PlainVersionFile.read_version(""), None);
+        assert_eq!(PlainVersionFile.read_version("  \n"), None);
+    }
+
+    // --- write_version ---
+
+    #[test]
+    fn write_version_overwrites_entirely() {
+        let result = PlainVersionFile.write_version("1.2.3\n", "2.0.0").unwrap();
+        assert_eq!(result, "2.0.0\n");
+    }
+
+    #[test]
+    fn write_version_always_has_trailing_newline() {
+        let result = PlainVersionFile.write_version("1.2.3", "2.0.0").unwrap();
+        assert_eq!(result, "2.0.0\n");
+    }
+
+    // --- integration ---
+
+    #[test]
+    fn integration_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("VERSION");
+        std::fs::write(&path, "1.2.3\n").unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(PlainVersionFile.detect(&content));
+        assert_eq!(
+            PlainVersionFile.read_version(&content),
+            Some("1.2.3".to_string()),
+        );
+
+        let updated = PlainVersionFile.write_version(&content, "3.0.0").unwrap();
+        std::fs::write(&path, &updated).unwrap();
+
+        let final_content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            PlainVersionFile.read_version(&final_content),
+            Some("3.0.0".to_string()),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PubspecVersionFile` for `pubspec.yaml` with `+N` build number increment
- Add `GradleVersionFile` for `gradle.properties` with `VERSION_CODE` auto-increment
- Add `PlainVersionFile` for `VERSION` files (bare version string overwrite)
- Add `extra_info()` default method to `VersionFile` trait for auxiliary change reporting

Closes #100, closes #101, closes #102

## Test plan

- [x] pubspec: detect, read, write with/without build number suffix
- [x] gradle: detect, read, write with/without VERSION_CODE, extra_info reporting
- [x] VERSION: detect (rejects garbage), read, write (full overwrite)
- [x] Integration tests with tempdir for all three engines
- [x] All 78 tests pass, `just lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)