### PR TITLE
refactor: use thiserror for error derives in library crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,7 @@ name = "standard-commit"
 version = "0.2.0"
 dependencies = [
  "git-conventional",
+ "thiserror",
 ]
 
 [[package]]
@@ -1284,6 +1285,7 @@ dependencies = [
  "serde_json",
  "standard-commit",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -1332,6 +1334,26 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thread_local"

--- a/crates/standard-commit/Cargo.toml
+++ b/crates/standard-commit/Cargo.toml
@@ -12,3 +12,4 @@ categories = ["development-tools", "parser-implementations"]
 
 [dependencies]
 git-conventional = "1.0.0"
+thiserror = "2"

--- a/crates/standard-commit/src/lint.rs
+++ b/crates/standard-commit/src/lint.rs
@@ -25,16 +25,11 @@ impl Default for LintConfig {
 }
 
 /// A lint error found in a commit message.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("{message}")]
 pub struct LintError {
     /// Human-readable description of the error.
     pub message: String,
-}
-
-impl std::fmt::Display for LintError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
-    }
 }
 
 /// Lint a commit message against the given configuration.

--- a/crates/standard-commit/src/parse.rs
+++ b/crates/standard-commit/src/parse.rs
@@ -25,24 +25,15 @@ pub struct Footer {
 }
 
 /// Errors that can occur when parsing a conventional commit message.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ParseError {
     /// The message is empty.
+    #[error("commit message is empty")]
     EmptyMessage,
     /// The message does not conform to the conventional commit format.
+    #[error("{0}")]
     InvalidFormat(String),
 }
-
-impl std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ParseError::EmptyMessage => write!(f, "commit message is empty"),
-            ParseError::InvalidFormat(msg) => write!(f, "{msg}"),
-        }
-    }
-}
-
-impl std::error::Error for ParseError {}
 
 /// Parse a commit message string into a [`ConventionalCommit`].
 ///

--- a/crates/standard-version/Cargo.toml
+++ b/crates/standard-version/Cargo.toml
@@ -15,6 +15,7 @@ regex = "1"
 semver = "1"
 serde_json = "1"
 standard-commit = { version = "0.2.0", path = "../standard-commit" }
+thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/standard-version/src/calver.rs
+++ b/crates/standard-version/src/calver.rs
@@ -6,8 +6,6 @@
 //!
 //! This module is pure — it takes the date as a parameter and performs no I/O.
 
-use std::fmt;
-
 /// Date information needed for calver computation.
 ///
 /// All fields are simple integers — the caller is responsible for computing
@@ -30,33 +28,18 @@ pub struct CalverDate {
 pub const DEFAULT_FORMAT: &str = "YYYY.MM.PATCH";
 
 /// Errors that can occur during calver computation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum CalverError {
     /// The format string contains no `PATCH` token.
+    #[error("calver format must contain the PATCH token")]
     NoPatchToken,
     /// The format string contains an unrecognised token.
+    #[error("unknown calver format token: {0}")]
     UnknownToken(String),
     /// The format string is empty.
+    #[error("calver format string is empty")]
     EmptyFormat,
 }
-
-impl fmt::Display for CalverError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CalverError::NoPatchToken => {
-                write!(f, "calver format must contain the PATCH token")
-            }
-            CalverError::UnknownToken(tok) => {
-                write!(f, "unknown calver format token: {tok}")
-            }
-            CalverError::EmptyFormat => {
-                write!(f, "calver format string is empty")
-            }
-        }
-    }
-}
-
-impl std::error::Error for CalverError {}
 
 /// A parsed token from the calver format string.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/standard-version/src/version_file.rs
+++ b/crates/standard-version/src/version_file.rs
@@ -4,7 +4,6 @@
 //! engines, and the [`update_version_files`] function that discovers and
 //! updates version files at a repository root.
 
-use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -21,40 +20,24 @@ use crate::version_plain::PlainVersionFile;
 // ---------------------------------------------------------------------------
 
 /// Errors that can occur when reading or writing version files.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum VersionFileError {
     /// The expected file was not found on disk.
+    #[error("file not found: {}", .0.display())]
     FileNotFound(PathBuf),
     /// The file does not contain a version field this engine can handle.
+    #[error("no version field found")]
     NoVersionField,
     /// Writing the updated content back to disk failed.
-    WriteFailed(std::io::Error),
+    #[error("write failed: {0}")]
+    WriteFailed(#[source] std::io::Error),
     /// Reading the file from disk failed.
-    ReadFailed(std::io::Error),
+    #[error("read failed: {0}")]
+    ReadFailed(#[source] std::io::Error),
     /// A user-supplied regex pattern is invalid or has no capture groups.
+    #[error("invalid regex: {0}")]
     InvalidRegex(String),
-}
-
-impl fmt::Display for VersionFileError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::FileNotFound(p) => write!(f, "file not found: {}", p.display()),
-            Self::NoVersionField => write!(f, "no version field found"),
-            Self::WriteFailed(e) => write!(f, "write failed: {e}"),
-            Self::ReadFailed(e) => write!(f, "read failed: {e}"),
-            Self::InvalidRegex(msg) => write!(f, "invalid regex: {msg}"),
-        }
-    }
-}
-
-impl std::error::Error for VersionFileError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::WriteFailed(e) | Self::ReadFailed(e) => Some(e),
-            _ => None,
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace manual `impl Display` + `impl Error` with `#[derive(thiserror::Error)]` in `standard-commit` (`ParseError`, `LintError`) and `standard-version` (`VersionFileError`, `CalverError`)
- Add `thiserror = "2"` as a dependency to `standard-commit` and `standard-version`
- No changes needed in `standard-changelog` or `standard-githooks` (no error types)

Closes #133

## Test plan

- [x] `cargo test -p standard-commit -p standard-version` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] All `Display` output unchanged (verified by existing snapshot and unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)