### PR TITLE
feat(bump): sync ecosystem lock files after version bump (#186)

### DIFF
--- a/crates/git-std/src/cli/bump/apply.rs
+++ b/crates/git-std/src/cli/bump/apply.rs
@@ -7,6 +7,7 @@ use crate::config::ProjectConfig;
 use crate::git;
 use crate::ui;
 
+use super::lock_sync;
 use super::{BumpOptions, FinalizeContext};
 
 /// Build a `VersionRelease` from raw commits for changelog generation.
@@ -64,9 +65,11 @@ pub(super) fn finalize_bump(
     if opts.dry_run {
         ui::blank();
 
-        match standard_version::detect_version_files(workdir, &custom_files) {
+        let dry_cargo_updated = match standard_version::detect_version_files(workdir, &custom_files)
+        {
             Ok(detected) if detected.is_empty() => {
                 ui::info("No version files detected");
+                false
             }
             Ok(detected) => {
                 ui::info("Would update:");
@@ -77,11 +80,15 @@ pub(super) fn finalize_bump(
                         &format!("{} \u{2192} {new_version}", f.old_version),
                     );
                 }
+                detected.iter().any(|f| f.name == "Cargo.toml")
             }
             Err(e) => {
                 ui::warning(&format!("cannot detect version files: {e}"));
+                false
             }
-        }
+        };
+
+        lock_sync::dry_run_lock_files(workdir, dry_cargo_updated);
 
         if !opts.skip_changelog {
             ui::info(&format!(
@@ -113,16 +120,9 @@ pub(super) fn finalize_bump(
             }
         };
 
-    // Sync Cargo.lock only when a Cargo.toml was actually updated.
+    // Sync ecosystem lock files.
     let cargo_updated = version_results.iter().any(|r| r.name == "Cargo.toml");
-    if cargo_updated {
-        let status = std::process::Command::new("cargo")
-            .args(["update", "--workspace"])
-            .status();
-        if let Err(e) = status {
-            ui::warning(&format!("failed to update Cargo.lock: {e}"));
-        }
-    }
+    let synced_locks = lock_sync::sync_lock_files(workdir, cargo_updated);
 
     // Generate/update changelog.
     if !opts.skip_changelog {
@@ -188,8 +188,9 @@ pub(super) fn finalize_bump(
         if !opts.skip_changelog {
             paths_to_stage.push("CHANGELOG.md");
         }
-        if cargo_updated {
-            paths_to_stage.push("Cargo.lock");
+        // Stage all successfully synced lock files.
+        for lock in &synced_locks {
+            paths_to_stage.push(lock.as_str());
         }
 
         if let Err(e) = git::stage_files(dir, &paths_to_stage) {

--- a/crates/git-std/src/cli/bump/lock_sync.rs
+++ b/crates/git-std/src/cli/bump/lock_sync.rs
@@ -1,0 +1,177 @@
+//! Lock file synchronisation after a version bump.
+//!
+//! Scans the repository root for known ecosystem lock files and runs each
+//! ecosystem's official tool to regenerate it. Missing tools and sync failures
+//! are reported as warnings but never abort the bump.
+
+use std::path::Path;
+
+use crate::ui;
+
+/// A known lock file entry: filename, sync args, and the required tool.
+struct LockEntry {
+    /// Lock file name to look for at the repo root.
+    filename: &'static str,
+    /// Command name of the required tool (also used for PATH lookup).
+    tool: &'static str,
+    /// Arguments to pass to the tool.
+    args: &'static [&'static str],
+}
+
+/// All lock files git-std knows how to sync.
+const LOCK_ENTRIES: &[LockEntry] = &[
+    LockEntry {
+        filename: "package-lock.json",
+        tool: "npm",
+        args: &["install", "--package-lock-only"],
+    },
+    LockEntry {
+        filename: "yarn.lock",
+        tool: "yarn",
+        args: &["install", "--mode", "update-lockfile"],
+    },
+    LockEntry {
+        filename: "pnpm-lock.yaml",
+        tool: "pnpm",
+        args: &["install", "--lockfile-only"],
+    },
+    LockEntry {
+        filename: "deno.lock",
+        tool: "deno",
+        args: &["install"],
+    },
+    LockEntry {
+        filename: "uv.lock",
+        tool: "uv",
+        args: &["lock"],
+    },
+    LockEntry {
+        filename: "poetry.lock",
+        tool: "poetry",
+        args: &["lock", "--no-update"],
+    },
+];
+
+/// Sync all ecosystem lock files found at `workdir`.
+///
+/// `cargo_updated` indicates whether `Cargo.toml` was part of the version
+/// bump; `Cargo.lock` is only synced in that case.
+///
+/// Returns the list of lock file names that were successfully synced, for
+/// staging alongside the version files.
+pub(super) fn sync_lock_files(workdir: &Path, cargo_updated: bool) -> Vec<String> {
+    let mut synced = Vec::new();
+
+    // Handle Cargo.lock specially: only sync when Cargo.toml was updated.
+    if cargo_updated {
+        let cargo_lock = workdir.join("Cargo.lock");
+        if cargo_lock.exists() {
+            run_sync(
+                workdir,
+                "Cargo.lock",
+                "cargo",
+                &["update", "--workspace"],
+                &mut synced,
+            );
+        }
+    }
+
+    // All other lock files.
+    for entry in LOCK_ENTRIES {
+        let path = workdir.join(entry.filename);
+        if path.exists() {
+            run_sync(workdir, entry.filename, entry.tool, entry.args, &mut synced);
+        }
+    }
+
+    synced
+}
+
+/// Emit dry-run messages for all lock files that would be synced.
+///
+/// `cargo_updated` indicates whether `Cargo.toml` would have been updated.
+pub(super) fn dry_run_lock_files(workdir: &Path, cargo_updated: bool) {
+    if cargo_updated && workdir.join("Cargo.lock").exists() {
+        ui::info("Would sync:   Cargo.lock");
+    }
+
+    for entry in LOCK_ENTRIES {
+        if workdir.join(entry.filename).exists() {
+            ui::info(&format!("Would sync:   {}", entry.filename));
+        }
+    }
+}
+
+/// Try to run `tool args` in `workdir`. On success, push `filename` to
+/// `synced` and print an info message. On failure (tool absent or non-zero
+/// exit), print a warning and skip staging.
+fn run_sync(workdir: &Path, filename: &str, tool: &str, args: &[&str], synced: &mut Vec<String>) {
+    match std::process::Command::new(tool)
+        .args(args)
+        .current_dir(workdir)
+        .status()
+    {
+        Err(_) => {
+            // `Err` means the tool binary was not found (or could not be
+            // spawned). Treat as "tool not on PATH".
+            ui::warning(&format!(
+                "{filename} found but {tool} is not on PATH — lock file not synced"
+            ));
+        }
+        Ok(status) if status.success() => {
+            ui::info(&format!("Synced:  {filename}"));
+            synced.push(filename.to_string());
+        }
+        Ok(status) => {
+            let code = status.code().unwrap_or(-1);
+            ui::warning(&format!("{filename} sync failed (exit {code})"));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// dry_run_lock_files emits no output for an empty directory.
+    #[test]
+    fn dry_run_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        // Should not panic or emit anything meaningful — we can't assert stderr
+        // easily in unit tests, but we verify it doesn't crash.
+        dry_run_lock_files(dir.path(), false);
+        dry_run_lock_files(dir.path(), true);
+    }
+
+    /// sync_lock_files returns empty vec when no lock files are present.
+    #[test]
+    fn sync_no_lock_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let synced = sync_lock_files(dir.path(), false);
+        assert!(synced.is_empty());
+    }
+
+    /// Cargo.lock is not synced when cargo_updated is false, even if file exists.
+    #[test]
+    fn cargo_lock_skipped_when_not_updated() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.lock"), "# placeholder\n").unwrap();
+        let synced = sync_lock_files(dir.path(), false);
+        // We don't expect Cargo.lock to be attempted (cargo_updated=false).
+        assert!(!synced.contains(&"Cargo.lock".to_string()));
+    }
+
+    /// dry_run_lock_files mentions Cargo.lock only when cargo_updated is true.
+    #[test]
+    fn dry_run_cargo_lock_conditional() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.lock"), "# placeholder\n").unwrap();
+        // Just verify no panic — stderr assertions covered by integration tests.
+        dry_run_lock_files(dir.path(), false);
+        dry_run_lock_files(dir.path(), true);
+    }
+}

--- a/crates/git-std/src/cli/bump/mod.rs
+++ b/crates/git-std/src/cli/bump/mod.rs
@@ -1,5 +1,6 @@
 mod apply;
 mod detect;
+mod lock_sync;
 mod plan;
 mod stable;
 

--- a/crates/git-std/tests/bump.rs
+++ b/crates/git-std/tests/bump.rs
@@ -468,3 +468,49 @@ fn bump_prerelease_cycle() {
         "tag v1.1.0-rc.1 should exist"
     );
 }
+
+/// A lock file for a missing tool emits a warning but does not fail the bump.
+#[test]
+fn bump_missing_tool_lock_file_warns_and_continues() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: small fix");
+
+    // Write a uv.lock — `uv` is very unlikely to be installed in CI.
+    // We rely on the warning path (tool not on PATH) rather than a real sync.
+    std::fs::write(dir.path().join("uv.lock"), "# placeholder\n").unwrap();
+
+    // Bump must still succeed.
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // Cargo.toml was updated — version bump happened.
+    let cargo = std::fs::read_to_string(dir.path().join("Cargo.toml")).unwrap();
+    assert!(cargo.contains("version = \"1.0.1\""));
+}
+
+/// dry-run with a lock file present mentions "Would sync".
+#[test]
+fn bump_dry_run_shows_would_sync() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "feat: new feature");
+
+    // Write a uv.lock so the dry-run path has something to report.
+    std::fs::write(dir.path().join("uv.lock"), "# placeholder\n").unwrap();
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Would sync"))
+        .stderr(predicate::str::contains("uv.lock"));
+}


### PR DESCRIPTION
## Summary

- After bumping version files, `git std bump` now scans the repo root for known ecosystem lock files and regenerates each one using the ecosystem's official tool.
- Lock files covered: `Cargo.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `deno.lock`, `uv.lock`, `poetry.lock`.
- `Cargo.lock` is only synced when `Cargo.toml` was actually updated (preserves existing behaviour).
- Missing tools and non-zero exits are best-effort: they emit `warning:` lines but never abort the bump.
- Dry-run mode (`--dry-run`) lists each lock file that would be synced.
- Successfully synced lock files are staged alongside version files in the release commit.

## Changes

- **new** `crates/git-std/src/cli/bump/lock_sync.rs` — `sync_lock_files` and `dry_run_lock_files` functions extracted into a focused module; 4 unit tests inline.
- **updated** `crates/git-std/src/cli/bump/mod.rs` — declares `lock_sync` submodule.
- **updated** `crates/git-std/src/cli/bump/apply.rs` — replaces the old ad-hoc Cargo.lock sync block with a call to `lock_sync::sync_lock_files`; dry-run path calls `lock_sync::dry_run_lock_files`; staging uses the returned `Vec<String>` instead of the hardcoded `"Cargo.lock"` string.
- **updated** `crates/git-std/tests/bump.rs` — 2 new integration tests: `bump_missing_tool_lock_file_warns_and_continues` and `bump_dry_run_shows_would_sync`.

## Test plan

- [ ] `just check` passes (all unit + integration tests green, clippy clean, fmt check, audit).
- [ ] `bump_missing_tool_lock_file_warns_and_continues` — creates a `uv.lock` placeholder in a temp repo, runs `bump`, verifies the bump succeeds and `Cargo.toml` is updated.
- [ ] `bump_dry_run_shows_would_sync` — creates a `uv.lock` placeholder, runs `bump --dry-run`, verifies stderr contains `Would sync` and `uv.lock`.
- [ ] Manual smoke test (optional): run `git std bump --dry-run` in a repo that has a `Cargo.lock`; verify `Would sync: Cargo.lock` appears only when `Cargo.toml` would be updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)