### PR TITLE
fix(ci): pin cross to v0.2.5 for aarch64-musl builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           sudo apt-get install -y musl-tools
       - name: Install cross (aarch64-musl)
         if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
       - name: Build (cross)
         if: matrix.target == 'aarch64-unknown-linux-musl'
         run: cross build --release --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary
- Pin cross installation to v0.2.5 instead of git HEAD
- Fixes error[E0463]: can not find crate for clap_derive in the aarch64-unknown-linux-musl build job
- The :main Docker image has an incompatible Rust toolchain that has been breaking all build-release CI runs on main

## Test plan
- [ ] Verify CI passes on this PR (specifically the Build (aarch64-unknown-linux-musl) job)