### PR TITLE
feat(hooks): enable/disable commands, .off shims, and install prompt

### DIFF
--- a/.githooks/pre-commit.hooks
+++ b/.githooks/pre-commit.hooks
@@ -1,1 +1,1 @@
-! just fmt
+! just lint

--- a/crates/git-std/src/cli/hooks.rs
+++ b/crates/git-std/src/cli/hooks.rs
@@ -1,9 +1,11 @@
 use std::process::Command;
 
+use inquire::MultiSelect;
 use yansi::Paint;
 
 use standard_githooks::{
-    HookCommand, HookMode, Prefix, default_mode, generate_shim, substitute_msg,
+    HookCommand, HookMode, KNOWN_HOOKS, Prefix, default_mode, generate_hooks_template,
+    generate_shim, substitute_msg,
 };
 
 use crate::ui;
@@ -241,31 +243,18 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
     if has_failure { 1 } else { 0 }
 }
 
-/// Scan `.githooks/` for `*.hooks` files and return sorted hook names.
-fn discover_hooks() -> Vec<String> {
-    let hooks_dir = std::path::Path::new(".githooks");
-    let entries = match std::fs::read_dir(hooks_dir) {
-        Ok(e) => e,
-        Err(_) => return Vec::new(),
-    };
-
-    let mut hooks: Vec<String> = entries
-        .filter_map(|entry| {
-            let entry = entry.ok()?;
-            let name = entry.file_name().to_string_lossy().to_string();
-            let hook_name = name.strip_suffix(".hooks")?;
-            Some(hook_name.to_string())
-        })
-        .collect();
-
-    hooks.sort();
-    hooks
+/// Returns true if a hook's shim is currently active (named exactly as the hook).
+fn is_enabled(hooks_dir: &std::path::Path, hook_name: &str) -> bool {
+    hooks_dir.join(hook_name).exists()
 }
 
 /// Run the `hooks install` subcommand. Returns the process exit code.
 ///
-/// Configures `core.hooksPath`, creates the `.githooks/` directory,
-/// and writes shim scripts for each `.hooks` file found.
+/// - Sets core.hooksPath
+/// - Creates .githooks/ directory
+/// - Writes .hooks template for every known hook (skips existing)
+/// - Prompts which hooks to enable (interactive multi-select)
+/// - Writes active shims for selected hooks, .off shims for the rest
 pub fn install() -> i32 {
     // 1. Set core.hooksPath
     let status = Command::new("git")
@@ -296,33 +285,83 @@ pub fn install() -> i32 {
         return 1;
     }
 
-    // 3. Write shims for each .hooks file
-    let hooks = discover_hooks();
-
-    if hooks.is_empty() {
-        ui::blank();
-        eprintln!(
-            "{INDENT}no .hooks files found in .githooks/",
-            INDENT = ui::INDENT
-        );
-        return 0;
+    // 3. Write .hooks templates for every known hook (skip if already exists)
+    for hook_name in KNOWN_HOOKS {
+        let template_path = hooks_dir.join(format!("{hook_name}.hooks"));
+        if !template_path.exists() {
+            let content = generate_hooks_template(hook_name);
+            if let Err(e) = std::fs::write(&template_path, &content) {
+                ui::error(&format!("cannot write {}: {e}", template_path.display()));
+                return 1;
+            }
+        }
     }
 
-    for hook_name in &hooks {
-        let shim_content = generate_shim(hook_name);
-        let shim_path = hooks_dir.join(hook_name);
+    // 4. Determine which hooks to enable — via env var (for tests/CI) or interactive prompt
+    let default_enabled = ["pre-commit", "commit-msg"];
 
-        if let Err(e) = std::fs::write(&shim_path, &shim_content) {
+    let env_enable = std::env::var("GIT_STD_HOOKS_ENABLE").ok();
+    let selected: Vec<&str> = if let Some(ref val) = env_enable {
+        // Comma-separated list of hook names, or "all" or "none"
+        match val.to_lowercase().as_str() {
+            "all" => KNOWN_HOOKS.to_vec(),
+            "none" => vec![],
+            _ => val
+                .split(',')
+                .map(|s| s.trim())
+                .filter(|s| KNOWN_HOOKS.contains(s))
+                .collect(),
+        }
+    } else {
+        let options: Vec<&str> = KNOWN_HOOKS.to_vec();
+        match MultiSelect::new("Which hooks do you want to enable?", options)
+            .with_default(
+                &KNOWN_HOOKS
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, h)| default_enabled.contains(h))
+                    .map(|(i, _)| i)
+                    .collect::<Vec<_>>(),
+            )
+            .prompt()
+        {
+            Ok(s) => s,
+            Err(_) => {
+                ui::error("install cancelled");
+                return 1;
+            }
+        }
+    };
+
+    ui::blank();
+
+    // 5. Write shims — active for selected, .off for the rest
+    for hook_name in KNOWN_HOOKS {
+        let shim_content = generate_shim(hook_name);
+        let enabled = selected.contains(hook_name);
+
+        let active_path = hooks_dir.join(hook_name);
+        let off_path = hooks_dir.join(format!("{hook_name}.off"));
+
+        // Remove stale counterpart
+        if enabled {
+            let _ = std::fs::remove_file(&off_path);
+        } else {
+            let _ = std::fs::remove_file(&active_path);
+        }
+
+        let shim_path = if enabled { &active_path } else { &off_path };
+
+        if let Err(e) = std::fs::write(shim_path, &shim_content) {
             ui::error(&format!("cannot write {}: {e}", shim_path.display()));
             return 1;
         }
 
-        // Set executable permissions on Unix
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
             let perms = std::fs::Permissions::from_mode(0o755);
-            if let Err(e) = std::fs::set_permissions(&shim_path, perms) {
+            if let Err(e) = std::fs::set_permissions(shim_path, perms) {
                 ui::error(&format!(
                     "cannot set permissions on {}: {e}",
                     shim_path.display()
@@ -331,10 +370,15 @@ pub fn install() -> i32 {
             }
         }
 
+        let status_label = if enabled {
+            "enabled ".green().to_string()
+        } else {
+            "disabled".dim().to_string()
+        };
+
         eprintln!(
-            "{INDENT}{}  .githooks/{:<18}\u{2192} git std hooks run {hook_name}",
+            "{INDENT}{}  {hook_name:<22} {status_label}",
             ui::pass(),
-            hook_name,
             INDENT = ui::INDENT,
         );
     }
@@ -342,26 +386,130 @@ pub fn install() -> i32 {
     0
 }
 
-/// Run the `hooks list` subcommand. Returns the process exit code.
-///
-/// Reads all `.githooks/*.hooks` files, parses them, and prints
-/// a human-readable summary of each hook and its commands.
-pub fn list() -> i32 {
-    let hooks = discover_hooks();
+/// Run the `hooks enable <hook>` subcommand. Returns the process exit code.
+pub fn enable(hook_name: &str) -> i32 {
+    if !KNOWN_HOOKS.contains(&hook_name) {
+        ui::error(&format!(
+            "unknown hook '{hook_name}' — known hooks: {}",
+            KNOWN_HOOKS.join(", ")
+        ));
+        return 1;
+    }
 
-    if hooks.is_empty() {
-        eprintln!("{INDENT}no hooks configured", INDENT = ui::INDENT);
+    let hooks_dir = std::path::Path::new(".githooks");
+    let active_path = hooks_dir.join(hook_name);
+    let off_path = hooks_dir.join(format!("{hook_name}.off"));
+
+    if active_path.exists() {
+        eprintln!(
+            "{INDENT}{} {hook_name} is already enabled",
+            ui::warn(),
+            INDENT = ui::INDENT
+        );
         return 0;
     }
 
-    for (i, hook_name) in hooks.iter().enumerate() {
+    if !off_path.exists() {
+        ui::error(&format!(
+            "{hook_name}.off not found — run 'git std hooks install' first"
+        ));
+        return 1;
+    }
+
+    if let Err(e) = std::fs::rename(&off_path, &active_path) {
+        ui::error(&format!("cannot enable {hook_name}: {e}"));
+        return 1;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o755);
+        let _ = std::fs::set_permissions(&active_path, perms);
+    }
+
+    eprintln!(
+        "{INDENT}{}  {hook_name} enabled",
+        ui::pass(),
+        INDENT = ui::INDENT
+    );
+    0
+}
+
+/// Run the `hooks disable <hook>` subcommand. Returns the process exit code.
+pub fn disable(hook_name: &str) -> i32 {
+    if !KNOWN_HOOKS.contains(&hook_name) {
+        ui::error(&format!(
+            "unknown hook '{hook_name}' — known hooks: {}",
+            KNOWN_HOOKS.join(", ")
+        ));
+        return 1;
+    }
+
+    let hooks_dir = std::path::Path::new(".githooks");
+    let active_path = hooks_dir.join(hook_name);
+    let off_path = hooks_dir.join(format!("{hook_name}.off"));
+
+    if off_path.exists() {
+        eprintln!(
+            "{INDENT}{} {hook_name} is already disabled",
+            ui::warn(),
+            INDENT = ui::INDENT
+        );
+        return 0;
+    }
+
+    if !active_path.exists() {
+        ui::error(&format!(
+            "{hook_name} not found — run 'git std hooks install' first"
+        ));
+        return 1;
+    }
+
+    if let Err(e) = std::fs::rename(&active_path, &off_path) {
+        ui::error(&format!("cannot disable {hook_name}: {e}"));
+        return 1;
+    }
+
+    eprintln!(
+        "{INDENT}{}  {hook_name} disabled",
+        ui::pass(),
+        INDENT = ui::INDENT
+    );
+    0
+}
+
+/// Run the `hooks list` subcommand. Returns the process exit code.
+///
+/// Shows all known hooks with enabled/disabled status and their commands.
+pub fn list() -> i32 {
+    let hooks_dir = std::path::Path::new(".githooks");
+
+    if !hooks_dir.exists() {
+        eprintln!(
+            "{INDENT}no hooks installed — run 'git std hooks install'",
+            INDENT = ui::INDENT
+        );
+        return 0;
+    }
+
+    for (i, hook_name) in KNOWN_HOOKS.iter().enumerate() {
         if i > 0 {
             println!();
         }
 
-        let commands = match read_and_parse_hooks(hook_name) {
-            Ok(c) => c,
-            Err(code) => return code,
+        let enabled = is_enabled(hooks_dir, hook_name);
+        let status_label = if enabled {
+            "enabled".green().to_string()
+        } else {
+            "disabled".dim().to_string()
+        };
+
+        let template_path = hooks_dir.join(format!("{hook_name}.hooks"));
+        let commands: Vec<HookCommand> = if template_path.exists() {
+            read_and_parse_hooks(hook_name).unwrap_or_default()
+        } else {
+            vec![]
         };
 
         let mode = default_mode(hook_name);
@@ -371,37 +519,40 @@ pub fn list() -> i32 {
         };
 
         println!(
-            "{INDENT}{hook_name} ({mode_label} mode):",
+            "{INDENT}{hook_name} ({mode_label}) [{status_label}]:",
             INDENT = ui::INDENT
         );
 
-        for cmd in &commands {
-            let prefix_char = match cmd.prefix {
-                Prefix::FailFast => "!",
-                Prefix::Advisory => "?",
-                Prefix::Default => " ",
-            };
-
-            let display = if let Some(ref glob) = cmd.glob {
-                // Right-align glob after command with padding
-                let cmd_part = format!("  {prefix_char} {}", cmd.command);
-                let total_width = 50;
-                let padding = if cmd_part.len() < total_width {
-                    total_width - cmd_part.len()
-                } else {
-                    4
+        if commands.is_empty() {
+            println!("{INDENT}  (no commands)", INDENT = ui::INDENT);
+        } else {
+            for cmd in &commands {
+                let prefix_char = match cmd.prefix {
+                    Prefix::FailFast => "!",
+                    Prefix::Advisory => "?",
+                    Prefix::Default => " ",
                 };
-                format!(
-                    "  {prefix_char} {}{:width$}{glob}",
-                    cmd.command,
-                    "",
-                    width = padding
-                )
-            } else {
-                format!("  {prefix_char} {}", cmd.command)
-            };
 
-            println!("{INDENT}{display}", INDENT = ui::INDENT);
+                let display = if let Some(ref glob) = cmd.glob {
+                    let cmd_part = format!("  {prefix_char} {}", cmd.command);
+                    let total_width = 50;
+                    let padding = if cmd_part.len() < total_width {
+                        total_width - cmd_part.len()
+                    } else {
+                        4
+                    };
+                    format!(
+                        "  {prefix_char} {}{:width$}{glob}",
+                        cmd.command,
+                        "",
+                        width = padding
+                    )
+                } else {
+                    format!("  {prefix_char} {}", cmd.command)
+                };
+
+                println!("{INDENT}{display}", INDENT = ui::INDENT);
+            }
         }
     }
 

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -156,6 +156,16 @@ enum HooksCommand {
     },
     /// Display all configured hooks and their commands.
     List,
+    /// Enable a hook (activate its shim).
+    Enable {
+        /// Hook name (e.g. pre-commit, commit-msg).
+        hook: String,
+    },
+    /// Disable a hook (deactivate its shim).
+    Disable {
+        /// Hook name (e.g. pre-commit, commit-msg).
+        hook: String,
+    },
 }
 
 fn main() {
@@ -282,6 +292,8 @@ fn main() {
                 HooksCommand::Install => cli::hooks::install(),
                 HooksCommand::Run { hook, args } => cli::hooks::run(&hook, &args),
                 HooksCommand::List => cli::hooks::list(),
+                HooksCommand::Enable { hook } => cli::hooks::enable(&hook),
+                HooksCommand::Disable { hook } => cli::hooks::disable(&hook),
             };
             std::process::exit(code);
         }

--- a/crates/git-std/tests/cli.rs
+++ b/crates/git-std/tests/cli.rs
@@ -806,34 +806,29 @@ fn hooks_install_creates_shims() {
     let dir = tempfile::tempdir().unwrap();
     init_hooks_repo(dir.path());
 
-    // Create .githooks/ with a hooks file.
     let hooks_dir = dir.path().join(".githooks");
     std::fs::create_dir_all(&hooks_dir).unwrap();
-    std::fs::write(
-        hooks_dir.join("pre-commit.hooks"),
-        "dprint check\ncargo test\n",
-    )
-    .unwrap();
 
     Command::cargo_bin("git-std")
         .unwrap()
         .args(["hooks", "install"])
+        .env("GIT_STD_HOOKS_ENABLE", "pre-commit")
         .current_dir(dir.path())
         .assert()
         .success()
-        .stderr(predicate::str::contains("core.hooksPath"))
-        .stderr(predicate::str::contains(".githooks/pre-commit"));
+        .stderr(predicate::str::contains("core.hooksPath"));
 
-    // Verify shim exists.
+    // Active shim should exist.
     let shim_path = hooks_dir.join("pre-commit");
-    assert!(shim_path.exists(), "shim should exist");
+    assert!(shim_path.exists(), "active shim should exist");
 
-    // Verify shim content.
+    // Shim should contain exec line and managed comment.
     let content = std::fs::read_to_string(&shim_path).unwrap();
-    assert_eq!(
-        content,
-        "#!/bin/bash\nexec git std hooks run pre-commit -- \"$@\"\n"
-    );
+    assert!(content.contains("exec git std hooks run pre-commit"));
+    assert!(content.contains("Managed by git-std"));
+
+    // Other hooks should be .off.
+    assert!(hooks_dir.join("commit-msg.off").exists());
 
     // Verify executable permissions on Unix.
     #[cfg(unix)]
@@ -851,25 +846,21 @@ fn hooks_install_multiple_hooks() {
 
     let hooks_dir = dir.path().join(".githooks");
     std::fs::create_dir_all(&hooks_dir).unwrap();
-    std::fs::write(hooks_dir.join("pre-commit.hooks"), "dprint check\n").unwrap();
-    std::fs::write(hooks_dir.join("pre-push.hooks"), "!cargo test\n").unwrap();
-    std::fs::write(
-        hooks_dir.join("commit-msg.hooks"),
-        "!git std check --file {msg}\n",
-    )
-    .unwrap();
 
     Command::cargo_bin("git-std")
         .unwrap()
         .args(["hooks", "install"])
+        .env("GIT_STD_HOOKS_ENABLE", "pre-commit,pre-push,commit-msg")
         .current_dir(dir.path())
         .assert()
         .success();
 
-    // All three shims should exist.
+    // Selected shims should be active.
     assert!(hooks_dir.join("pre-commit").exists());
     assert!(hooks_dir.join("pre-push").exists());
     assert!(hooks_dir.join("commit-msg").exists());
+    // Unselected should be .off.
+    assert!(hooks_dir.join("post-commit.off").exists());
 }
 
 #[test]
@@ -879,23 +870,21 @@ fn hooks_install_is_idempotent() {
 
     let hooks_dir = dir.path().join(".githooks");
     std::fs::create_dir_all(&hooks_dir).unwrap();
-    std::fs::write(hooks_dir.join("pre-commit.hooks"), "cargo test\n").unwrap();
 
     // Run install twice.
     for _ in 0..2 {
         Command::cargo_bin("git-std")
             .unwrap()
             .args(["hooks", "install"])
+            .env("GIT_STD_HOOKS_ENABLE", "pre-commit")
             .current_dir(dir.path())
             .assert()
             .success();
     }
 
+    // Shim should exist and contain exec line.
     let content = std::fs::read_to_string(hooks_dir.join("pre-commit")).unwrap();
-    assert_eq!(
-        content,
-        "#!/bin/bash\nexec git std hooks run pre-commit -- \"$@\"\n"
-    );
+    assert!(content.contains("exec git std hooks run pre-commit"));
 }
 
 #[test]
@@ -905,12 +894,12 @@ fn hooks_install_preserves_non_hooks_files() {
 
     let hooks_dir = dir.path().join(".githooks");
     std::fs::create_dir_all(&hooks_dir).unwrap();
-    std::fs::write(hooks_dir.join("pre-commit.hooks"), "cargo test\n").unwrap();
     std::fs::write(hooks_dir.join("custom-script.sh"), "#!/bin/bash\necho hi\n").unwrap();
 
     Command::cargo_bin("git-std")
         .unwrap()
         .args(["hooks", "install"])
+        .env("GIT_STD_HOOKS_ENABLE", "pre-commit")
         .current_dir(dir.path())
         .assert()
         .success();
@@ -943,7 +932,7 @@ fn hooks_list_shows_configured_hooks() {
 
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
     assert!(
-        stdout.contains("pre-commit (collect mode):"),
+        stdout.contains("pre-commit (collect)"),
         "should show hook name and mode, got: {stdout}"
     );
     assert!(stdout.contains("dprint check"), "should list commands");
@@ -972,7 +961,7 @@ fn hooks_list_fail_fast_mode() {
 
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
     assert!(
-        stdout.contains("pre-push (fail-fast mode):"),
+        stdout.contains("pre-push (fail-fast)"),
         "should show fail-fast mode"
     );
     assert!(
@@ -1002,7 +991,7 @@ fn hooks_list_commit_msg() {
 
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
     assert!(
-        stdout.contains("commit-msg (fail-fast mode):"),
+        stdout.contains("commit-msg (fail-fast)"),
         "should show commit-msg with fail-fast mode"
     );
     assert!(
@@ -1022,7 +1011,7 @@ fn hooks_list_no_hooks() {
         .current_dir(dir.path())
         .assert()
         .success()
-        .stderr(predicate::str::contains("no hooks configured"));
+        .stderr(predicate::str::contains("no hooks installed"));
 }
 
 #[test]
@@ -1244,6 +1233,7 @@ fn hooks_full_install_cycle() {
     Command::cargo_bin("git-std")
         .unwrap()
         .args(["hooks", "install"])
+        .env("GIT_STD_HOOKS_ENABLE", "pre-commit,commit-msg")
         .current_dir(dir.path())
         .assert()
         .success();

--- a/crates/standard-githooks/src/lib.rs
+++ b/crates/standard-githooks/src/lib.rs
@@ -12,4 +12,4 @@ mod shim;
 pub use glob::matches_any;
 pub use parse::{HookCommand, Prefix, parse};
 pub use run::{HookMode, default_mode, substitute_msg};
-pub use shim::generate_shim;
+pub use shim::{KNOWN_HOOKS, generate_hooks_template, generate_shim};

--- a/crates/standard-githooks/src/shim.rs
+++ b/crates/standard-githooks/src/shim.rs
@@ -1,3 +1,13 @@
+/// All git hook types managed by git-std, in recommended install order.
+pub const KNOWN_HOOKS: &[&str] = &[
+    "pre-commit",
+    "commit-msg",
+    "pre-push",
+    "post-commit",
+    "prepare-commit-msg",
+    "post-merge",
+];
+
 /// Generate the shim script content for a given hook name.
 ///
 /// The shim delegates execution to `git std hooks run <hook> -- <args>`,
@@ -10,10 +20,49 @@
 /// use standard_githooks::generate_shim;
 ///
 /// let shim = generate_shim("pre-commit");
-/// assert_eq!(shim, "#!/bin/bash\nexec git std hooks run pre-commit -- \"$@\"\n");
+/// assert!(shim.contains("exec git std hooks run pre-commit"));
 /// ```
 pub fn generate_shim(hook_name: &str) -> String {
-    format!("#!/bin/bash\nexec git std hooks run {hook_name} -- \"$@\"\n")
+    format!(
+        "#!/bin/bash\n\
+         # Managed by git-std — do not edit.\n\
+         # Configure commands in .githooks/{hook_name}.hooks\n\
+         exec git std hooks run {hook_name} -- \"$@\"\n"
+    )
+}
+
+/// Generate the `.hooks` template file content for a given hook name.
+///
+/// Includes a full header comment explaining the prefix system with examples.
+pub fn generate_hooks_template(hook_name: &str) -> String {
+    let fix_line = if hook_name == "pre-commit" {
+        "#   ~  fix       auto-format staged files and re-stage (pre-commit only)\n\
+         #                uses a stash dance to safely isolate staged content\n"
+    } else {
+        ""
+    };
+    format!(
+        "# git-std hooks — {hook_name}.hooks\n\
+         #\n\
+         # Each line is a command run during the {hook_name} hook.\n\
+         # Prefix controls behavior:\n\
+         #\n\
+         #   !  check     run command, block commit on failure\n\
+         {fix_line}\
+         #   ?  advisory  run command, never block commit\n\
+         #\n\
+         # $@ contains the list of staged files — commands can use or ignore it.\n\
+         #\n\
+         # Examples:\n\
+         #   ! cargo fmt --check   # fail if code is unformatted\n\
+         #   ! cargo clippy        # lint workspace\n\
+         #   ? cargo test          # run tests, never block commit\n\
+         #\n\
+         # Enable/disable this hook:\n\
+         #   git std hooks enable {hook_name}\n\
+         #   git std hooks disable {hook_name}\n\
+         #\n"
+    )
 }
 
 #[cfg(test)]
@@ -21,29 +70,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn shim_for_pre_commit() {
+    fn shim_contains_exec_line() {
         let shim = generate_shim("pre-commit");
-        assert_eq!(
-            shim,
-            "#!/bin/bash\nexec git std hooks run pre-commit -- \"$@\"\n"
-        );
+        assert!(shim.contains("exec git std hooks run pre-commit -- \"$@\""));
     }
 
     #[test]
-    fn shim_for_commit_msg() {
+    fn shim_has_managed_comment() {
         let shim = generate_shim("commit-msg");
-        assert_eq!(
-            shim,
-            "#!/bin/bash\nexec git std hooks run commit-msg -- \"$@\"\n"
-        );
+        assert!(shim.contains("Managed by git-std"));
+        assert!(shim.contains(".githooks/commit-msg.hooks"));
     }
 
     #[test]
-    fn shim_for_pre_push() {
-        let shim = generate_shim("pre-push");
-        assert_eq!(
-            shim,
-            "#!/bin/bash\nexec git std hooks run pre-push -- \"$@\"\n"
-        );
+    fn hooks_template_has_header() {
+        let t = generate_hooks_template("pre-commit");
+        assert!(t.contains("pre-commit.hooks"));
+        assert!(t.contains("!  check"));
+        assert!(t.contains("~  fix"));
+        assert!(t.contains("?  advisory"));
+    }
+
+    #[test]
+    fn hooks_template_no_fix_line_for_non_precommit() {
+        let t = generate_hooks_template("commit-msg");
+        assert!(!t.contains("~  fix"));
+    }
+
+    #[test]
+    fn known_hooks_contains_standard_hooks() {
+        assert!(KNOWN_HOOKS.contains(&"pre-commit"));
+        assert!(KNOWN_HOOKS.contains(&"commit-msg"));
+        assert!(KNOWN_HOOKS.contains(&"pre-push"));
     }
 }

--- a/spec/snapshots/hooks/list_fail_fast_mode.stdout.expected
+++ b/spec/snapshots/hooks/list_fail_fast_mode.stdout.expected
@@ -1,3 +1,18 @@
-...
-[..] pre-push (fail-fast mode):[..]
-...
+  pre-commit (collect) [disabled]:
+    (no commands)
+
+  commit-msg (fail-fast) [disabled]:
+    (no commands)
+
+  pre-push (fail-fast) [disabled]:
+    ! cargo build --workspace
+    ! cargo test --workspace
+
+  post-commit (collect) [disabled]:
+    (no commands)
+
+  prepare-commit-msg (collect) [disabled]:
+    (no commands)
+
+  post-merge (collect) [disabled]:
+    (no commands)

--- a/spec/snapshots/hooks/list_no_hooks.stderr.expected
+++ b/spec/snapshots/hooks/list_no_hooks.stderr.expected
@@ -1,1 +1,1 @@
-[..] no hooks configured
+  no hooks installed — run 'git std hooks install'

--- a/spec/snapshots/hooks/list_shows_configured_hooks.stdout.expected
+++ b/spec/snapshots/hooks/list_shows_configured_hooks.stdout.expected
@@ -1,3 +1,18 @@
-...
-[..] pre-commit (collect mode):[..]
-...
+  pre-commit (collect) [disabled]:
+      dprint check
+      cargo clippy --workspace -- -D warnings       *.rs
+
+  commit-msg (fail-fast) [disabled]:
+    (no commands)
+
+  pre-push (fail-fast) [disabled]:
+    (no commands)
+
+  post-commit (collect) [disabled]:
+    (no commands)
+
+  prepare-commit-msg (collect) [disabled]:
+    (no commands)
+
+  post-merge (collect) [disabled]:
+    (no commands)

--- a/spec/tests/hooks.rs
+++ b/spec/tests/hooks.rs
@@ -61,6 +61,7 @@ fn hooks_install_creates_shims() {
 
     Command::new(TestRepo::bin_path())
         .args(["hooks", "install"])
+        .env("GIT_STD_HOOKS_ENABLE", "pre-commit")
         .current_dir(repo.path())
         .assert()
         .success()


### PR DESCRIPTION
## Summary

Implements #198 — full hook lifecycle management.

- **`install`** writes `.hooks` templates for all 6 known hooks (skips existing), prompts which to enable (multi-select, default: `pre-commit` + `commit-msg`), writes active shims for selected and `.off` shims for the rest
- **`enable <hook>`** renames `<hook>.off` → `<hook>`
- **`disable <hook>`** renames `<hook>` → `<hook>.off`
- **`list`** shows all known hooks with enabled/disabled status and commands
- All generated shims include managed-by comment + pointer to `.hooks` file
- All generated `.hooks` templates include full prefix documentation header
- `GIT_STD_HOOKS_ENABLE` env var bypasses the interactive prompt (CI/tests)

## Test plan

- [ ] CI passes
- [ ] `git std hooks install` prompts and creates correct shims + templates
- [ ] `git std hooks enable pre-push` renames `.off` → active
- [ ] `git std hooks disable pre-commit` renames active → `.off`
- [ ] `git std hooks list` shows all hooks with status
- [ ] Re-running install is idempotent (preserves existing `.hooks` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)