### PR TITLE
feat(bump): implement scheme = patch for patch-only branches

### DIFF
--- a/crates/git-std/src/cli/bump.rs
+++ b/crates/git-std/src/cli/bump.rs
@@ -909,10 +909,7 @@ fn run_patch(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
         .any(|c| c.is_breaking);
 
     if has_breaking && !opts.force {
-        ui::error(
-            "breaking change detected — patch-only scheme does not allow major bumps. \
-             Use --force to override.",
-        );
+        ui::error("breaking change not allowed on patch-only branch (use --force to override)");
         return 1;
     }
 

--- a/crates/git-std/tests/cli.rs
+++ b/crates/git-std/tests/cli.rs
@@ -241,6 +241,7 @@ fn bump_help_shows_flags() {
         "--no-commit",
         "--skip-changelog",
         "--sign",
+        "--force",
         "--stable",
         "--minor",
     ] {
@@ -1387,8 +1388,9 @@ fn bump_patch_scheme_rejects_breaking_without_force() {
         .current_dir(dir.path())
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("breaking change detected"))
-        .stderr(predicate::str::contains("--force"));
+        .stderr(predicate::str::contains(
+            "breaking change not allowed on patch-only branch (use --force to override)",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Align the breaking-change error message in `run_patch` with the spec: `breaking change not allowed on patch-only branch (use --force to override)`
- Add `--force` to the bump help flag assertions test
- Update the `bump_patch_scheme_rejects_breaking_without_force` test to match the new message

Closes #138

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `bump_patch_scheme_rejects_breaking_without_force` checks for spec-compliant error message
- [x] `bump_help_shows_flags` now includes `--force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)