### PR TITLE
fix(commit): fail fast with clear error when stdin is not a TTY

### DIFF
--- a/crates/git-std/src/cli/commit.rs
+++ b/crates/git-std/src/cli/commit.rs
@@ -1,3 +1,5 @@
+use std::io::IsTerminal;
+
 use crate::config::{ProjectConfig, ScopesConfig};
 use crate::ui;
 use inquire::{
@@ -143,6 +145,10 @@ fn gather_answers(
     opts: &CommitOptions,
 ) -> Result<PromptAnswers, Box<dyn std::error::Error>> {
     let fully_non_interactive = opts.commit_type.is_some() && opts.message.is_some();
+
+    if !fully_non_interactive && !std::io::stdin().is_terminal() {
+        return Err("interactive prompts require a TTY \u{2014} use --message to provide a commit message non-interactively".into());
+    }
 
     let commit_type = if let Some(t) = &opts.commit_type {
         t.clone()

--- a/crates/git-std/tests/cli.rs
+++ b/crates/git-std/tests/cli.rs
@@ -143,6 +143,41 @@ fn commit_short_flags() {
         .stderr(predicate::str::contains("feat: short flag"));
 }
 
+#[test]
+fn commit_fails_fast_when_stdin_is_not_a_tty() {
+    // Piping stdin makes it non-TTY; without --type and --message the command
+    // should fail immediately with a clear error rather than hanging.
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["commit"])
+        .write_stdin("")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "interactive prompts require a TTY \u{2014} use --message to provide a commit message non-interactively",
+        ));
+}
+
+#[test]
+fn commit_non_interactive_with_type_and_message_works_in_piped_context() {
+    // When --type and --message are both provided, no prompt is needed; the
+    // command must succeed even with a piped (non-TTY) stdin.
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args([
+            "commit",
+            "--type",
+            "feat",
+            "-m",
+            "no tty needed",
+            "--dry-run",
+        ])
+        .write_stdin("")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("feat: no tty needed"));
+}
+
 // --- Commit integration tests (actual repo) ---
 
 /// Helper: run a git command and return stdout.


### PR DESCRIPTION
Closes #201

## Summary

- Added TTY check in `gather_answers` before any `inquire` prompt is called
- When stdin is not a TTY and at least one prompt is needed, exits immediately with: `interactive prompts require a TTY — use --message to provide a commit message non-interactively`
- Fully non-interactive path (`--type` + `--message`) bypasses the check entirely — works fine in piped/CI context

## Test plan

- [x] `commit_fails_fast_when_stdin_is_not_a_tty` — pipes empty stdin, asserts failure + exact error message
- [x] `commit_non_interactive_with_type_and_message_works_in_piped_context` — pipes empty stdin with `--type` + `--message`, asserts success
- [x] `just check` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)