### PR TITLE
feat(bump): implement scheme = patch for patch-only branches

### DIFF
--- a/crates/git-std/src/cli/bump.rs
+++ b/crates/git-std/src/cli/bump.rs
@@ -26,12 +26,17 @@ pub struct BumpOptions {
     pub skip_changelog: bool,
     /// GPG-sign the commit and tag.
     pub sign: bool,
+    /// Allow breaking changes in patch-only scheme.
+    pub force: bool,
 }
 
 /// Run the bump subcommand. Returns the exit code.
 pub fn run(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
     if config.scheme == Scheme::Calver {
         return run_calver(config, opts);
+    }
+    if config.scheme == Scheme::Patch {
+        return run_patch(config, opts);
     }
 
     let repo = match git2::Repository::discover(".") {
@@ -532,6 +537,91 @@ fn calver_date_from_epoch_days(days: i32) -> standard_version::calver::CalverDat
         iso_week: iso_week as u32,
         day_of_week: dow,
     }
+}
+
+/// Run the bump subcommand in patch-only mode.
+///
+/// Always increments the patch version. Rejects breaking changes unless
+/// `--force` is passed.
+fn run_patch(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
+    let repo = match git2::Repository::discover(".") {
+        Ok(r) => r,
+        Err(e) => {
+            ui::error(&format!("cannot open repository: {e}"));
+            return 1;
+        }
+    };
+
+    let tag_prefix = &config.versioning.tag_prefix;
+
+    // Find latest semver tag.
+    let current_version = match git::find_latest_version_tag(&repo, tag_prefix) {
+        Ok(Some((oid, ver))) => Some((oid, ver)),
+        Ok(None) => None,
+        Err(e) => {
+            ui::error(&e.to_string());
+            return 1;
+        }
+    };
+
+    // Collect commits since that tag.
+    let head_oid = match repo.head().and_then(|h| h.peel_to_commit().map(|c| c.id())) {
+        Ok(oid) => oid,
+        Err(e) => {
+            ui::error(&format!("cannot resolve HEAD: {e}"));
+            return 1;
+        }
+    };
+
+    let tag_oid = current_version.as_ref().map(|(oid, _)| *oid);
+    let raw_commits = match git::walk_commits(&repo, head_oid, tag_oid) {
+        Ok(c) => c,
+        Err(e) => {
+            ui::error(&e.to_string());
+            return 1;
+        }
+    };
+
+    // Parse commits and check for breaking changes.
+    let has_breaking = raw_commits
+        .iter()
+        .filter_map(|(_, msg)| standard_commit::parse(msg).ok())
+        .any(|c| c.is_breaking);
+
+    if has_breaking && !opts.force {
+        ui::error(
+            "breaking change detected — patch-only scheme does not allow major bumps. \
+             Use --force to override.",
+        );
+        return 1;
+    }
+
+    let cur_ver = current_version
+        .as_ref()
+        .map(|(_, v)| v.clone())
+        .unwrap_or_else(|| semver::Version::new(0, 0, 0));
+
+    // Always bump patch.
+    let new_version = semver::Version::new(cur_ver.major, cur_ver.minor, cur_ver.patch + 1);
+
+    ui::blank();
+    eprintln!(
+        "{INDENT}{} (patch)",
+        format!("{cur_ver} \u{2192} {new_version}").bold(),
+        INDENT = ui::INDENT,
+    );
+
+    let prev_ver_str = current_version
+        .as_ref()
+        .map(|(_, v)| v.to_string());
+
+    let ctx = FinalizeContext {
+        new_version: new_version.to_string(),
+        prev_version: prev_ver_str.as_deref(),
+        raw_commits: &raw_commits,
+    };
+
+    finalize_bump(&repo, config, opts, &ctx)
 }
 
 /// Run the bump subcommand in calver mode.

--- a/crates/git-std/src/config.rs
+++ b/crates/git-std/src/config.rs
@@ -16,6 +16,8 @@ pub enum Scheme {
     Semver,
     /// Calendar versioning.
     Calver,
+    /// Patch-only bumps (always increment patch, reject breaking without --force).
+    Patch,
 }
 
 /// How scopes are resolved.
