### PR TITLE
fix(git-std): replace Box&lt;dyn Error&gt; with anyhow::Result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
 name = "git-std"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "clap",
  "clap_complete",

--- a/crates/git-std/Cargo.toml
+++ b/crates/git-std/Cargo.toml
@@ -16,6 +16,7 @@ name = "git-std"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1"
 clap = { version = "4.6.0", features = ["derive"] }
 clap_complete = "4"
 inquire = "0.9"

--- a/crates/git-std/src/cli/changelog.rs
+++ b/crates/git-std/src/cli/changelog.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use standard_changelog::{ChangelogConfig, RepoHost, VersionRelease};
 
 use crate::git;
@@ -119,7 +120,7 @@ pub(crate) fn build_release_from_commits(
 fn build_unreleased(
     dir: &std::path::Path,
     config: &ChangelogConfig,
-) -> Result<Option<VersionRelease>, Box<dyn std::error::Error>> {
+) -> Result<Option<VersionRelease>> {
     let tags = git::collect_tags(dir)?;
 
     let head_oid = git::head_oid(dir)?;
@@ -211,10 +212,7 @@ fn run_range(
 }
 
 /// Build version releases from git history.
-fn build_releases(
-    dir: &std::path::Path,
-    config: &ChangelogConfig,
-) -> Result<Vec<VersionRelease>, Box<dyn std::error::Error>> {
+fn build_releases(dir: &std::path::Path, config: &ChangelogConfig) -> Result<Vec<VersionRelease>> {
     let tags = git::collect_tags(dir)?;
 
     let mut releases = Vec::new();

--- a/crates/git-std/src/cli/commit.rs
+++ b/crates/git-std/src/cli/commit.rs
@@ -2,6 +2,7 @@ use std::io::IsTerminal;
 
 use crate::config::{ProjectConfig, ScopesConfig};
 use crate::ui;
+use anyhow::{Result, bail};
 use inquire::{
     Select, Text,
     validator::{ErrorMessage, Validation},
@@ -140,14 +141,13 @@ fn print_commit_result(dir: &std::path::Path, amend: bool) {
 /// When all required fields (`--type` and `--message`) are provided via flags,
 /// prompts are skipped entirely (non-interactive mode). When some flags are
 /// given, only the missing fields are prompted.
-fn gather_answers(
-    config: &ProjectConfig,
-    opts: &CommitOptions,
-) -> Result<PromptAnswers, Box<dyn std::error::Error>> {
+fn gather_answers(config: &ProjectConfig, opts: &CommitOptions) -> Result<PromptAnswers> {
     let fully_non_interactive = opts.commit_type.is_some() && opts.message.is_some();
 
     if !fully_non_interactive && !std::io::stdin().is_terminal() {
-        return Err("interactive prompts require a TTY \u{2014} use --message to provide a commit message non-interactively".into());
+        bail!(
+            "interactive prompts require a TTY \u{2014} use --message to provide a commit message non-interactively"
+        );
     }
 
     let commit_type = if let Some(t) = &opts.commit_type {
@@ -200,7 +200,7 @@ fn gather_answers(
     })
 }
 
-fn prompt_type(types: &[String]) -> Result<String, Box<dyn std::error::Error>> {
+fn prompt_type(types: &[String]) -> Result<String> {
     let display: Vec<String> = types
         .iter()
         .map(|t| {
@@ -216,7 +216,7 @@ fn prompt_type(types: &[String]) -> Result<String, Box<dyn std::error::Error>> {
     Ok(types[choice.index].clone())
 }
 
-fn prompt_scope(config: &ProjectConfig) -> Result<Option<String>, Box<dyn std::error::Error>> {
+fn prompt_scope(config: &ProjectConfig) -> Result<Option<String>> {
     match &config.scopes {
         ScopesConfig::None => Ok(None),
         ScopesConfig::List(scopes) => {
@@ -257,7 +257,7 @@ fn prompt_scope(config: &ProjectConfig) -> Result<Option<String>, Box<dyn std::e
     }
 }
 
-fn prompt_description() -> Result<String, Box<dyn std::error::Error>> {
+fn prompt_description() -> Result<String> {
     let desc = Text::new("subject:")
         .with_validator(|input: &str| {
             if input.trim().is_empty() {
@@ -272,7 +272,7 @@ fn prompt_description() -> Result<String, Box<dyn std::error::Error>> {
     Ok(desc)
 }
 
-fn prompt_body() -> Result<Option<String>, Box<dyn std::error::Error>> {
+fn prompt_body() -> Result<Option<String>> {
     let mut paragraphs: Vec<String> = Vec::new();
     loop {
         let line = Text::new("body:").with_help_message("optional").prompt()?;
@@ -288,7 +288,7 @@ fn prompt_body() -> Result<Option<String>, Box<dyn std::error::Error>> {
     }
 }
 
-fn prompt_breaking() -> Result<Option<String>, Box<dyn std::error::Error>> {
+fn prompt_breaking() -> Result<Option<String>> {
     let desc = Text::new("breaks:")
         .with_help_message("optional")
         .prompt()?;
@@ -299,7 +299,7 @@ fn prompt_breaking() -> Result<Option<String>, Box<dyn std::error::Error>> {
     }
 }
 
-fn prompt_refs() -> Result<Vec<String>, Box<dyn std::error::Error>> {
+fn prompt_refs() -> Result<Vec<String>> {
     let mut refs: Vec<String> = Vec::new();
     loop {
         let input = Text::new("issues:")


### PR DESCRIPTION
Closes #203

## Summary

- Added `anyhow = "1"` to `crates/git-std/Cargo.toml`
- `cli/commit.rs` — 7 functions (`gather_answers`, `prompt_type`, `prompt_scope`, `prompt_description`, `prompt_body`, `prompt_breaking`, `prompt_refs`) now return `anyhow::Result`
- `cli/changelog.rs` — 2 functions (`build_unreleased`, `build_releases`) now return `anyhow::Result`
- `Err("...".into())` in `gather_answers` replaced with `bail!(...)`

## Test plan

- [x] No `Box<dyn Error>` in git-std binary crate
- [x] All 179 tests pass
- [x] Zero clippy warnings, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)