### PR TITLE
feat: add shell completions for bash, zsh, and fish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +412,7 @@ version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "clap_complete",
  "inquire",
  "predicates",
  "semver",

--- a/crates/git-std/Cargo.toml
+++ b/crates/git-std/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
+clap_complete = "4"
 inquire = "0.9"
 semver = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -1,6 +1,7 @@
 use std::io::IsTerminal;
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
 
 mod cli;
 mod config;
@@ -132,6 +133,11 @@ enum Command {
     Hooks {
         #[command(subcommand)]
         subcommand: HooksCommand,
+    },
+    /// Generate shell completion scripts.
+    Completions {
+        /// Target shell.
+        shell: Shell,
     },
     /// Update git-std to the latest version.
     SelfUpdate,
@@ -281,6 +287,10 @@ fn main() {
             };
             std::process::exit(code);
         }
+        Command::Completions { shell } => {
+            let mut cmd = Cli::command();
+            clap_complete::generate(shell, &mut cmd, "git-std", &mut std::io::stdout());
+        }
         other => {
             let name = match other {
                 Command::Commit { .. } => unreachable!(),
@@ -288,6 +298,7 @@ fn main() {
                 Command::Changelog { .. } => unreachable!(),
                 Command::Bump { .. } => unreachable!(),
                 Command::Hooks { .. } => unreachable!(),
+                Command::Completions { .. } => unreachable!(),
                 Command::SelfUpdate => "self-update",
             };
             eprintln!("git-std {name}: not yet implemented");

--- a/crates/git-std/tests/cli.rs
+++ b/crates/git-std/tests/cli.rs
@@ -28,6 +28,7 @@ fn help_lists_subcommands() {
         "bump",
         "changelog",
         "hooks",
+        "completions",
         "self-update",
     ] {
         assert!(
@@ -1976,4 +1977,34 @@ fn commit_dry_run_auto_scopes() {
         .assert()
         .success()
         .stdout(predicate::str::contains("feat(web): add page"));
+}
+
+#[test]
+fn completions_bash_outputs_script() {
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("complete"));
+}
+
+#[test]
+fn completions_zsh_outputs_script() {
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("_git-std"));
+}
+
+#[test]
+fn completions_fish_outputs_script() {
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("complete"));
 }

--- a/spec/tests/cmd/general/completions_help.toml
+++ b/spec/tests/cmd/general/completions_help.toml
@@ -1,0 +1,3 @@
+bin.name = "git-std"
+args = ["completions", "--help"]
+status = "success"

--- a/spec/tests/cmd/general/help.stdout
+++ b/spec/tests/cmd/general/help.stdout
@@ -8,7 +8,7 @@ Commands:
   bump         Version bump, changelog, commit, and tag
   changelog    Generate a changelog (incremental by default, --full to regenerate)
   hooks        Git hooks management
+  completions  Generate shell completion scripts
   self-update  Update git-std to the latest version
   help         Print this message or the help of the given subcommand(s)
-
 ...


### PR DESCRIPTION
## Summary
- Add `completions` subcommand using `clap_complete` to generate shell completion scripts
- Supports bash, zsh, and fish shells via `git std completions <shell>`
- Closes #58

## Test plan
- [x] `completions_bash_outputs_script` — verifies bash output contains "complete"
- [x] `completions_zsh_outputs_script` — verifies zsh output contains "_git-std"
- [x] `completions_fish_outputs_script` — verifies fish output contains "complete"
- [x] trycmd test for `completions --help`
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)