### PR TITLE
refactor(standard-version): split calver.rs into parse, bump submodules

### DIFF
--- a/crates/standard-version/src/calver/bump.rs
+++ b/crates/standard-version/src/calver/bump.rs
@@ -1,169 +1,10 @@
-//! Calendar versioning (calver) support.
+//! Bump calculation for calver.
 //!
-//! Computes the next calver version from a format string, the current date,
-//! and the previous version string. The format string uses tokens like
-//! `YYYY`, `MM`, `PATCH`, etc.
-//!
-//! This module is pure — it takes the date as a parameter and performs no I/O.
+//! Computes the next version string given a format, current date, and
+//! optional previous version.
 
-/// Date information needed for calver computation.
-///
-/// All fields are simple integers — the caller is responsible for computing
-/// them from the current date. This keeps the library pure (no clock access).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CalverDate {
-    /// Full year (e.g. 2026).
-    pub year: u32,
-    /// Month (1–12).
-    pub month: u32,
-    /// Day of month (1–31).
-    pub day: u32,
-    /// ISO week number (1–53).
-    pub iso_week: u32,
-    /// ISO day of week (1=Monday, 7=Sunday).
-    pub day_of_week: u32,
-}
-
-/// The default calver format when none is specified.
-pub const DEFAULT_FORMAT: &str = "YYYY.MM.PATCH";
-
-/// Errors that can occur during calver computation.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum CalverError {
-    /// The format string contains no `PATCH` token.
-    #[error("calver format must contain the PATCH token")]
-    NoPatchToken,
-    /// The format string contains an unrecognised token.
-    #[error("unknown calver format token: {0}")]
-    UnknownToken(String),
-    /// The format string is empty.
-    #[error("calver format string is empty")]
-    EmptyFormat,
-}
-
-/// A parsed token from the calver format string.
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum Token {
-    /// Full year (e.g. `2026`).
-    FullYear,
-    /// Short year (e.g. `26`).
-    ShortYear,
-    /// Zero-padded month (e.g. `03`).
-    ZeroPaddedMonth,
-    /// Month without padding (e.g. `3`).
-    Month,
-    /// ISO week number (e.g. `11`).
-    IsoWeek,
-    /// Day of month (e.g. `13`).
-    Day,
-    /// Auto-incrementing patch counter.
-    Patch,
-    /// A literal separator (e.g. `.`).
-    Separator(String),
-}
-
-/// Parse a calver format string into tokens.
-fn parse_format(format: &str) -> Result<Vec<Token>, CalverError> {
-    if format.is_empty() {
-        return Err(CalverError::EmptyFormat);
-    }
-
-    let mut tokens = Vec::new();
-    let mut remaining = format;
-
-    while !remaining.is_empty() {
-        // Try to match known tokens (longest first to avoid ambiguity).
-        if let Some(rest) = remaining.strip_prefix("YYYY") {
-            tokens.push(Token::FullYear);
-            remaining = rest;
-        } else if let Some(rest) = remaining.strip_prefix("YY") {
-            tokens.push(Token::ShortYear);
-            remaining = rest;
-        } else if let Some(rest) = remaining.strip_prefix("0M") {
-            tokens.push(Token::ZeroPaddedMonth);
-            remaining = rest;
-        } else if let Some(rest) = remaining.strip_prefix("MM") {
-            tokens.push(Token::Month);
-            remaining = rest;
-        } else if let Some(rest) = remaining.strip_prefix("WW") {
-            tokens.push(Token::IsoWeek);
-            remaining = rest;
-        } else if let Some(rest) = remaining.strip_prefix("DD") {
-            tokens.push(Token::Day);
-            remaining = rest;
-        } else if let Some(rest) = remaining.strip_prefix("PATCH") {
-            tokens.push(Token::Patch);
-            remaining = rest;
-        } else {
-            // Consume separator characters (`.`, `-`, etc.).
-            let ch = remaining.chars().next().unwrap();
-            if ch == '.' || ch == '-' || ch == '_' {
-                // Merge consecutive separators of the same kind.
-                if let Some(Token::Separator(s)) = tokens.last_mut() {
-                    s.push(ch);
-                } else {
-                    tokens.push(Token::Separator(ch.to_string()));
-                }
-                remaining = &remaining[ch.len_utf8()..];
-            } else {
-                // Unknown character sequence — find the next known token boundary.
-                return Err(CalverError::UnknownToken(remaining.to_string()));
-            }
-        }
-    }
-
-    // Validate that PATCH is present.
-    if !tokens.iter().any(|t| matches!(t, Token::Patch)) {
-        return Err(CalverError::NoPatchToken);
-    }
-
-    Ok(tokens)
-}
-
-/// Build the date prefix from the format (everything before PATCH, including
-/// the separator before PATCH).
-fn build_date_prefix(tokens: &[Token], date: CalverDate) -> String {
-    let mut prefix = String::new();
-    for token in tokens {
-        match token {
-            Token::Patch => break,
-            Token::FullYear => prefix.push_str(&date.year.to_string()),
-            Token::ShortYear => prefix.push_str(&format!("{}", date.year % 100)),
-            Token::ZeroPaddedMonth => prefix.push_str(&format!("{:02}", date.month)),
-            Token::Month => prefix.push_str(&date.month.to_string()),
-            Token::IsoWeek => prefix.push_str(&date.iso_week.to_string()),
-            Token::Day => prefix.push_str(&date.day.to_string()),
-            Token::Separator(s) => prefix.push_str(s),
-        }
-    }
-    prefix
-}
-
-/// Build the suffix after PATCH from the format tokens.
-fn build_date_suffix(tokens: &[Token], date: CalverDate) -> String {
-    let mut suffix = String::new();
-    let mut past_patch = false;
-    for token in tokens {
-        if matches!(token, Token::Patch) {
-            past_patch = true;
-            continue;
-        }
-        if !past_patch {
-            continue;
-        }
-        match token {
-            Token::FullYear => suffix.push_str(&date.year.to_string()),
-            Token::ShortYear => suffix.push_str(&format!("{}", date.year % 100)),
-            Token::ZeroPaddedMonth => suffix.push_str(&format!("{:02}", date.month)),
-            Token::Month => suffix.push_str(&date.month.to_string()),
-            Token::IsoWeek => suffix.push_str(&date.iso_week.to_string()),
-            Token::Day => suffix.push_str(&date.day.to_string()),
-            Token::Separator(s) => suffix.push_str(s),
-            Token::Patch => {} // only one PATCH allowed, already past it
-        }
-    }
-    suffix
-}
+use super::parse::{build_date_prefix, build_date_suffix, find_separator, parse_format};
+use super::{CalverDate, CalverError};
 
 /// Compute the next calver version string.
 ///
