### PR TITLE
test: add end-to-end tests for auto-discover scopes

### DIFF
--- a/crates/git-std/tests/check.rs
+++ b/crates/git-std/tests/check.rs
@@ -518,3 +518,63 @@ fn color_never_no_ansi_codes_invalid() {
     );
     assert!(stderr.contains("\u{2717}"));
 }
+
+// ── auto-discover scopes (#72) ──────────────────────────────────
+
+#[test]
+fn strict_auto_scopes_accepts_discovered() {
+    let dir = tempfile::tempdir().unwrap();
+    let _repo = make_test_repo(dir.path());
+    std::fs::create_dir_all(dir.path().join("crates/auth")).unwrap();
+    std::fs::write(dir.path().join(".git-std.toml"), "scopes = \"auto\"\n").unwrap();
+
+    git_std()
+        .args(["check", "--strict", "feat(auth): add login"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn strict_auto_scopes_rejects_unknown() {
+    let dir = tempfile::tempdir().unwrap();
+    let _repo = make_test_repo(dir.path());
+    std::fs::create_dir_all(dir.path().join("crates/auth")).unwrap();
+    std::fs::write(dir.path().join(".git-std.toml"), "scopes = \"auto\"\n").unwrap();
+
+    git_std()
+        .args(["check", "--strict", "feat(unknown): something"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(contains("not in the allowed list"));
+}
+
+#[test]
+fn strict_auto_scopes_requires_scope() {
+    let dir = tempfile::tempdir().unwrap();
+    let _repo = make_test_repo(dir.path());
+    std::fs::create_dir_all(dir.path().join("crates/auth")).unwrap();
+    std::fs::write(dir.path().join(".git-std.toml"), "scopes = \"auto\"\n").unwrap();
+
+    git_std()
+        .args(["check", "--strict", "feat: no scope"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(contains("scope is required"));
+}
+
+#[test]
+fn strict_auto_scopes_empty_dirs_no_requirement() {
+    let dir = tempfile::tempdir().unwrap();
+    let _repo = make_test_repo(dir.path());
+    // No crates/packages/modules directories
+    std::fs::write(dir.path().join(".git-std.toml"), "scopes = \"auto\"\n").unwrap();
+
+    git_std()
+        .args(["check", "--strict", "feat: anything"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+}

--- a/crates/git-std/tests/cli.rs
+++ b/crates/git-std/tests/cli.rs
@@ -1988,3 +1988,31 @@ regex = 'version = "(\d+\.\d+\.\d+)"'
         .stderr(predicate::str::contains("Cargo.toml"))
         .stderr(predicate::str::contains("Would update"));
 }
+
+// ── commit --dry-run with auto-discover scopes (#72) ────────────
+
+#[test]
+fn commit_dry_run_auto_scopes() {
+    let dir = tempfile::tempdir().unwrap();
+    init_commit_repo(dir.path());
+    std::fs::create_dir_all(dir.path().join("crates/web")).unwrap();
+    std::fs::create_dir_all(dir.path().join("crates/api")).unwrap();
+    std::fs::write(dir.path().join(".git-std.toml"), "scopes = \"auto\"\n").unwrap();
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args([
+            "commit",
+            "--type",
+            "feat",
+            "--scope",
+            "web",
+            "--message",
+            "add page",
+            "--dry-run",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("feat(web): add page"));
+}


### PR DESCRIPTION
## Summary
- Add 4 integration tests in `crates/git-std/tests/check.rs` for `scopes = "auto"` with `--strict`: accepts discovered scope, rejects unknown scope, requires scope when scopes exist, allows scopeless when no workspace dirs
- Add 1 integration test in `crates/git-std/tests/cli.rs` for `commit --dry-run` with auto-discovered scopes

## Test plan
- [x] `strict_auto_scopes_accepts_discovered` — `crates/auth/` dir + `scopes = "auto"` + `feat(auth): add login` passes
- [x] `strict_auto_scopes_rejects_unknown` — same setup + `feat(unknown): something` fails with "not in the allowed list"
- [x] `strict_auto_scopes_requires_scope` — same setup + `feat: no scope` fails with "scope is required"
- [x] `strict_auto_scopes_empty_dirs_no_requirement` — no workspace dirs + `feat: anything` passes
- [x] `commit_dry_run_auto_scopes` — `crates/web/` + `crates/api/` + `scopes = "auto"` + dry-run commit succeeds

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)