@@ -197,6 +199,7 @@ fn parse_config(content: &str) -> ProjectConfig {
 
     let scheme = match table.get("scheme").and_then(|v| v.as_str()) {
         Some("calver") => Scheme::Calver,
+        Some("patch") => Scheme::Patch,
         _ => Scheme::Semver,
     };
 
@@ -451,6 +454,12 @@ regex = 'version:\s*(.+)'
     fn scheme_calver_parsed() {
         let config = parse_config("scheme = \"calver\"\n");
         assert_eq!(config.scheme, Scheme::Calver);
+    }
+
+    #[test]
+    fn scheme_patch_parsed() {
+        let config = parse_config("scheme = \"patch\"\n");
+        assert_eq!(config.scheme, Scheme::Patch);
     }
 
     #[test]

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -103,6 +103,9 @@ enum Command {
         /// GPG-sign the release commit and annotated tag.
         #[arg(short = 'S', long)]
         sign: bool,
+        /// Allow breaking changes in patch-only scheme.
+        #[arg(long)]
+        force: bool,
     },
     /// Generate a changelog (incremental by default, --full to regenerate).
     Changelog {
@@ -241,6 +244,7 @@ fn main() {
             no_commit,
             skip_changelog,
             sign,
+            force,
         } => {
             let project_config = config::load(&std::env::current_dir().unwrap_or_default());
             let opts = cli::bump::BumpOptions {
@@ -252,6 +256,7 @@ fn main() {
                 no_commit,
                 skip_changelog,
                 sign,
+                force,
             };
             let code = cli::bump::run(&project_config, &opts);
             std::process::exit(code);

--- a/crates/git-std/tests/cli.rs
+++ b/crates/git-std/tests/cli.rs
@@ -1338,3 +1338,79 @@ fn changelog_range_no_conventional_commits() {
         "should report no conventional commits, got stderr: {stderr}"
     );
 }
+
+// --- Patch scheme integration tests (#138) ---
+
+#[test]
+fn bump_patch_scheme_produces_patch_from_feat() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = init_bump_repo(dir.path());
+    create_tag(&repo, "v1.0.0");
+
+    // Write a .git-std.toml with patch scheme.
+    std::fs::write(dir.path().join(".git-std.toml"), "scheme = \"patch\"\n").unwrap();
+
+    // Add a feat commit — should still produce a patch bump.
+    add_commit(&repo, dir.path(), "a.txt", "feat: add feature A");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("1.0.0 \u{2192} 1.0.1"))
+        .stderr(predicate::str::contains("patch"));
+
+    // Verify tag was created.
+    let tag = repo.find_reference("refs/tags/v1.0.1");
+    assert!(tag.is_ok(), "tag v1.0.1 should exist");
+}
+
+#[test]
+fn bump_patch_scheme_rejects_breaking_without_force() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = init_bump_repo(dir.path());
+    create_tag(&repo, "v1.0.0");
+
+    // Write a .git-std.toml with patch scheme.
+    std::fs::write(dir.path().join(".git-std.toml"), "scheme = \"patch\"\n").unwrap();
+
+    // Add a breaking change commit.
+    add_commit(&repo, dir.path(), "a.txt", "feat!: remove old API");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("breaking change detected"))
+        .stderr(predicate::str::contains("--force"));
+}
+
+#[test]
+fn bump_patch_scheme_allows_breaking_with_force() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = init_bump_repo(dir.path());
+    create_tag(&repo, "v1.0.0");
+
+    // Write a .git-std.toml with patch scheme.
+    std::fs::write(dir.path().join(".git-std.toml"), "scheme = \"patch\"\n").unwrap();
+
+    // Add a breaking change commit.
+    add_commit(&repo, dir.path(), "a.txt", "feat!: remove old API");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--force"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("1.0.0 \u{2192} 1.0.1"))
+        .stderr(predicate::str::contains("patch"));
+
+    // Verify tag was created.
+    let tag = repo.find_reference("refs/tags/v1.0.1");
+    assert!(tag.is_ok(), "tag v1.0.1 should exist");
+}


### PR DESCRIPTION
## Summary

- Add `Patch` variant to the `Scheme` enum in `config.rs` and accept `"patch"` in `.git-std.toml`
- Add `--force` flag to the `bump` subcommand for overriding the breaking-change guard
- Implement `run_patch()` in `bump.rs`: always increments patch, rejects breaking changes unless `--force` is used
- Add three integration tests covering patch bump from feat, breaking rejection, and `--force` override

Closes #138

## Test plan

- [x] `cargo test --workspace` passes (all existing + 3 new tests)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [ ] Manual: create a repo with `scheme = "patch"`, verify feat commit produces patch bump
- [ ] Manual: verify breaking commit is rejected without `--force` and accepted with `--force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)