@@ -208,8 +49,16 @@ pub fn next_version(
     Ok(format!("{date_prefix}{patch}{date_suffix}"))
 }
 
+/// Validate a calver format string without computing a version.
+///
+/// Returns `Ok(())` if the format is valid, or an error describing the problem.
+pub fn validate_format(format: &str) -> Result<(), CalverError> {
+    parse_format(format)?;
+    Ok(())
+}
+
 /// Check if the date segments of the previous version match the current date.
-fn date_segments_match(previous: &str, tokens: &[Token], date: CalverDate) -> bool {
+fn date_segments_match(previous: &str, tokens: &[super::parse::Token], date: CalverDate) -> bool {
     // Build the expected date prefix from the current date.
     let expected_prefix = build_date_prefix(tokens, date);
     // Build the expected date suffix from the current date.
@@ -227,7 +76,9 @@ fn date_segments_match(previous: &str, tokens: &[Token], date: CalverDate) -> bo
 }
 
 /// Extract the patch number from a previous version string.
-fn extract_patch(previous: &str, tokens: &[Token]) -> u64 {
+fn extract_patch(previous: &str, tokens: &[super::parse::Token]) -> u64 {
+    use super::parse::Token;
+
     // Count the number of segments before PATCH and after PATCH.
     let mut segments_before_patch = 0;
     let mut segments_after_patch = 0;
@@ -263,28 +114,10 @@ fn extract_patch(previous: &str, tokens: &[Token]) -> u64 {
     }
 }
 
-/// Find the primary separator character from the format tokens.
-fn find_separator(tokens: &[Token]) -> String {
-    for token in tokens {
-        if let Token::Separator(s) = token {
-            // Return first char as the separator.
-            return s.chars().next().unwrap().to_string();
-        }
-    }
-    ".".to_string()
-}
-
-/// Validate a calver format string without computing a version.
-///
-/// Returns `Ok(())` if the format is valid, or an error describing the problem.
-pub fn validate_format(format: &str) -> Result<(), CalverError> {
-    parse_format(format)?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::calver::CalverDate;
 
     fn date_2026_03() -> CalverDate {
         CalverDate {
@@ -304,53 +137,6 @@ mod tests {
             iso_week: 14,
             day_of_week: 3, // Wednesday
         }
-    }
-
-    // ── Format parsing ──────────────────────────────────────────────
-
-    #[test]
-    fn parse_default_format() {
-        let tokens = parse_format("YYYY.MM.PATCH").unwrap();
-        assert_eq!(tokens.len(), 5); // YYYY, ., MM, ., PATCH
-    }
-
-    #[test]
-    fn parse_zero_padded_month() {
-        let tokens = parse_format("YYYY.0M.PATCH").unwrap();
-        assert_eq!(tokens.len(), 5);
-        assert_eq!(tokens[2], Token::ZeroPaddedMonth);
-    }
-
-    #[test]
-    fn parse_daily_format() {
-        let tokens = parse_format("YYYY.MM.DD.PATCH").unwrap();
-        assert_eq!(tokens.len(), 7); // YYYY . MM . DD . PATCH
-    }
-
-    #[test]
-    fn parse_weekly_format() {
-        let tokens = parse_format("YY.WW.PATCH").unwrap();
-        assert_eq!(tokens.len(), 5);
-        assert_eq!(tokens[0], Token::ShortYear);
-        assert_eq!(tokens[2], Token::IsoWeek);
-    }
-
-    #[test]
-    fn error_no_patch_token() {
-        let err = parse_format("YYYY.MM").unwrap_err();
-        assert_eq!(err, CalverError::NoPatchToken);
-    }
-
-    #[test]
-    fn error_empty_format() {
-        let err = parse_format("").unwrap_err();
-        assert_eq!(err, CalverError::EmptyFormat);
-    }
-
-    #[test]
-    fn error_unknown_token() {
-        let err = parse_format("YYYY.MM.PATCH.UNKNOWN").unwrap_err();
-        assert!(matches!(err, CalverError::UnknownToken(_)));
     }
 
     // ── First release ───────────────────────────────────────────────
@@ -506,6 +292,7 @@ mod tests {
 
     #[test]
     fn error_display() {
+        use crate::calver::CalverError;
         assert_eq!(
             CalverError::NoPatchToken.to_string(),
             "calver format must contain the PATCH token"

--- a/crates/standard-version/src/calver/mod.rs
+++ b/crates/standard-version/src/calver/mod.rs
@@ -1,0 +1,47 @@
+//! Calendar versioning (calver) support.
+//!
+//! Computes the next calver version from a format string, the current date,
+//! and the previous version string. The format string uses tokens like
+//! `YYYY`, `MM`, `PATCH`, etc.
+//!
+//! This module is pure — it takes the date as a parameter and performs no I/O.
+
+pub mod bump;
+pub mod parse;
+
+pub use bump::{next_version, validate_format};
+
+/// Date information needed for calver computation.
+///
+/// All fields are simple integers — the caller is responsible for computing
+/// them from the current date. This keeps the library pure (no clock access).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CalverDate {
+    /// Full year (e.g. 2026).
+    pub year: u32,
+    /// Month (1–12).
+    pub month: u32,
+    /// Day of month (1–31).
+    pub day: u32,
+    /// ISO week number (1–53).
+    pub iso_week: u32,
+    /// ISO day of week (1=Monday, 7=Sunday).
+    pub day_of_week: u32,
+}
+
+/// The default calver format when none is specified.
+pub const DEFAULT_FORMAT: &str = "YYYY.MM.PATCH";
+
+/// Errors that can occur during calver computation.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CalverError {
+    /// The format string contains no `PATCH` token.
+    #[error("calver format must contain the PATCH token")]
+    NoPatchToken,
+    /// The format string contains an unrecognised token.
+    #[error("unknown calver format token: {0}")]
+    UnknownToken(String),
+    /// The format string is empty.
+    #[error("calver format string is empty")]
+    EmptyFormat,
+}

--- a/crates/standard-version/src/calver/parse.rs
+++ b/crates/standard-version/src/calver/parse.rs
@@ -1,0 +1,193 @@
+//! Format string parsing for calver.
+//!
+//! Tokenises the calver format string and provides helpers to render
+//! date segments from the resulting token list.
+
+use super::{CalverDate, CalverError};
+
+/// A parsed token from the calver format string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Token {
+    /// Full year (e.g. `2026`).
+    FullYear,
+    /// Short year (e.g. `26`).
+    ShortYear,
+    /// Zero-padded month (e.g. `03`).
+    ZeroPaddedMonth,
+    /// Month without padding (e.g. `3`).
+    Month,
+    /// ISO week number (e.g. `11`).
+    IsoWeek,
+    /// Day of month (e.g. `13`).
+    Day,
+    /// Auto-incrementing patch counter.
+    Patch,
+    /// A literal separator (e.g. `.`).
+    Separator(String),
+}
+
+/// Parse a calver format string into tokens.
+pub(super) fn parse_format(format: &str) -> Result<Vec<Token>, CalverError> {
+    if format.is_empty() {
+        return Err(CalverError::EmptyFormat);
+    }
+
+    let mut tokens = Vec::new();
+    let mut remaining = format;
+
+    while !remaining.is_empty() {
+        // Try to match known tokens (longest first to avoid ambiguity).
+        if let Some(rest) = remaining.strip_prefix("YYYY") {
+            tokens.push(Token::FullYear);
+            remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("YY") {
+            tokens.push(Token::ShortYear);
+            remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("0M") {
+            tokens.push(Token::ZeroPaddedMonth);
+            remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("MM") {
+            tokens.push(Token::Month);
+            remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("WW") {
+            tokens.push(Token::IsoWeek);
+            remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("DD") {
+            tokens.push(Token::Day);
+            remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("PATCH") {
+            tokens.push(Token::Patch);
+            remaining = rest;
+        } else {
+            // Consume separator characters (`.`, `-`, etc.).
+            let ch = remaining.chars().next().unwrap();
+            if ch == '.' || ch == '-' || ch == '_' {
+                // Merge consecutive separators of the same kind.
+                if let Some(Token::Separator(s)) = tokens.last_mut() {
+                    s.push(ch);
+                } else {
+                    tokens.push(Token::Separator(ch.to_string()));
+                }
+                remaining = &remaining[ch.len_utf8()..];
+            } else {
+                // Unknown character sequence — find the next known token boundary.
+                return Err(CalverError::UnknownToken(remaining.to_string()));
+            }
+        }
+    }
+
+    // Validate that PATCH is present.
+    if !tokens.iter().any(|t| matches!(t, Token::Patch)) {
+        return Err(CalverError::NoPatchToken);
+    }
+
+    Ok(tokens)
+}
+
+/// Build the date prefix from the format (everything before PATCH, including
+/// the separator before PATCH).
+pub(super) fn build_date_prefix(tokens: &[Token], date: CalverDate) -> String {
+    let mut prefix = String::new();
+    for token in tokens {
+        match token {
+            Token::Patch => break,
+            Token::FullYear => prefix.push_str(&date.year.to_string()),
+            Token::ShortYear => prefix.push_str(&format!("{}", date.year % 100)),
+            Token::ZeroPaddedMonth => prefix.push_str(&format!("{:02}", date.month)),
+            Token::Month => prefix.push_str(&date.month.to_string()),
+            Token::IsoWeek => prefix.push_str(&date.iso_week.to_string()),
+            Token::Day => prefix.push_str(&date.day.to_string()),
+            Token::Separator(s) => prefix.push_str(s),
+        }
+    }
+    prefix
+}
+
+/// Build the suffix after PATCH from the format tokens.
+pub(super) fn build_date_suffix(tokens: &[Token], date: CalverDate) -> String {
+    let mut suffix = String::new();
+    let mut past_patch = false;
+    for token in tokens {
+        if matches!(token, Token::Patch) {
+            past_patch = true;
+            continue;
+        }
+        if !past_patch {
+            continue;
+        }
+        match token {
+            Token::FullYear => suffix.push_str(&date.year.to_string()),
+            Token::ShortYear => suffix.push_str(&format!("{}", date.year % 100)),
+            Token::ZeroPaddedMonth => suffix.push_str(&format!("{:02}", date.month)),
+            Token::Month => suffix.push_str(&date.month.to_string()),
+            Token::IsoWeek => suffix.push_str(&date.iso_week.to_string()),
+            Token::Day => suffix.push_str(&date.day.to_string()),
+            Token::Separator(s) => suffix.push_str(s),
+            Token::Patch => {} // only one PATCH allowed, already past it
+        }
+    }
+    suffix
+}
+
+/// Find the primary separator character from the format tokens.
+pub(super) fn find_separator(tokens: &[Token]) -> String {
+    for token in tokens {
+        if let Token::Separator(s) = token {
+            // Return first char as the separator.
+            return s.chars().next().unwrap().to_string();
+        }
+    }
+    ".".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Format parsing ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_default_format() {
+        let tokens = parse_format("YYYY.MM.PATCH").unwrap();
+        assert_eq!(tokens.len(), 5); // YYYY, ., MM, ., PATCH
+    }
+
+    #[test]
+    fn parse_zero_padded_month() {
+        let tokens = parse_format("YYYY.0M.PATCH").unwrap();
+        assert_eq!(tokens.len(), 5);
+        assert_eq!(tokens[2], Token::ZeroPaddedMonth);
+    }
+
+    #[test]
+    fn parse_daily_format() {
+        let tokens = parse_format("YYYY.MM.DD.PATCH").unwrap();
+        assert_eq!(tokens.len(), 7); // YYYY . MM . DD . PATCH
+    }
+
+    #[test]
+    fn parse_weekly_format() {
+        let tokens = parse_format("YY.WW.PATCH").unwrap();
+        assert_eq!(tokens.len(), 5);
+        assert_eq!(tokens[0], Token::ShortYear);
+        assert_eq!(tokens[2], Token::IsoWeek);
+    }
+
+    #[test]
+    fn error_no_patch_token() {
+        let err = parse_format("YYYY.MM").unwrap_err();
+        assert_eq!(err, CalverError::NoPatchToken);
+    }
+
+    #[test]
+    fn error_empty_format() {
+        let err = parse_format("").unwrap_err();
+        assert_eq!(err, CalverError::EmptyFormat);
+    }
+
+    #[test]
+    fn error_unknown_token() {
+        let err = parse_format("YYYY.MM.PATCH.UNKNOWN").unwrap_err();
+        assert!(matches!(err, CalverError::UnknownToken(_)));
+    }
+}


### PR DESCRIPTION
Closes #211

## Summary

- `calver.rs` (523 lines) split into `calver/mod.rs`, `calver/parse.rs`, `calver/bump.rs`
- `mod.rs` (47 lines) — `CalverDate`, `CalverError`, `DEFAULT_FORMAT`, re-exports
- `parse.rs` (193 lines) — `Token` enum, format string parsing, date prefix/suffix building
- `bump.rs` (310 lines) — `next_version`, `validate_format`, patch extraction, bump logic
- Original `calver.rs` deleted; public API unchanged

## Test plan

- [x] No single file exceeds 500 lines
- [x] All 160 tests pass
- [x] `just check` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)