### PR TITLE
ci: add GitHub Release workflow for tag-triggered cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: aarch64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }} -p git-std
+      - name: Create tarball
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../git-std-${{ matrix.target }}.tar.gz git-std
+          cd ../../..
+      - name: Generate SHA256 checksum
+        run: shasum -a 256 git-std-${{ matrix.target }}.tar.gz > git-std-${{ matrix.target }}.tar.gz.sha256
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-std-${{ matrix.target }}
+          path: |
+            git-std-${{ matrix.target }}.tar.gz
+            git-std-${{ matrix.target }}.tar.gz.sha256
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          files: |
+            git-std-*.tar.gz
+            git-std-*.tar.gz.sha256


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` triggered on `v*` tag pushes
- Cross-compile for `x86_64-unknown-linux-gnu`, `x86_64-apple-darwin`, and `aarch64-apple-darwin`
- Create GitHub Release with tarballs and SHA256 checksum files using `softprops/action-gh-release@v2`

Closes #6

## Test plan

- [ ] Push a `v*` tag and verify the workflow triggers
- [ ] Confirm binaries build for all three targets
- [ ] Confirm GitHub Release is created with tarballs and `.sha256` files
- [ ] Verify checksums match the tarballs

🤖 Generated with [Claude Code](https://claude.com/claude-code)