### PR TITLE
feat(bump): implement --stable flag for creating patch-only branches

### DIFF
--- a/crates/git-std/src/cli/bump.rs
+++ b/crates/git-std/src/cli/bump.rs
@@ -28,10 +28,20 @@ pub struct BumpOptions {
     pub sign: bool,
     /// Allow breaking changes in patch-only scheme.
     pub force: bool,
+    /// Create a stable branch for patch-only releases.
+    ///
+    /// `None` = flag not used, `Some(None)` = `--stable` without value
+    /// (auto-generate branch name), `Some(Some(name))` = custom branch name.
+    pub stable: Option<Option<String>>,
+    /// Use minor bump instead of major when advancing main after `--stable`.
+    pub minor: bool,
 }
 
 /// Run the bump subcommand. Returns the exit code.
 pub fn run(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
+    if opts.stable.is_some() {
+        return run_stable(config, opts);
+    }
     if config.scheme == Scheme::Calver {
         return run_calver(config, opts);
     }
@@ -537,6 +547,316 @@ fn calver_date_from_epoch_days(days: i32) -> standard_version::calver::CalverDat
         iso_week: iso_week as u32,
         day_of_week: dow,
     }
+}
+
+/// Run the bump subcommand in stable-branch mode.
+///
+/// Creates a stable branch from HEAD configured for patch-only bumps,
+/// then advances the current branch with a major (or minor) version bump.
+fn run_stable(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
+    // --stable is not supported with calver.
+    if config.scheme == Scheme::Calver {
+        ui::error("--stable is not supported with scheme = \"calver\"");
+        return 1;
+    }
+
+    let repo = match git2::Repository::discover(".") {
+        Ok(r) => r,
+        Err(e) => {
+            ui::error(&format!("cannot open repository: {e}"));
+            return 1;
+        }
+    };
+
+    let tag_prefix = &config.versioning.tag_prefix;
+
+    // Step 1: Find latest version tag and get current version.
+    let current_version = match git::find_latest_version_tag(&repo, tag_prefix) {
+        Ok(Some((oid, ver))) => Some((oid, ver)),
+        Ok(None) => None,
+        Err(e) => {
+            ui::error(&e.to_string());
+            return 1;
+        }
+    };
+
+    let cur_ver = current_version
+        .as_ref()
+        .map(|(_, v)| v.clone())
+        .unwrap_or_else(|| semver::Version::new(0, 0, 0));
+
+    // Step 2: Error if working tree is dirty.
+    match git::is_working_tree_dirty(&repo) {
+        Ok(true) => {
+            ui::error("working tree has uncommitted changes");
+            return 1;
+        }
+        Err(e) => {
+            ui::error(&format!("cannot check working tree status: {e}"));
+            return 1;
+        }
+        Ok(false) => {}
+    }
+
+    // Step 3: Determine stable branch name.
+    let stable_branch_name = match &opts.stable {
+        Some(Some(name)) => name.clone(),
+        _ => format!("stable-v{}.{}", cur_ver.major, cur_ver.minor),
+    };
+
+    // Step 4: Error if that branch already exists.
+    if git::branch_exists(&repo, &stable_branch_name) {
+        ui::error(&format!("branch '{stable_branch_name}' already exists"));
+        return 1;
+    }
+
+    // Determine the current branch name so we can switch back.
+    let original_branch = match repo.head() {
+        Ok(head) => head
+            .shorthand()
+            .unwrap_or("main")
+            .to_string(),
+        Err(e) => {
+            ui::error(&format!("cannot resolve HEAD: {e}"));
+            return 1;
+        }
+    };
+
+    // Compute the new version for main.
+    let new_version = if opts.minor {
+        semver::Version::new(cur_ver.major, cur_ver.minor + 1, 0)
+    } else {
+        semver::Version::new(cur_ver.major + 1, 0, 0)
+    };
+
+    let bump_kind = if opts.minor { "minor" } else { "major" };
+
+    // --- Dry run: print plan and exit ---
+    if opts.dry_run {
+        ui::blank();
+        eprintln!("{INDENT}Creating stable branch...", INDENT = ui::INDENT);
+        ui::item("Branch:", &stable_branch_name);
+        ui::item("Scheme:", "patch (patch-only bumps)");
+        ui::blank();
+        eprintln!(
+            "{INDENT}Would commit: chore(release): stabilize v{}.{}",
+            cur_ver.major, cur_ver.minor,
+            INDENT = ui::INDENT,
+        );
+        ui::blank();
+        eprintln!("{INDENT}Advancing {original_branch}...", INDENT = ui::INDENT);
+        eprintln!(
+            "{DETAIL}{} ({bump_kind})",
+            format!("{cur_ver} \u{2192} {new_version}").bold(),
+            DETAIL = ui::DETAIL_INDENT,
+        );
+        ui::blank();
+        eprintln!(
+            "{INDENT}Would commit: chore(release): {new_version}",
+            INDENT = ui::INDENT,
+        );
+        eprintln!(
+            "{INDENT}Would tag:    {tag_prefix}{new_version}",
+            INDENT = ui::INDENT,
+        );
+        ui::blank();
+        eprintln!("{INDENT}Push with:", INDENT = ui::INDENT);
+        ui::item("", &format!("git push origin {stable_branch_name}"));
+        ui::item("", "git push --follow-tags");
+        ui::blank();
+        return 0;
+    }
+
+    // --- Actual execution ---
+
+    // Step 5: Create the stable branch from HEAD.
+    let head_commit = match repo.head().and_then(|h| h.peel_to_commit()) {
+        Ok(c) => c,
+        Err(e) => {
+            ui::error(&format!("cannot resolve HEAD: {e}"));
+            return 1;
+        }
+    };
+
+    if let Err(e) = git::create_branch(&repo, &stable_branch_name, &head_commit) {
+        ui::error(&format!("cannot create branch: {e}"));
+        return 1;
+    }
+
+    // Step 6: Switch to the stable branch and commit config.
+    if let Err(e) = git::checkout_branch(&repo, &stable_branch_name) {
+        ui::error(&format!("cannot checkout branch: {e}"));
+        return 1;
+    }
+
+    let workdir = match repo.workdir() {
+        Some(w) => w.to_path_buf(),
+        None => {
+            ui::error("bare repository not supported");
+            return 1;
+        }
+    };
+
+    // Write/update .git-std.toml with scheme = "patch".
+    let config_path = workdir.join(".git-std.toml");
+    let config_content = if config_path.exists() {
+        let existing = std::fs::read_to_string(&config_path).unwrap_or_default();
+        update_scheme_in_config(&existing, "patch")
+    } else {
+        "[versioning]\nscheme = \"patch\"\n".to_string()
+    };
+
+    if let Err(e) = std::fs::write(&config_path, &config_content) {
+        ui::error(&format!("cannot write .git-std.toml: {e}"));
+        return 1;
+    }
+
+    // Stage and commit on the stable branch.
+    if let Err(e) = git::stage_files(&repo, &[".git-std.toml"]) {
+        ui::error(&format!("cannot stage files: {e}"));
+        return 1;
+    }
+
+    let stabilize_msg = format!(
+        "chore(release): stabilize v{}.{}",
+        cur_ver.major, cur_ver.minor
+    );
+
+    if let Err(e) = git::create_commit(&repo, &stabilize_msg) {
+        ui::error(&format!("cannot create commit: {e}"));
+        return 1;
+    }
+
+    ui::blank();
+    eprintln!("{INDENT}Creating stable branch...", INDENT = ui::INDENT);
+    ui::item("Branch:", &stable_branch_name);
+    ui::item("Scheme:", "patch (patch-only bumps)");
+    ui::blank();
+    eprintln!(
+        "{INDENT}Committed: {}",
+        stabilize_msg.green(),
+        INDENT = ui::INDENT,
+    );
+
+    // Step 7: Switch back to the original branch.
+    if let Err(e) = git::checkout_branch(&repo, &original_branch) {
+        ui::error(&format!("cannot checkout branch '{original_branch}': {e}"));
+        return 1;
+    }
+
+    // Step 8 & 9: Bump on main and finalize.
+    ui::blank();
+    eprintln!("{INDENT}Advancing {original_branch}...", INDENT = ui::INDENT);
+    eprintln!(
+        "{DETAIL}{} ({bump_kind})",
+        format!("{cur_ver} \u{2192} {new_version}").bold(),
+        DETAIL = ui::DETAIL_INDENT,
+    );
+
+    // Collect commits since tag for changelog.
+    let head_oid = match repo.head().and_then(|h| h.peel_to_commit().map(|c| c.id())) {
+        Ok(oid) => oid,
+        Err(e) => {
+            ui::error(&format!("cannot resolve HEAD: {e}"));
+            return 1;
+        }
+    };
+
+    let tag_oid = current_version.as_ref().map(|(oid, _)| *oid);
+    let raw_commits = match git::walk_commits(&repo, head_oid, tag_oid) {
+        Ok(c) => c,
+        Err(e) => {
+            ui::error(&e.to_string());
+            return 1;
+        }
+    };
+
+    let prev_ver_str = current_version
+        .as_ref()
+        .map(|(_, v)| v.to_string());
+
+    let ctx = FinalizeContext {
+        new_version: new_version.to_string(),
+        prev_version: prev_ver_str.as_deref(),
+        raw_commits: &raw_commits,
+    };
+
+    let exit = finalize_bump(&repo, config, opts, &ctx);
+    if exit != 0 {
+        return exit;
+    }
+
+    // Step 10: Print push instructions for both branches (overrides finalize_bump's output).
+    // finalize_bump already printed the push instruction for the main branch,
+    // but we want to add the stable branch push instruction.
+    // The finalize_bump already prints "Push with: git push --follow-tags" so
+    // we just need to print the stable branch push before it.
+    // Actually, finalize_bump prints it. Let's just add the stable branch.
+    eprintln!(
+        "{INDENT}Push stable: git push origin {stable_branch_name}",
+        INDENT = ui::INDENT,
+    );
+    ui::blank();
+
+    0
+}
+
+/// Update or add `scheme = "patch"` in a `.git-std.toml` config string.
+fn update_scheme_in_config(existing: &str, scheme: &str) -> String {
+    let mut result = String::new();
+    let mut found_scheme = false;
+    let mut in_versioning = false;
+    let mut has_versioning = false;
+
+    for line in existing.lines() {
+        let trimmed = line.trim();
+
+        // Track table sections.
+        if trimmed.starts_with('[') {
+            if trimmed == "[versioning]" {
+                has_versioning = true;
+                in_versioning = true;
+            } else {
+                in_versioning = false;
+            }
+        }
+
+        // Replace existing scheme line anywhere at top level.
+        if trimmed.starts_with("scheme") && trimmed.contains('=') && !in_versioning {
+            result.push_str(&format!("scheme = \"{scheme}\"\n"));
+            found_scheme = true;
+            continue;
+        }
+
+        // Replace scheme inside [versioning] section.
+        if in_versioning && trimmed.starts_with("scheme") && trimmed.contains('=') {
+            result.push_str(&format!("scheme = \"{scheme}\"\n"));
+            found_scheme = true;
+            continue;
+        }
+
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    if !found_scheme {
+        if has_versioning {
+            // Insert scheme after the [versioning] header by reconstructing.
+            let mut new_result = String::new();
+            for line in result.lines() {
+                new_result.push_str(line);
+                new_result.push('\n');
+                if line.trim() == "[versioning]" {
+                    new_result.push_str(&format!("scheme = \"{scheme}\"\n"));
+                }
+            }
+            return new_result;
+        }
+        // No scheme or versioning section, just prepend.
+        result.insert_str(0, &format!("scheme = \"{scheme}\"\n"));
+    }
+
+    result
 }
 
 /// Run the bump subcommand in patch-only mode.

--- a/crates/git-std/src/git.rs
+++ b/crates/git-std/src/git.rs
@@ -211,6 +211,42 @@ pub fn create_annotated_tag(
     Ok(())
 }
 
+/// Check whether the working tree has uncommitted changes.
+pub fn is_working_tree_dirty(repo: &git2::Repository) -> Result<bool, git2::Error> {
+    let statuses = repo.statuses(Some(
+        git2::StatusOptions::new()
+            .include_untracked(true)
+            .recurse_untracked_dirs(true),
+    ))?;
+    Ok(!statuses.is_empty())
+}
+
+/// Create a branch pointing at the given commit.
+pub fn create_branch<'a>(
+    repo: &'a git2::Repository,
+    name: &str,
+    commit: &git2::Commit<'a>,
+) -> Result<git2::Branch<'a>, git2::Error> {
+    repo.branch(name, commit, false)
+}
+
+/// Check whether a local branch exists.
+pub fn branch_exists(repo: &git2::Repository, name: &str) -> bool {
+    repo.find_branch(name, git2::BranchType::Local).is_ok()
+}
+
+/// Switch HEAD to the given branch name (e.g. `main`).
+pub fn checkout_branch(
+    repo: &git2::Repository,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let refname = format!("refs/heads/{name}");
+    let obj = repo.revparse_single(&refname)?;
+    repo.checkout_tree(&obj, Some(git2::build::CheckoutBuilder::new().force()))?;
+    repo.set_head(&refname)?;
+    Ok(())
+}
+
 /// Create a signed tag by shelling out to `git`.
 pub fn create_signed_tag(name: &str, message: &str) -> Result<(), Box<dyn std::error::Error>> {
     let status = std::process::Command::new("git")

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -106,6 +106,12 @@ enum Command {
         /// Allow breaking changes in patch-only scheme.
         #[arg(long)]
         force: bool,
+        /// Create a stable branch for patch-only releases. Optionally specify a custom branch name.
+        #[arg(long, num_args = 0..=1, default_missing_value = "")]
+        stable: Option<String>,
+        /// Use minor bump (instead of major) when advancing main after --stable.
+        #[arg(long)]
+        minor: bool,
     },
     /// Generate a changelog (incremental by default, --full to regenerate).
     Changelog {
@@ -245,8 +251,11 @@ fn main() {
             skip_changelog,
             sign,
             force,
+            stable,
+            minor,
         } => {
             let project_config = config::load(&std::env::current_dir().unwrap_or_default());
+            let stable = stable.map(|s| if s.is_empty() { None } else { Some(s) });
             let opts = cli::bump::BumpOptions {
                 dry_run,
                 prerelease,
@@ -257,6 +266,8 @@ fn main() {
                 skip_changelog,
                 sign,
                 force,
+                stable,
+                minor,
             };
             let code = cli::bump::run(&project_config, &opts);
             std::process::exit(code);

--- a/crates/git-std/tests/cli.rs
+++ b/crates/git-std/tests/cli.rs
@@ -241,6 +241,8 @@ fn bump_help_shows_flags() {
         "--no-commit",
         "--skip-changelog",
         "--sign",
+        "--stable",
+        "--minor",
     ] {
         assert!(stdout.contains(flag), "bump help should list '{flag}' flag");
     }
@@ -1413,4 +1415,202 @@ fn bump_patch_scheme_allows_breaking_with_force() {
     // Verify tag was created.
     let tag = repo.find_reference("refs/tags/v1.0.1");
     assert!(tag.is_ok(), "tag v1.0.1 should exist");
+}
+
+// --- Stable branch integration tests (#139) ---
+
+#[test]
+fn bump_stable_creates_branch_and_bumps_major() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = init_bump_repo(dir.path());
+    create_tag(&repo, "v1.0.0");
+    add_commit(&repo, dir.path(), "a.txt", "feat: new feature");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--stable", "--skip-changelog"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Creating stable branch"))
+        .stderr(predicate::str::contains("stable-v1.0"))
+        .stderr(predicate::str::contains("patch (patch-only bumps)"))
+        .stderr(predicate::str::contains("Committed"))
+        .stderr(predicate::str::contains("1.0.0 \u{2192} 2.0.0"))
+        .stderr(predicate::str::contains("major"))
+        .stderr(predicate::str::contains("Tagged"));
+
+    // Verify the stable branch was created.
+    assert!(
+        repo.find_branch("stable-v1.0", git2::BranchType::Local).is_ok(),
+        "stable-v1.0 branch should exist"
+    );
+
+    // Verify HEAD is back on the original branch with the new tag.
+    let tag = repo.find_reference("refs/tags/v2.0.0");
+    assert!(tag.is_ok(), "tag v2.0.0 should exist");
+
+    // Verify main was bumped in Cargo.toml.
+    let cargo = std::fs::read_to_string(dir.path().join("Cargo.toml")).unwrap();
+    assert!(
+        cargo.contains("version = \"2.0.0\""),
+        "expected version 2.0.0, got: {cargo}"
+    );
+
+    // Verify the stable branch has .git-std.toml with scheme = "patch".
+    let stable_ref = repo.find_branch("stable-v1.0", git2::BranchType::Local).unwrap();
+    let stable_commit = stable_ref.get().peel_to_commit().unwrap();
+    let stable_tree = stable_commit.tree().unwrap();
+    let config_entry = stable_tree.get_name(".git-std.toml");
+    assert!(config_entry.is_some(), ".git-std.toml should exist on stable branch");
+
+    let config_blob = config_entry.unwrap().to_object(&repo).unwrap();
+    let config_content = std::str::from_utf8(config_blob.as_blob().unwrap().content()).unwrap();
+    assert!(
+        config_content.contains("scheme = \"patch\""),
+        "stable branch config should have scheme = \"patch\", got: {config_content}"
+    );
+}
+
+#[test]
+fn bump_stable_with_minor_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = init_bump_repo(dir.path());
+    create_tag(&repo, "v1.0.0");
+    add_commit(&repo, dir.path(), "a.txt", "feat: new feature");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--stable", "--minor", "--skip-changelog"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("1.0.0 \u{2192} 1.1.0"))
+        .stderr(predicate::str::contains("minor"));
+
+    // Verify the tag.
+    let tag = repo.find_reference("refs/tags/v1.1.0");
+    assert!(tag.is_ok(), "tag v1.1.0 should exist");
+
+    // Verify Cargo.toml.
+    let cargo = std::fs::read_to_string(dir.path().join("Cargo.toml")).unwrap();
+    assert!(
+        cargo.contains("version = \"1.1.0\""),
+        "expected version 1.1.0, got: {cargo}"
+    );
+}
+
+#[test]
+fn bump_stable_custom_branch_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = init_bump_repo(dir.path());
+    create_tag(&repo, "v1.0.0");
+    add_commit(&repo, dir.path(), "a.txt", "feat: new feature");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--stable", "my-release-branch", "--skip-changelog"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("my-release-branch"));
+
+    // Verify the custom branch was created.
+    assert!(
+        repo.find_branch("my-release-branch", git2::BranchType::Local).is_ok(),
+        "my-release-branch should exist"
+    );
+}
+
+#[test]
+fn bump_stable_dry_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = init_bump_repo(dir.path());
+    create_tag(&repo, "v1.0.0");
+    add_commit(&repo, dir.path(), "a.txt", "feat: new feature");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--stable", "--dry-run"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Creating stable branch"))
+        .stderr(predicate::str::contains("stable-v1.0"))
+        .stderr(predicate::str::contains("Would commit"))
+        .stderr(predicate::str::contains("Would tag"))
+        .stderr(predicate::str::contains("Advancing"))
+        .stderr(predicate::str::contains("1.0.0 \u{2192} 2.0.0"));
+
+    // No branch should be created.
+    assert!(
+        repo.find_branch("stable-v1.0", git2::BranchType::Local).is_err(),
+        "stable-v1.0 branch should NOT exist in dry-run"
+    );
+
+    // No tag should be created.
+    assert!(
+        repo.find_reference("refs/tags/v2.0.0").is_err(),
+        "tag v2.0.0 should NOT exist in dry-run"
+    );
+}
+
+#[test]
+fn bump_stable_rejects_existing_branch() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = init_bump_repo(dir.path());
+    create_tag(&repo, "v1.0.0");
+    add_commit(&repo, dir.path(), "a.txt", "feat: new feature");
+
+    // Pre-create the branch that --stable would try to create.
+    let head = repo.head().unwrap().peel_to_commit().unwrap();
+    repo.branch("stable-v1.0", &head, false).unwrap();
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--stable", "--skip-changelog"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("branch 'stable-v1.0' already exists"));
+}
+
+#[test]
+fn bump_stable_rejects_calver_scheme() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = init_bump_repo(dir.path());
+
+    // Write a .git-std.toml with calver scheme.
+    std::fs::write(dir.path().join(".git-std.toml"), "scheme = \"calver\"\n").unwrap();
+
+    add_commit(&repo, dir.path(), "a.txt", "feat: new feature");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--stable"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "--stable is not supported with scheme = \"calver\"",
+        ));
+}
+
+#[test]
+fn bump_stable_rejects_dirty_working_tree() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = init_bump_repo(dir.path());
+    create_tag(&repo, "v1.0.0");
+    add_commit(&repo, dir.path(), "a.txt", "feat: new feature");
+
+    // Create an uncommitted file to make the working tree dirty.
+    std::fs::write(dir.path().join("dirty.txt"), "uncommitted").unwrap();
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--stable"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("working tree has uncommitted changes"));
 }


### PR DESCRIPTION
## Summary
- Add `--stable [branch-name]` flag to `git std bump` that creates a stable branch configured for patch-only versioning, then advances the current branch with a major version bump
- Add `--minor` flag to use minor bump instead of major when advancing main after `--stable`
- Add git2 helpers for dirty tree detection, branch creation/existence check, and branch checkout

## Test plan
- [x] `bump_stable_creates_branch_and_bumps_major` -- default `--stable` creates `stable-vX.Y` branch and bumps major
- [x] `bump_stable_with_minor_flag` -- `--stable --minor` bumps minor instead of major
- [x] `bump_stable_custom_branch_name` -- `--stable my-branch` uses custom name
- [x] `bump_stable_dry_run` -- `--stable --dry-run` shows plan without writing
- [x] `bump_stable_rejects_existing_branch` -- errors if branch already exists
- [x] `bump_stable_rejects_calver_scheme` -- errors with calver scheme
- [x] `bump_stable_rejects_dirty_working_tree` -- errors with uncommitted changes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)