### PR TITLE
feat(hooks): skip hook execution when GIT_STD_SKIP_HOOKS is set

### DIFF
--- a/crates/git-std/src/cli/hooks.rs
+++ b/crates/git-std/src/cli/hooks.rs
@@ -113,6 +113,14 @@ fn execute_and_print(cmd: &HookCommand, msg_path: &str) -> (CommandResult, bool)
 /// according to the hook's default mode and per-command prefix
 /// overrides, and prints a summary.
 pub fn run(hook: &str, args: &[String]) -> i32 {
+    // Allow skipping all hook execution via environment variable.
+    if let Ok(val) = std::env::var("GIT_STD_SKIP_HOOKS")
+        && (val == "1" || val.eq_ignore_ascii_case("true"))
+    {
+        eprintln!("  \u{26a0} hooks skipped (GIT_STD_SKIP_HOOKS)");
+        return 0;
+    }
+
     let commands = match read_and_parse_hooks(hook) {
         Ok(c) => c,
         Err(code) => return code,

--- a/spec/snapshots/hooks/run_skip_via_env_var.stderr.expected
+++ b/spec/snapshots/hooks/run_skip_via_env_var.stderr.expected
@@ -1,0 +1,1 @@
+  ⚠ hooks skipped (GIT_STD_SKIP_HOOKS)

--- a/spec/tests/hooks.rs
+++ b/spec/tests/hooks.rs
@@ -88,6 +88,38 @@ fn hooks_run_pass_fail_advisory() {
         ]);
 }
 
+/// `hooks run` skips execution when GIT_STD_SKIP_HOOKS=1 is set.
+#[test]
+fn hooks_run_skip_via_env_var() {
+    let repo = TestRepo::new().with_hooks_file("pre-commit", "false\n");
+
+    Command::new(TestRepo::bin_path())
+        .args(["hooks", "run", "pre-commit"])
+        .env("GIT_STD_SKIP_HOOKS", "1")
+        .current_dir(repo.path())
+        .assert()
+        .success()
+        .stderr_eq(file![
+            "../snapshots/hooks/run_skip_via_env_var.stderr.expected"
+        ]);
+}
+
+/// `hooks run` skips execution when GIT_STD_SKIP_HOOKS=true is set.
+#[test]
+fn hooks_run_skip_via_env_var_true() {
+    let repo = TestRepo::new().with_hooks_file("pre-commit", "false\n");
+
+    Command::new(TestRepo::bin_path())
+        .args(["hooks", "run", "pre-commit"])
+        .env("GIT_STD_SKIP_HOOKS", "true")
+        .current_dir(repo.path())
+        .assert()
+        .success()
+        .stderr_eq(file![
+            "../snapshots/hooks/run_skip_via_env_var.stderr.expected"
+        ]);
+}
+
 /// `hooks run` displays glob patterns and skips commands that don't match.
 #[test]
 fn hooks_run_glob_filtering() {


### PR DESCRIPTION
## Summary

- When `GIT_STD_SKIP_HOOKS=1` or `=true` is set, `git std hooks run` skips all hook execution, prints a warning message, and exits 0
- Adds two integration tests covering both accepted env var values (`1` and `true`)

Closes #73

## Test plan

- [x] `cargo test --workspace` passes (all 8 hooks tests green, including 2 new ones)
- [x] `cargo clippy --workspace -- -D warnings` passes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)