### PR TITLE
chore: dogfood git-std for commits and releases

### DIFF
--- a/.git-std.toml
+++ b/.git-std.toml
@@ -1,0 +1,8 @@
+[versioning]
+scheme = "semver"
+tag_prefix = "v"
+
+[commits]
+strict = true
+types = ["feat", "fix", "docs", "style", "refactor", "perf", "test", "build", "ci", "chore", "revert"]
+scopes = "auto"

--- a/.githooks/commit-msg.hooks
+++ b/.githooks/commit-msg.hooks
@@ -1,0 +1,1 @@
+! git std check --file {msg}

--- a/.githooks/pre-commit.hooks
+++ b/.githooks/pre-commit.hooks
@@ -1,0 +1,2 @@
+cargo fmt -- --check  *.rs
+cargo clippy --workspace -- -D warnings  *.rs

--- a/justfile
+++ b/justfile
@@ -42,6 +42,10 @@ doc:
 book:
     mdbook serve
 
+# Bump version, update changelog, commit, and tag
+release:
+    git std bump
+
 # Publish all crates to crates.io (dependency order)
 # Skips separate dry-run — cargo publish already verifies
 # each package before uploading.


### PR DESCRIPTION
## Summary

- Add `.git-std.toml` with semver scheme, strict conventional commits, and auto-discovered scopes
- Add `.githooks/commit-msg.hooks` to validate commit messages via `git std check`
- Add `.githooks/pre-commit.hooks` with `cargo fmt` and `cargo clippy` checks on staged `.rs` files
- Add `release` recipe in `justfile` that runs `git std bump`

Closes #7

## Test plan

- [ ] Run `git std hooks install` and verify shims are generated
- [ ] Make a commit with a non-conventional message and confirm it is rejected
- [ ] Run `just release` and verify it invokes `git std bump`

🤖 Generated with [Claude Code](https://claude.com/claude-code)