### PR TITLE
fix(config): validate calver_format at parse time

### DIFF
--- a/crates/git-std/src/config.rs
+++ b/crates/git-std/src/config.rs
@@ -123,12 +123,27 @@ fn default_types() -> Vec<String> {
     DEFAULT_TYPES.iter().map(|t| (*t).to_string()).collect()
 }
 
+/// Validate a calver format string.
+///
+/// Returns `Ok(())` when the format contains valid calver tokens with at
+/// least one date segment and a `PATCH` token, or an error message
+/// describing the problem.
+pub fn validate_calver_format(format: &str) -> Result<(), String> {
+    standard_version::calver::validate_format(format).map_err(|e| e.to_string())
+}
+
 /// Load configuration from `.git-std.toml` in the given directory, or return defaults.
-pub fn load(dir: &Path) -> ProjectConfig {
+///
+/// # Errors
+///
+/// Returns an error if the configuration is syntactically valid TOML but
+/// contains semantic errors (e.g. an invalid `calver_format` when
+/// `scheme = "calver"`).
+pub fn load(dir: &Path) -> Result<ProjectConfig, String> {
     let path = dir.join(CONFIG_FILE);
     match std::fs::read_to_string(&path) {
         Ok(content) => parse_config(&content),
-        Err(_) => ProjectConfig {
+        Err(_) => Ok(ProjectConfig {
             types: default_types(),
             scopes: ScopesConfig::None,
             strict: false,
@@ -136,15 +151,15 @@ pub fn load(dir: &Path) -> ProjectConfig {
             changelog: ChangelogConfig::default(),
             versioning: VersioningConfig::default(),
             version_files: Vec::new(),
-        },
+        }),
     }
 }
 
-fn parse_config(content: &str) -> ProjectConfig {
+fn parse_config(content: &str) -> Result<ProjectConfig, String> {
     let table: toml::Table = match content.parse() {
         Ok(t) => t,
         Err(_) => {
-            return ProjectConfig {
+            return Ok(ProjectConfig {
                 types: default_types(),
                 scopes: ScopesConfig::None,
                 strict: false,
@@ -152,7 +167,7 @@ fn parse_config(content: &str) -> ProjectConfig {
                 changelog: ChangelogConfig::default(),
                 versioning: VersioningConfig::default(),
                 version_files: Vec::new(),
-            };
+            });
         }
     };
 
@@ -201,7 +216,12 @@ fn parse_config(content: &str) -> ProjectConfig {
     let versioning = parse_versioning_config(&table);
     let version_files = parse_version_files(&table);
 
-    ProjectConfig {
+    // Validate calver_format when scheme is calver.
+    if scheme == Scheme::Calver {
+        validate_calver_format(&versioning.calver_format)?;
+    }
+
+    Ok(ProjectConfig {
         types,
         scopes,
         strict,
@@ -209,7 +229,7 @@ fn parse_config(content: &str) -> ProjectConfig {
         changelog,
         versioning,
         version_files,
-    }
+    })
 }
 
 fn parse_versioning_config(table: &toml::Table) -> VersioningConfig {
@@ -309,7 +329,7 @@ mod tests {
     #[test]
     fn default_types_when_no_config() {
         let dir = tempfile::tempdir().unwrap();
-        let config = load(dir.path());
+        let config = load(dir.path()).unwrap();
         assert_eq!(config.types.len(), DEFAULT_TYPES.len());
         assert!(config.types.contains(&"feat".to_string()));
         assert_eq!(config.scopes, ScopesConfig::None);
@@ -317,13 +337,13 @@ mod tests {
 
     #[test]
     fn custom_types() {
-        let config = parse_config(r#"types = ["feat", "fix", "custom"]"#);
+        let config = parse_config(r#"types = ["feat", "fix", "custom"]"#).unwrap();
         assert_eq!(config.types, vec!["feat", "fix", "custom"]);
     }
 
     #[test]
     fn scopes_explicit_list() {
-        let config = parse_config("scopes = [\"auth\", \"api\"]\n");
+        let config = parse_config("scopes = [\"auth\", \"api\"]\n").unwrap();
         assert_eq!(
             config.scopes,
             ScopesConfig::List(vec!["auth".to_string(), "api".to_string()])
@@ -332,19 +352,19 @@ mod tests {
 
     #[test]
     fn scopes_auto() {
-        let config = parse_config("scopes = \"auto\"\n");
+        let config = parse_config("scopes = \"auto\"\n").unwrap();
         assert_eq!(config.scopes, ScopesConfig::Auto);
     }
 
     #[test]
     fn no_scopes_means_none() {
-        let config = parse_config(r#"types = ["feat"]"#);
+        let config = parse_config(r#"types = ["feat"]"#).unwrap();
         assert_eq!(config.scopes, ScopesConfig::None);
     }
 
     #[test]
     fn invalid_toml_uses_defaults() {
-        let config = parse_config("not valid toml {{{{");
+        let config = parse_config("not valid toml {{{{").unwrap();
         assert_eq!(config.types.len(), DEFAULT_TYPES.len());
     }
 
@@ -388,13 +408,13 @@ mod tests {
 
     #[test]
     fn strict_from_config() {
-        let config = parse_config("strict = true\n");
+        let config = parse_config("strict = true\n").unwrap();
         assert!(config.strict);
     }
 
     #[test]
     fn strict_default_false() {
-        let config = parse_config(r#"types = ["feat"]"#);
+        let config = parse_config(r#"types = ["feat"]"#).unwrap();
         assert!(!config.strict);
     }
 
@@ -406,7 +426,7 @@ mod tests {
             strict: true,
             ..Default::default()
         };
-        // strict=true in config, flag=false → still strict
+        // strict=true in config, flag=false -- still strict
         let lint = config.to_lint_config(false);
         assert_eq!(lint.types, Some(vec!["feat".into()]));
         assert_eq!(lint.scopes, Some(vec!["auth".into()]));
@@ -416,16 +436,9 @@ mod tests {
     #[test]
     fn version_files_parsed() {
         let config = parse_config(
-            r#"
-[[version_files]]
-path = "pom.xml"
-regex = '<version>([^<]+)</version>'
-
-[[version_files]]
-path = "Chart.yaml"
-regex = 'version:\s*(.+)'
-"#,
-        );
+            "[[version_files]]\npath = \"pom.xml\"\nregex = '<version>([^<]+)</version>'\n\n[[version_files]]\npath = \"Chart.yaml\"\nregex = 'version:\\s*(.+)'\n",
+        )
+        .unwrap();
         assert_eq!(config.version_files.len(), 2);
         assert_eq!(config.version_files[0].path, "pom.xml");
         assert_eq!(config.version_files[0].regex, "<version>([^<]+)</version>");
@@ -434,31 +447,31 @@ regex = 'version:\s*(.+)'
 
     #[test]
     fn version_files_default_empty() {
-        let config = parse_config(r#"types = ["feat"]"#);
+        let config = parse_config(r#"types = ["feat"]"#).unwrap();
         assert!(config.version_files.is_empty());
     }
 
     #[test]
     fn scheme_defaults_to_semver() {
-        let config = parse_config(r#"types = ["feat"]"#);
+        let config = parse_config(r#"types = ["feat"]"#).unwrap();
         assert_eq!(config.scheme, Scheme::Semver);
     }
 
     #[test]
     fn scheme_calver_parsed() {
-        let config = parse_config("scheme = \"calver\"\n");
+        let config = parse_config("scheme = \"calver\"\n").unwrap();
         assert_eq!(config.scheme, Scheme::Calver);
     }
 
     #[test]
     fn scheme_unknown_falls_back_to_semver() {
-        let config = parse_config("scheme = \"unknown\"\n");
+        let config = parse_config("scheme = \"unknown\"\n").unwrap();
         assert_eq!(config.scheme, Scheme::Semver);
     }
 
     #[test]
     fn calver_format_default() {
-        let config = parse_config(r#"types = ["feat"]"#);
+        let config = parse_config(r#"types = ["feat"]"#).unwrap();
         assert_eq!(
             config.versioning.calver_format,
             standard_version::calver::DEFAULT_FORMAT
@@ -468,11 +481,62 @@ regex = 'version:\s*(.+)'
     #[test]
     fn calver_format_custom() {
         let config = parse_config(
-            r#"
-[versioning]
-calver_format = "YYYY.0M.PATCH"
-"#,
-        );
+            "scheme = \"calver\"\n\n[versioning]\ncalver_format = \"YYYY.0M.PATCH\"\n",
+        )
+        .unwrap();
         assert_eq!(config.versioning.calver_format, "YYYY.0M.PATCH");
+    }
+
+    // -- Calver format validation --
+
+    #[test]
+    fn calver_format_invalid_rejects_at_parse_time() {
+        let err = parse_config(
+            "scheme = \"calver\"\n\n[versioning]\ncalver_format = \"INVALID.PATCH\"\n",
+        );
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("unknown calver format token"));
+    }
+
+    #[test]
+    fn calver_format_no_patch_rejects_at_parse_time() {
+        let err = parse_config(
+            "scheme = \"calver\"\n\n[versioning]\ncalver_format = \"YYYY.MM\"\n",
+        );
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("PATCH"));
+    }
+
+    #[test]
+    fn calver_format_no_date_segment_rejects_at_parse_time() {
+        let err = parse_config(
+            "scheme = \"calver\"\n\n[versioning]\ncalver_format = \"PATCH\"\n",
+        );
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("date segment"));
+    }
+
+    #[test]
+    fn calver_format_not_validated_for_semver() {
+        let config = parse_config(
+            "[versioning]\ncalver_format = \"TOTALLY_INVALID\"\n",
+        )
+        .unwrap();
+        assert_eq!(config.versioning.calver_format, "TOTALLY_INVALID");
+    }
+
+    #[test]
+    fn validate_calver_format_valid() {
+        assert!(validate_calver_format("YYYY.MM.PATCH").is_ok());
+        assert!(validate_calver_format("YY.0W.PATCH").is_ok());
+        assert!(validate_calver_format("0Y.0M.0D.PATCH").is_ok());
+    }
+
+    #[test]
+    fn validate_calver_format_invalid() {
+        assert!(validate_calver_format("").is_err());
+        assert!(validate_calver_format("YYYY.MM").is_err());
+        assert!(validate_calver_format("PATCH").is_err());
+        assert!(validate_calver_format("INVALID").is_err());
     }
 }

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -6,7 +6,7 @@ mod cli;
 mod config;
 mod git;
 
-/// Standard git workflow — commits, versioning, hooks.
+/// Standard git workflow -- commits, versioning, hooks.
 #[derive(Parser)]
 #[command(name = "git-std", version, about)]
 struct Cli {
@@ -144,6 +144,17 @@ enum HooksCommand {
     List,
 }
 
+/// Load project config, printing an error and exiting on failure.
+fn load_config() -> config::ProjectConfig {
+    match config::load(&std::env::current_dir().unwrap_or_default()) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: invalid config: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
 
@@ -166,7 +177,7 @@ fn main() {
             strict,
             format,
         } => {
-            let project_config = config::load(&std::env::current_dir().unwrap_or_default());
+            let project_config = load_config();
             let effective_strict = strict || project_config.strict;
             let lint_config = project_config.to_lint_config(strict);
             let lint_ref = if effective_strict {
@@ -197,7 +208,7 @@ fn main() {
             sign,
             all,
         } => {
-            let project_config = config::load(&std::env::current_dir().unwrap_or_default());
+            let project_config = load_config();
             let opts = cli::commit::CommitOptions {
                 commit_type,
                 scope,
@@ -217,7 +228,7 @@ fn main() {
             output,
             range,
         } => {
-            let project_config = config::load(&std::env::current_dir().unwrap_or_default());
+            let project_config = load_config();
             let changelog_config = project_config.to_changelog_config();
             let opts = cli::changelog::ChangelogOptions {
                 full,
@@ -238,7 +249,7 @@ fn main() {
             skip_changelog,
             sign,
         } => {
-            let project_config = config::load(&std::env::current_dir().unwrap_or_default());
+            let project_config = load_config();
             let opts = cli::bump::BumpOptions {
                 dry_run,
                 prerelease,

--- a/crates/standard-version/src/calver.rs
+++ b/crates/standard-version/src/calver.rs
@@ -34,6 +34,9 @@ pub const DEFAULT_FORMAT: &str = "YYYY.MM.PATCH";
 pub enum CalverError {
     /// The format string contains no `PATCH` token.
     NoPatchToken,
+    /// The format string contains no date segment placeholder.
+    #[error("calver format must contain at least one date segment (YYYY, YY, 0Y, MM, 0M, DD, 0D, WW, 0W)")]
+    NoDateSegment,
     /// The format string contains an unrecognised token.
     UnknownToken(String),
     /// The format string is empty.
@@ -65,14 +68,20 @@ enum Token {
     FullYear,
     /// Short year (e.g. `26`).
     ShortYear,
+    /// Zero-padded short year (e.g. `06`).
+    ZeroPaddedShortYear,
     /// Zero-padded month (e.g. `03`).
     ZeroPaddedMonth,
     /// Month without padding (e.g. `3`).
     Month,
     /// ISO week number (e.g. `11`).
     IsoWeek,
+    /// Zero-padded ISO week number (e.g. `02`).
+    ZeroPaddedIsoWeek,
     /// Day of month (e.g. `13`).
     Day,
+    /// Zero-padded day of month (e.g. `03`).
+    ZeroPaddedDay,
     /// Auto-incrementing patch counter.
     Patch,
     /// A literal separator (e.g. `.`).
@@ -96,14 +105,23 @@ fn parse_format(format: &str) -> Result<Vec<Token>, CalverError> {
         } else if let Some(rest) = remaining.strip_prefix("YY") {
             tokens.push(Token::ShortYear);
             remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("0Y") {
+            tokens.push(Token::ZeroPaddedShortYear);
+            remaining = rest;
         } else if let Some(rest) = remaining.strip_prefix("0M") {
             tokens.push(Token::ZeroPaddedMonth);
             remaining = rest;
         } else if let Some(rest) = remaining.strip_prefix("MM") {
             tokens.push(Token::Month);
             remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("0W") {
+            tokens.push(Token::ZeroPaddedIsoWeek);
+            remaining = rest;
         } else if let Some(rest) = remaining.strip_prefix("WW") {
             tokens.push(Token::IsoWeek);
+            remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("0D") {
+            tokens.push(Token::ZeroPaddedDay);
             remaining = rest;
         } else if let Some(rest) = remaining.strip_prefix("DD") {
             tokens.push(Token::Day);
@@ -134,6 +152,25 @@ fn parse_format(format: &str) -> Result<Vec<Token>, CalverError> {
         return Err(CalverError::NoPatchToken);
     }
 
+    // Validate that at least one date segment is present.
+    let has_date = tokens.iter().any(|t| {
+        matches!(
+            t,
+            Token::FullYear
+                | Token::ShortYear
+                | Token::ZeroPaddedShortYear
+                | Token::ZeroPaddedMonth
+                | Token::Month
+                | Token::IsoWeek
+                | Token::ZeroPaddedIsoWeek
+                | Token::Day
+                | Token::ZeroPaddedDay
+        )
+    });
+    if !has_date {
+        return Err(CalverError::NoDateSegment);
+    }
+
     Ok(tokens)
 }
 
@@ -146,10 +183,13 @@ fn build_date_prefix(tokens: &[Token], date: CalverDate) -> String {
             Token::Patch => break,
             Token::FullYear => prefix.push_str(&date.year.to_string()),
             Token::ShortYear => prefix.push_str(&format!("{}", date.year % 100)),
+            Token::ZeroPaddedShortYear => prefix.push_str(&format!("{:02}", date.year % 100)),
             Token::ZeroPaddedMonth => prefix.push_str(&format!("{:02}", date.month)),
             Token::Month => prefix.push_str(&date.month.to_string()),
             Token::IsoWeek => prefix.push_str(&date.iso_week.to_string()),
+            Token::ZeroPaddedIsoWeek => prefix.push_str(&format!("{:02}", date.iso_week)),
             Token::Day => prefix.push_str(&date.day.to_string()),
+            Token::ZeroPaddedDay => prefix.push_str(&format!("{:02}", date.day)),
             Token::Separator(s) => prefix.push_str(s),
         }
     }
@@ -171,10 +211,13 @@ fn build_date_suffix(tokens: &[Token], date: CalverDate) -> String {
         match token {
             Token::FullYear => suffix.push_str(&date.year.to_string()),
             Token::ShortYear => suffix.push_str(&format!("{}", date.year % 100)),
+            Token::ZeroPaddedShortYear => suffix.push_str(&format!("{:02}", date.year % 100)),
             Token::ZeroPaddedMonth => suffix.push_str(&format!("{:02}", date.month)),
             Token::Month => suffix.push_str(&date.month.to_string()),
             Token::IsoWeek => suffix.push_str(&date.iso_week.to_string()),
+            Token::ZeroPaddedIsoWeek => suffix.push_str(&format!("{:02}", date.iso_week)),
             Token::Day => suffix.push_str(&date.day.to_string()),
+            Token::ZeroPaddedDay => suffix.push_str(&format!("{:02}", date.day)),
             Token::Separator(s) => suffix.push_str(s),
             Token::Patch => {} // only one PATCH allowed, already past it
         }
@@ -323,7 +366,7 @@ mod tests {
         }
     }
 
-    // ── Format parsing ──────────────────────────────────────────────
+    // -- Format parsing --
 
     #[test]
     fn parse_default_format() {
@@ -370,7 +413,7 @@ mod tests {
         assert!(matches!(err, CalverError::UnknownToken(_)));
     }
 
-    // ── First release ───────────────────────────────────────────────
+    // -- First release --
 
     #[test]
     fn first_release_default_format() {
@@ -402,7 +445,7 @@ mod tests {
         assert_eq!(v, "26.12.0");
     }
 
-    // ── Patch increment (same period) ───────────────────────────────
+    // -- Patch increment (same period) --
 
     #[test]
     fn patch_increments_same_month() {
@@ -428,7 +471,7 @@ mod tests {
         assert_eq!(v, "2026.3.16.1");
     }
 
-    // ── Patch reset (new period) ────────────────────────────────────
+    // -- Patch reset (new period) --
 
     #[test]
     fn patch_resets_new_month() {
@@ -475,7 +518,7 @@ mod tests {
         assert_eq!(v, "26.13.0");
     }
 
-    // ── Format validation ───────────────────────────────────────────
+    // -- Format validation --
 
     #[test]
     fn validate_valid_format() {
@@ -483,6 +526,9 @@ mod tests {
         assert!(validate_format("YYYY.0M.PATCH").is_ok());
         assert!(validate_format("YY.WW.PATCH").is_ok());
         assert!(validate_format("YYYY.MM.DD.PATCH").is_ok());
+        assert!(validate_format("0Y.0M.PATCH").is_ok());
+        assert!(validate_format("YYYY.0M.0D.PATCH").is_ok());
+        assert!(validate_format("YY.0W.PATCH").is_ok());
     }
 
     #[test]
@@ -491,18 +537,16 @@ mod tests {
         assert!(validate_format("").is_err());
     }
 
-    // ── Edge cases ──────────────────────────────────────────────────
+    // -- Edge cases --
 
     #[test]
     fn previous_version_is_completely_different() {
-        // Previous version from a totally different format/period.
         let v = next_version("YYYY.MM.PATCH", date_2026_03(), Some("1.2.3")).unwrap();
         assert_eq!(v, "2026.3.0");
     }
 
     #[test]
     fn previous_version_unparseable_patch() {
-        // If the patch segment isn't a number, treat as 0 and reset.
         let v = next_version("YYYY.MM.PATCH", date_2026_03(), Some("2026.3.abc")).unwrap();
         assert_eq!(v, "2026.3.1");
     }
@@ -519,7 +563,55 @@ mod tests {
         assert_eq!(v, "2026-3-3");
     }
 
-    // ── CalverError Display ─────────────────────────────────────────
+    // -- Zero-padded tokens --
+
+    #[test]
+    fn zero_padded_short_year() {
+        let v = next_version("0Y.MM.PATCH", date_2026_03(), None).unwrap();
+        assert_eq!(v, "26.3.0");
+    }
+
+    #[test]
+    fn zero_padded_day() {
+        let date = CalverDate {
+            year: 2026,
+            month: 3,
+            day: 5,
+            iso_week: 10,
+            day_of_week: 4,
+        };
+        let v = next_version("YYYY.0M.0D.PATCH", date, None).unwrap();
+        assert_eq!(v, "2026.03.05.0");
+    }
+
+    #[test]
+    fn zero_padded_week() {
+        let date = CalverDate {
+            year: 2026,
+            month: 1,
+            day: 5,
+            iso_week: 2,
+            day_of_week: 1,
+        };
+        let v = next_version("YY.0W.PATCH", date, None).unwrap();
+        assert_eq!(v, "26.02.0");
+    }
+
+    // -- No date segment --
+
+    #[test]
+    fn error_no_date_segment() {
+        let err = parse_format("PATCH").unwrap_err();
+        assert_eq!(err, CalverError::NoDateSegment);
+    }
+
+    #[test]
+    fn error_patch_only_with_separator() {
+        let err = parse_format(".PATCH").unwrap_err();
+        assert_eq!(err, CalverError::NoDateSegment);
+    }
+
+    // -- CalverError Display --
 
     #[test]
     fn error_display() {
@@ -536,5 +628,8 @@ mod tests {
                 .to_string()
                 .contains("unknown calver format token")
         );
+        assert!(CalverError::NoDateSegment
+            .to_string()
+            .contains("at least one date segment"));
     }
 }


### PR DESCRIPTION
## Summary

- Add validation of `calver_format` at config parse time when `scheme = "calver"`, rejecting invalid format strings early with a clear error message
- Add `NoDateSegment` error variant requiring at least one date segment placeholder (YYYY, YY, 0Y, MM, 0M, DD, 0D, WW, 0W)
- Add zero-padded token support: `0Y` (short year), `0D` (day), `0W` (week)
- Add `validate_calver_format()` public function and call it during `parse_config()` when scheme is calver
- Change `config::load()` to return `Result<ProjectConfig, String>` so errors propagate cleanly

## Test plan

- [x] `cargo test --workspace` passes (all 471 tests)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] New unit tests verify invalid formats are rejected at parse time
- [x] New unit tests verify semver scheme does not validate calver_format
- [x] New unit tests for zero-padded tokens (0Y, 0D, 0W)
- [x] New unit tests for `NoDateSegment` error (PATCH-only format)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)