### PR TITLE
refactor(git-std): route all eprintln! calls through ui:: helpers

### DIFF
--- a/crates/git-std/src/cli/bump.rs
+++ b/crates/git-std/src/cli/bump.rs
@@ -118,10 +118,7 @@ pub fn run(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
                     "Analysing commits since ",
                     &format!("{}...", cur_ver_str.bold()),
                 );
-                eprintln!(
-                    "{DETAIL}no bump-worthy commits found",
-                    DETAIL = ui::DETAIL_INDENT
-                );
+                ui::detail("no bump-worthy commits found");
                 ui::blank();
                 return 0;
             }
@@ -161,11 +158,10 @@ pub fn run(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
     };
 
     ui::blank();
-    eprintln!(
-        "{INDENT}{} ({bump_reason})",
+    ui::info(&format!(
+        "{} ({bump_reason})",
         format!("{cur_ver} \u{2192} {new_version}").bold(),
-        INDENT = ui::INDENT,
-    );
+    ));
 
     let prev_ver_str = current_version.as_ref().map(|(_, v)| v.to_string());
 
@@ -225,10 +221,10 @@ fn finalize_bump(
 
         match standard_version::detect_version_files(workdir, &custom_files) {
             Ok(detected) if detected.is_empty() => {
-                eprintln!("{INDENT}No version files detected", INDENT = ui::INDENT);
+                ui::info("No version files detected");
             }
             Ok(detected) => {
-                eprintln!("{INDENT}Would update:", INDENT = ui::INDENT);
+                ui::info("Would update:");
                 for f in &detected {
                     let rel = f.path.strip_prefix(workdir).unwrap_or(&f.path).display();
                     ui::item(
@@ -238,32 +234,22 @@ fn finalize_bump(
                 }
             }
             Err(e) => {
-                eprintln!(
-                    "{INDENT}warning: cannot detect version files: {e}",
-                    INDENT = ui::INDENT,
-                );
+                ui::warning(&format!("cannot detect version files: {e}"));
             }
         }
 
         if !opts.skip_changelog {
-            eprintln!(
-                "{INDENT}Would update: CHANGELOG.md         prepend {tag_prefix}{new_version} section",
-                INDENT = ui::INDENT,
-            );
+            ui::info(&format!(
+                "Would update: CHANGELOG.md         prepend {tag_prefix}{new_version} section"
+            ));
         }
 
         if !opts.no_commit {
-            eprintln!(
-                "{INDENT}Would commit: chore(release): {new_version}",
-                INDENT = ui::INDENT,
-            );
+            ui::info(&format!("Would commit: chore(release): {new_version}"));
         }
 
         if !opts.no_commit && !opts.no_tag {
-            eprintln!(
-                "{INDENT}Would tag:    {tag_prefix}{new_version}",
-                INDENT = ui::INDENT,
-            );
+            ui::info(&format!("Would tag:    {tag_prefix}{new_version}"));
         }
 
         ui::blank();
@@ -320,7 +306,7 @@ fn finalize_bump(
     // Print updated files.
     if !version_results.is_empty() {
         ui::blank();
-        eprintln!("{INDENT}Updated:", INDENT = ui::INDENT);
+        ui::info("Updated:");
         for r in &version_results {
             let rel = r.path.strip_prefix(workdir).unwrap_or(&r.path).display();
             ui::item(
@@ -335,7 +321,7 @@ fn finalize_bump(
 
     if !opts.skip_changelog {
         ui::blank();
-        eprintln!("{INDENT}Changelog:", INDENT = ui::INDENT);
+        ui::info("Changelog:");
         ui::item(
             "CHANGELOG.md",
             &format!("prepended {tag_prefix}{new_version} section"),
@@ -379,11 +365,7 @@ fn finalize_bump(
         }
 
         ui::blank();
-        eprintln!(
-            "{INDENT}Committed: {}",
-            commit_msg.green(),
-            INDENT = ui::INDENT,
-        );
+        ui::info(&format!("Committed: {}", commit_msg.green()));
     }
 
     // Create annotated tag.
@@ -401,18 +383,11 @@ fn finalize_bump(
             return 1;
         }
 
-        eprintln!(
-            "{INDENT}Tagged:    {}",
-            tag_name.green(),
-            INDENT = ui::INDENT,
-        );
+        ui::info(&format!("Tagged:    {}", tag_name.green()));
     }
 
     ui::blank();
-    eprintln!(
-        "{INDENT}Push with: git push --follow-tags",
-        INDENT = ui::INDENT,
-    );
+    ui::info("Push with: git push --follow-tags");
     ui::blank();
 
     0
@@ -434,7 +409,7 @@ fn print_summary(summary: &standard_version::BumpSummary) {
         parts.push(format!("{} other", summary.other_count));
     }
     if !parts.is_empty() {
-        eprintln!("{DETAIL}{}", parts.join(", "), DETAIL = ui::DETAIL_INDENT);
+        ui::detail(&parts.join(", "));
     }
 }
 
@@ -609,37 +584,25 @@ fn run_stable(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
 
     if opts.dry_run {
         ui::blank();
-        eprintln!("{INDENT}Creating stable branch...", INDENT = ui::INDENT);
+        ui::info("Creating stable branch...");
         ui::item("Branch:", &stable_branch_name);
         ui::item("Scheme:", "patch (patch-only bumps)");
         ui::blank();
-        eprintln!(
-            "{INDENT}Would commit: chore(release): stabilize v{}.{}",
-            cur_ver.major,
-            cur_ver.minor,
-            INDENT = ui::INDENT,
-        );
+        ui::info(&format!(
+            "Would commit: chore(release): stabilize v{}.{}",
+            cur_ver.major, cur_ver.minor,
+        ));
         ui::blank();
-        eprintln!(
-            "{INDENT}Advancing {original_branch}...",
-            INDENT = ui::INDENT
-        );
-        eprintln!(
-            "{DETAIL}{} ({bump_kind})",
+        ui::info(&format!("Advancing {original_branch}..."));
+        ui::detail(&format!(
+            "{} ({bump_kind})",
             format!("{cur_ver} \u{2192} {new_version}").bold(),
-            DETAIL = ui::DETAIL_INDENT,
-        );
+        ));
         ui::blank();
-        eprintln!(
-            "{INDENT}Would commit: chore(release): {new_version}",
-            INDENT = ui::INDENT,
-        );
-        eprintln!(
-            "{INDENT}Would tag:    {tag_prefix}{new_version}",
-            INDENT = ui::INDENT,
-        );
+        ui::info(&format!("Would commit: chore(release): {new_version}"));
+        ui::info(&format!("Would tag:    {tag_prefix}{new_version}"));
         ui::blank();
-        eprintln!("{INDENT}Push with:", INDENT = ui::INDENT);
+        ui::info("Push with:");
         ui::item("", &format!("git push origin {stable_branch_name}"));
         ui::item("", "git push --follow-tags");
         ui::blank();
@@ -695,15 +658,11 @@ fn run_stable(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
     }
 
     ui::blank();
-    eprintln!("{INDENT}Creating stable branch...", INDENT = ui::INDENT);
+    ui::info("Creating stable branch...");
     ui::item("Branch:", &stable_branch_name);
     ui::item("Scheme:", "patch (patch-only bumps)");
     ui::blank();
-    eprintln!(
-        "{INDENT}Committed: {}",
-        stabilize_msg.green(),
-        INDENT = ui::INDENT,
-    );
+    ui::info(&format!("Committed: {}", stabilize_msg.green()));
 
     if let Err(e) = git::checkout_branch(dir, &original_branch) {
         ui::error(&format!("cannot checkout branch '{original_branch}': {e}"));
@@ -711,15 +670,11 @@ fn run_stable(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
     }
 
     ui::blank();
-    eprintln!(
-        "{INDENT}Advancing {original_branch}...",
-        INDENT = ui::INDENT
-    );
-    eprintln!(
-        "{DETAIL}{} ({bump_kind})",
+    ui::info(&format!("Advancing {original_branch}..."));
+    ui::detail(&format!(
+        "{} ({bump_kind})",
         format!("{cur_ver} \u{2192} {new_version}").bold(),
-        DETAIL = ui::DETAIL_INDENT,
-    );
+    ));
 
     let head_oid = match git::head_oid(dir) {
         Ok(oid) => oid,
@@ -751,10 +706,9 @@ fn run_stable(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
         return exit;
     }
 
-    eprintln!(
-        "{INDENT}Push stable: git push origin {stable_branch_name}",
-        INDENT = ui::INDENT,
-    );
+    ui::info(&format!(
+        "Push stable: git push origin {stable_branch_name}"
+    ));
     ui::blank();
 
     0
@@ -873,11 +827,10 @@ fn run_patch(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
     let new_version = semver::Version::new(cur_ver.major, cur_ver.minor, cur_ver.patch + 1);
 
     ui::blank();
-    eprintln!(
-        "{INDENT}{} (patch)",
+    ui::info(&format!(
+        "{} (patch)",
         format!("{cur_ver} \u{2192} {new_version}").bold(),
-        INDENT = ui::INDENT,
-    );
+    ));
 
     let prev_ver_str = current_version.as_ref().map(|(_, v)| v.to_string());
 
@@ -951,11 +904,10 @@ fn run_calver(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
     };
 
     ui::blank();
-    eprintln!(
-        "{INDENT}{} (calver)",
+    ui::info(&format!(
+        "{} (calver)",
         format!("{} \u{2192} {new_version}", prev_ver.unwrap_or("none")).bold(),
-        INDENT = ui::INDENT,
-    );
+    ));
 
     let ctx = FinalizeContext {
         new_version: new_version.clone(),

--- a/crates/git-std/src/cli/changelog.rs
+++ b/crates/git-std/src/cli/changelog.rs
@@ -64,7 +64,7 @@ fn run_incremental(
     let release = match build_unreleased(dir, config) {
         Ok(Some(r)) => r,
         Ok(None) => {
-            eprintln!("no unreleased changes found");
+            ui::print("no unreleased changes found");
             return 0;
         }
         Err(e) => {
@@ -94,7 +94,7 @@ fn write_output(content: &str, opts: &ChangelogOptions) -> i32 {
             ui::error(&format!("cannot write {}: {e}", opts.output));
             return 1;
         }
-        eprintln!("wrote {}", opts.output);
+        ui::info(&format!("wrote {}", opts.output));
     }
     0
 }
@@ -194,7 +194,7 @@ fn run_range(
             r
         }
         None => {
-            eprintln!("no conventional commits found in range {range}");
+            ui::info(&format!("no conventional commits found in range {range}"));
             return 0;
         }
     };

--- a/crates/git-std/src/cli/check.rs
+++ b/crates/git-std/src/cli/check.rs
@@ -40,27 +40,20 @@ pub fn run(message: &str, lint_config: Option<&LintConfig>, format: OutputFormat
     if let Some(config) = lint_config {
         let errors = standard_commit::lint(message, config);
         if errors.is_empty() {
-            eprintln!("{} {}", ui::pass(), "valid".green());
+            ui::print(&format!("{} {}", ui::pass(), "valid".green()));
             return 0;
         }
         for error in &errors {
-            eprintln!("{} {}", ui::fail(), error.to_string().red());
+            ui::print(&format!("{} {}", ui::fail(), error.to_string().red()));
         }
-        eprintln!(
-            "{INDENT}Expected: <type>(<scope>): <description>",
-            INDENT = ui::INDENT
-        );
-        eprintln!(
-            "{INDENT}Got:      {}",
-            first_line(message),
-            INDENT = ui::INDENT
-        );
+        ui::info("Expected: <type>(<scope>): <description>");
+        ui::info(&format!("Got:      {}", first_line(message)));
         return 1;
     }
 
     match standard_commit::parse(message) {
         Ok(_) => {
-            eprintln!("{} {}", ui::pass(), "valid".green());
+            ui::print(&format!("{} {}", ui::pass(), "valid".green()));
             0
         }
         Err(e) => {
@@ -170,15 +163,14 @@ pub fn run_range(range: &str, lint_config: Option<&LintConfig>, format: OutputFo
             if errors.is_empty() {
                 true
             } else {
-                eprintln!(
-                    "{INDENT}{} {} {}",
+                ui::result_line(&format!(
+                    "{} {} {}",
                     ui::fail(),
                     short,
                     first_line(message).red(),
-                    INDENT = ui::INDENT,
-                );
+                ));
                 for error in &errors {
-                    eprintln!("{DETAIL}\u{2192} {}", error, DETAIL = ui::DETAIL_INDENT,);
+                    ui::detail(&format!("\u{2192} {}", error));
                 }
                 false
             }
@@ -186,27 +178,25 @@ pub fn run_range(range: &str, lint_config: Option<&LintConfig>, format: OutputFo
             match standard_commit::parse(message) {
                 Ok(_) => true,
                 Err(e) => {
-                    eprintln!(
-                        "{INDENT}{} {} {}",
+                    ui::result_line(&format!(
+                        "{} {} {}",
                         ui::fail(),
                         short,
                         first_line(message).red(),
-                        INDENT = ui::INDENT,
-                    );
-                    eprintln!("{DETAIL}\u{2192} {}", e, DETAIL = ui::DETAIL_INDENT,);
+                    ));
+                    ui::detail(&format!("\u{2192} {}", e));
                     false
                 }
             }
         };
 
         if valid {
-            eprintln!(
-                "{INDENT}{} {} {}",
+            ui::result_line(&format!(
+                "{} {} {}",
                 ui::pass(),
                 short,
                 first_line(message).green(),
-                INDENT = ui::INDENT,
-            );
+            ));
         } else {
             failures += 1;
         }
@@ -214,7 +204,7 @@ pub fn run_range(range: &str, lint_config: Option<&LintConfig>, format: OutputFo
 
     let valid_count = total - failures;
     ui::blank();
-    eprintln!("{}/{} valid", valid_count, total);
+    ui::summary_counts(valid_count, total);
 
     if failures > 0 { 1 } else { 0 }
 }
@@ -273,16 +263,13 @@ fn strip_comments(content: &str) -> String {
 }
 
 fn print_diagnostic(message: &str, error: &standard_commit::ParseError) {
-    eprintln!("{} {}", ui::fail(), format!("invalid: {error}").red());
-    eprintln!(
-        "{INDENT}Expected: <type>(<scope>): <description>",
-        INDENT = ui::INDENT
-    );
-    eprintln!(
-        "{INDENT}Got:      {}",
-        first_line(message),
-        INDENT = ui::INDENT
-    );
+    ui::print(&format!(
+        "{} {}",
+        ui::fail(),
+        format!("invalid: {error}").red()
+    ));
+    ui::info("Expected: <type>(<scope>): <description>");
+    ui::info(&format!("Got:      {}", first_line(message)));
 }
 
 fn first_line(s: &str) -> &str {

--- a/crates/git-std/src/cli/commit.rs
+++ b/crates/git-std/src/cli/commit.rs
@@ -91,7 +91,7 @@ pub fn run_interactive(config: &ProjectConfig, opts: &CommitOptions) -> i32 {
     }
 
     if opts.dry_run {
-        eprintln!("{}{message}", ui::INDENT);
+        ui::info(&message);
         return 0;
     }
 

--- a/crates/git-std/src/cli/hooks.rs
+++ b/crates/git-std/src/cli/hooks.rs
@@ -85,31 +85,19 @@ fn execute_and_print(cmd: &HookCommand, msg_path: &str) -> (CommandResult, bool)
 
     // Print the result line
     if success {
-        eprintln!("{INDENT}{} {}", ui::pass(), display, INDENT = ui::INDENT);
+        ui::result_line(&format!("{} {}", ui::pass(), display));
     } else if is_advisory {
         let info = match exit_code {
             Some(code) => format!("(advisory, exit {code})"),
             None => "(advisory, killed)".to_string(),
         };
-        eprintln!(
-            "{INDENT}{} {} {}",
-            ui::warn(),
-            display,
-            info.yellow(),
-            INDENT = ui::INDENT
-        );
+        ui::result_line(&format!("{} {} {}", ui::warn(), display, info.yellow()));
     } else {
         let info = match exit_code {
             Some(code) => format!("(exit {code})"),
             None => "(killed)".to_string(),
         };
-        eprintln!(
-            "{INDENT}{} {} {}",
-            ui::fail(),
-            display,
-            info.red(),
-            INDENT = ui::INDENT
-        );
+        ui::result_line(&format!("{} {} {}", ui::fail(), display, info.red()));
     }
 
     let failed = !success && !is_advisory;
@@ -133,11 +121,10 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
     if let Ok(val) = std::env::var("GIT_STD_SKIP_HOOKS")
         && (val == "1" || val.eq_ignore_ascii_case("true"))
     {
-        eprintln!(
-            "{INDENT}{} hooks skipped (GIT_STD_SKIP_HOOKS)",
-            ui::warn(),
-            INDENT = ui::INDENT
-        );
+        ui::result_line(&format!(
+            "{} hooks skipped (GIT_STD_SKIP_HOOKS)",
+            ui::warn()
+        ));
         return 0;
     }
 
@@ -195,16 +182,15 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
             let remaining = commands.len() - results.len();
             if remaining > 0 {
                 ui::blank();
-                eprintln!(
-                    "{INDENT}{} remaining {} skipped (fail-fast)",
+                ui::info(&format!(
+                    "{} remaining {} skipped (fail-fast)",
                     remaining,
                     if remaining == 1 {
                         "command"
                     } else {
                         "commands"
                     },
-                    INDENT = ui::INDENT,
-                );
+                ));
             }
             ui::blank();
             return 1;
@@ -237,7 +223,7 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
                 }
             ));
         }
-        eprintln!("{INDENT}{}", parts.join(", "), INDENT = ui::INDENT);
+        ui::info(&parts.join(", "));
     }
 
     if has_failure { 1 } else { 0 }
@@ -263,15 +249,14 @@ pub fn install() -> i32 {
 
     match status {
         Ok(s) if s.success() => {
-            eprintln!(
-                "{INDENT}{}  core.hooksPath \u{2192} .githooks",
-                ui::pass(),
-                INDENT = ui::INDENT,
-            );
+            ui::result_line(&format!(
+                "{}  core.hooksPath \u{2192} .githooks",
+                ui::pass()
+            ));
         }
         _ => {
             ui::error("failed to set core.hooksPath");
-            eprintln!("  hint: ensure you are inside a git repository and have write access");
+            ui::hint("ensure you are inside a git repository and have write access");
             return 1;
         }
     }
@@ -376,11 +361,7 @@ pub fn install() -> i32 {
             "disabled".dim().to_string()
         };
 
-        eprintln!(
-            "{INDENT}{}  {hook_name:<22} {status_label}",
-            ui::pass(),
-            INDENT = ui::INDENT,
-        );
+        ui::result_line(&format!("{}  {hook_name:<22} {status_label}", ui::pass()));
     }
 
     0
@@ -401,11 +382,7 @@ pub fn enable(hook_name: &str) -> i32 {
     let off_path = hooks_dir.join(format!("{hook_name}.off"));
 
     if active_path.exists() {
-        eprintln!(
-            "{INDENT}{} {hook_name} is already enabled",
-            ui::warn(),
-            INDENT = ui::INDENT
-        );
+        ui::result_line(&format!("{} {hook_name} is already enabled", ui::warn()));
         return 0;
     }
 
@@ -428,11 +405,7 @@ pub fn enable(hook_name: &str) -> i32 {
         let _ = std::fs::set_permissions(&active_path, perms);
     }
 
-    eprintln!(
-        "{INDENT}{}  {hook_name} enabled",
-        ui::pass(),
-        INDENT = ui::INDENT
-    );
+    ui::result_line(&format!("{}  {hook_name} enabled", ui::pass()));
     0
 }
 
@@ -451,11 +424,7 @@ pub fn disable(hook_name: &str) -> i32 {
     let off_path = hooks_dir.join(format!("{hook_name}.off"));
 
     if off_path.exists() {
-        eprintln!(
-            "{INDENT}{} {hook_name} is already disabled",
-            ui::warn(),
-            INDENT = ui::INDENT
-        );
+        ui::result_line(&format!("{} {hook_name} is already disabled", ui::warn()));
         return 0;
     }
 
@@ -471,11 +440,7 @@ pub fn disable(hook_name: &str) -> i32 {
         return 1;
     }
 
-    eprintln!(
-        "{INDENT}{}  {hook_name} disabled",
-        ui::pass(),
-        INDENT = ui::INDENT
-    );
+    ui::result_line(&format!("{}  {hook_name} disabled", ui::pass()));
     0
 }
 
@@ -486,10 +451,7 @@ pub fn list() -> i32 {
     let hooks_dir = std::path::Path::new(".githooks");
 
     if !hooks_dir.exists() {
-        eprintln!(
-            "{INDENT}no hooks installed — run 'git std hooks install'",
-            INDENT = ui::INDENT
-        );
+        ui::info("no hooks installed — run 'git std hooks install'");
         return 0;
     }
 

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -208,9 +208,9 @@ fn main() {
                 cli::check::run(&message, lint_ref, format)
             } else {
                 ui::error("no input provided");
-                eprintln!("  usage: git std check <message>");
-                eprintln!("         git std check --file <path>");
-                eprintln!("         git std check --range <from..to>");
+                ui::info("usage: git std check <message>");
+                ui::info("       git std check --file <path>");
+                ui::info("       git std check --range <from..to>");
                 2
             };
             std::process::exit(code);

--- a/crates/git-std/src/ui.rs
+++ b/crates/git-std/src/ui.rs
@@ -59,3 +59,35 @@ pub fn item(label: &str, value: &str) {
         width = LABEL_WIDTH
     );
 }
+
+/// Print an indented informational line (two-space indent).
+pub fn info(msg: &str) {
+    eprintln!("{INDENT}{msg}");
+}
+
+/// Print a detail-indented line (four-space indent).
+pub fn detail(msg: &str) {
+    eprintln!("{DETAIL_INDENT}{msg}");
+}
+
+/// Print a hint line (two-space indent, no prefix).
+pub fn hint(msg: &str) {
+    eprintln!("{INDENT}hint: {msg}");
+}
+
+/// Print a summary count line (`valid_count/total valid`).
+pub fn summary_counts(valid: usize, total: usize) {
+    eprintln!("{valid}/{total} valid");
+}
+
+/// Print a plain message to stderr with no indentation.
+pub fn print(msg: &str) {
+    eprintln!("{msg}");
+}
+
+/// Print a plain indented line to stderr (two-space indent) with a leading symbol.
+///
+/// Suitable for check/hook result lines: `  ✓ <text>` or `  ✗ <text>`.
+pub fn result_line(msg: &str) {
+    eprintln!("{INDENT}{msg}");
+}


### PR DESCRIPTION
Closes #204

## Summary
- Replace 77+ direct `eprintln!` calls in `cli/*.rs` and `main.rs` with `ui::` helper calls
- Add any missing helpers to `ui.rs` as needed
- Output wording reviewed for consistency

## Test plan
- [ ] `just check` passes
- [ ] `just fmt` clean
- [ ] No `eprintln!` remaining outside `ui.rs`