### PR TITLE
ci: add GitHub Pages workflow for mdbook user guide

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "book.toml"
+      - ".github/workflows/docs.yml"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build mdbook
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdbook
+        run: |
+          curl -sSfL https://github.com/rust-lang/mdBook/releases/latest/download/mdbook-v0.4.44-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz -C /usr/local/bin
+      - name: Build book
+        run: mdbook build
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/book
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,3 +1,4 @@
 # Summary
 
+- [Usage](USAGE.md)
 - [Specification](SPEC.md)


### PR DESCRIPTION
## Summary

- Add `.github/workflows/docs.yml` to deploy mdbook to GitHub Pages
- Add USAGE chapter link to `docs/SUMMARY.md`
- Triggers on push to main when `docs/`, `book.toml`, or the workflow changes
- Requires enabling GitHub Pages source as 'GitHub Actions' in repo settings

Closes #141

Generated with [Claude Code](https://claude.com/claude-code)