### PR TITLE
fix(spec): remove dead_code warnings in spec/support/mod.rs

### DIFF
--- a/spec/support/mod.rs
+++ b/spec/support/mod.rs
@@ -25,6 +25,8 @@ impl TestRepo {
     }
 
     /// Write a `.githooks/<name>.hooks` file with the given content.
+    // Used by: spec/tests/hooks.rs (not referenced in every test binary)
+    #[allow(dead_code)]
     pub fn with_hooks_file(self, name: &str, content: &str) -> Self {
         let hooks_dir = self.dir.path().join(".githooks");
         std::fs::create_dir_all(&hooks_dir).expect("failed to create .githooks dir");
@@ -34,6 +36,8 @@ impl TestRepo {
     }
 
     /// Write a `.git-std.toml` config file.
+    // Used by: spec/tests/check.rs, spec/tests/bump.rs (not referenced in every test binary)
+    #[allow(dead_code)]
     pub fn with_config(self, content: &str) -> Self {
         std::fs::write(self.dir.path().join(".git-std.toml"), content)
             .expect("failed to write config");
@@ -41,6 +45,8 @@ impl TestRepo {
     }
 
     /// Write a minimal `Cargo.toml` with the given version.
+    // Used by: spec/tests/bump.rs, spec/tests/changelog.rs (not referenced in every test binary)
+    #[allow(dead_code)]
     pub fn with_cargo_toml(self, version: &str) -> Self {
         std::fs::write(
             self.dir.path().join("Cargo.toml"),
@@ -53,6 +59,8 @@ impl TestRepo {
     }
 
     /// Write a minimal `package.json` with the given version.
+    // Used by: spec/tests/bump.rs (not referenced in every test binary)
+    #[allow(dead_code)]
     pub fn with_package_json(self, version: &str) -> Self {
         std::fs::write(
             self.dir.path().join("package.json"),
@@ -76,6 +84,8 @@ impl TestRepo {
     }
 
     /// Create an annotated tag at HEAD.
+    // Used by: spec/tests/bump.rs, spec/tests/changelog.rs (not referenced in every test binary)
+    #[allow(dead_code)]
     pub fn create_tag(&self, name: &str) -> &Self {
         git(self.dir.path(), &["tag", "-a", name, "-m", name]);
         self


### PR DESCRIPTION
Closes #219

## Summary
- Each test binary in `spec/tests/` includes `support/mod.rs` via `#[path = ...]`, so Rust evaluates dead_code per binary. All five methods (`with_hooks_file`, `with_config`, `with_cargo_toml`, `with_package_json`, `create_tag`) are actively used across the test suite but not in every individual binary, triggering cross-binary false-positive warnings.
- Added `#[allow(dead_code)]` to each of the five flagged methods with a `// Used by: <test files>` comment explaining which binaries reference them.
- No test logic was changed.

## Test plan
- [ ] `cargo test --workspace` passes with zero warnings
- [ ] `just check` passes clean