### PR TITLE
test(spec): add check and commit snapshot scenarios

### DIFF
--- a/spec/tests/cmd/check/format_json.stdout
+++ b/spec/tests/cmd/check/format_json.stdout
@@ -1,0 +1,1 @@
+{"valid":true,"type":"feat","description":"add login","breaking":false,"errors":[]}

--- a/spec/tests/cmd/check/format_json.toml
+++ b/spec/tests/cmd/check/format_json.toml
@@ -1,0 +1,3 @@
+bin.name = "git-std"
+args = ["check", "--format", "json", "feat: add login"]
+status = "success"

--- a/spec/tests/cmd/commit/dry_run.stdout
+++ b/spec/tests/cmd/commit/dry_run.stdout
@@ -1,0 +1,1 @@
+feat: add login

--- a/spec/tests/cmd/commit/dry_run.toml
+++ b/spec/tests/cmd/commit/dry_run.toml
@@ -1,0 +1,3 @@
+bin.name = "git-std"
+args = ["commit", "--dry-run", "--type", "feat", "-m", "add login"]
+status = "success"

--- a/spec/tests/cmd/commit/type_scope_message.stdout
+++ b/spec/tests/cmd/commit/type_scope_message.stdout
@@ -1,0 +1,1 @@
+fix(auth): handle timeout

--- a/spec/tests/cmd/commit/type_scope_message.toml
+++ b/spec/tests/cmd/commit/type_scope_message.toml
@@ -1,0 +1,3 @@
+bin.name = "git-std"
+args = ["commit", "--dry-run", "--type", "fix", "--scope", "auth", "-m", "handle timeout"]
+status = "success"

--- a/spec/tests/commit.rs
+++ b/spec/tests/commit.rs
@@ -1,0 +1,4 @@
+#[test]
+fn trycmd_commit() {
+    trycmd::TestCases::new().case("tests/cmd/commit/*.toml");
+}


### PR DESCRIPTION
Partially addresses #145

- `check --format json` trycmd scenario
- `commit --dry-run` trycmd scenario
- `commit --dry-run --type --scope -m` non-interactive scenario
- New `spec/tests/commit.rs` test runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)