### PR TITLE
fix(standard-version): replace Box<dyn Error> with typed VersionError

### DIFF
--- a/crates/standard-version/src/lib.rs
+++ b/crates/standard-version/src/lib.rs
@@ -240,10 +240,8 @@ pub fn summarise(commits: &[ConventionalCommit]) -> BumpSummary {
 pub fn replace_version_in_toml(
     content: &str,
     new_version: &str,
-) -> Result<String, Box<dyn std::error::Error>> {
-    CargoVersionFile
-        .write_version(content, new_version)
-        .map_err(|e| e.to_string().into())
+) -> Result<String, VersionFileError> {
+    CargoVersionFile.write_version(content, new_version)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #202

## Summary
- Changed `replace_version_in_toml` return type from `Result<String, Box<dyn std::error::Error>>` to `Result<String, VersionFileError>`
- Removed the intermediate `.map_err(|e| e.to_string().into())` conversion; the function now forwards the `VersionFileError` from `CargoVersionFile::write_version` directly
- No callers outside the crate — the `git-std` binary crate does not call this function, so no downstream changes were needed

## Test plan
- [ ] `replace_version_in_toml` returns typed `Result<String, VersionError>`
- [ ] No `Box<dyn Error>` in any public library API
- [ ] `just check` passes clean