### PR TITLE
feat(hooks): add real-time visual feedback during hook execution (#189)

### DIFF
--- a/crates/git-std/src/cli/hooks/run.rs
+++ b/crates/git-std/src/cli/hooks/run.rs
@@ -49,10 +49,23 @@ fn format_display(command_text: &str, glob: Option<&str>) -> String {
 
 /// Execute a single hook command and print its result line.
 ///
+/// Prints a pending indicator before spawning the command. On a TTY the
+/// pending line is overwritten in place with the final result; on a
+/// non-TTY the result is printed on a new line below it.
+///
 /// Returns the [`CommandResult`] and whether the command failed (non-advisory).
-fn execute_and_print(cmd: &HookCommand, msg_path: &str) -> (CommandResult, bool) {
+fn execute_and_print(
+    cmd: &HookCommand,
+    msg_path: &str,
+    index: usize,
+    total: usize,
+) -> (CommandResult, bool) {
     let command_text = substitute_msg(&cmd.command, msg_path);
     let is_advisory = cmd.prefix == Prefix::Advisory;
+    let display = format_display(&command_text, cmd.glob.as_deref());
+
+    // Show the pending indicator before spawning.
+    ui::pending(index, total, &display);
 
     // Execute via sh -c
     let status = Command::new("sh").arg("-c").arg(&command_text).status();
@@ -63,7 +76,12 @@ fn execute_and_print(cmd: &HookCommand, msg_path: &str) -> (CommandResult, bool)
     };
 
     let success = exit_code == Some(0);
-    let display = format_display(&command_text, cmd.glob.as_deref());
+
+    // On a TTY, move the cursor back to the start of the pending line and
+    // clear it so the result line overwrites it cleanly.
+    if ui::is_tty() && yansi::is_enabled() {
+        eprint!("\r\x1b[K");
+    }
 
     // Print the result line
     if success {
@@ -132,6 +150,8 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
 
     let mut results: Vec<CommandResult> = Vec::new();
     let mut has_failure = false;
+    let total = commands.len();
+    let mut index: usize = 0;
 
     for cmd in &commands {
         // Glob filtering: skip command if glob doesn't match any files.
@@ -151,7 +171,8 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
             Prefix::Default => mode,
         };
 
-        let (result, failed) = execute_and_print(cmd, msg_path);
+        let (result, failed) = execute_and_print(cmd, msg_path, index, total);
+        index += 1;
         if failed {
             has_failure = true;
         }

--- a/crates/git-std/src/ui.rs
+++ b/crates/git-std/src/ui.rs
@@ -3,6 +3,8 @@
 //! All human-readable output goes to stderr. Symbols use
 //! yansi for colour when enabled.
 
+use std::io::IsTerminal;
+
 use yansi::Paint;
 
 /// Two-space indent for top-level output sections.
@@ -90,4 +92,23 @@ pub fn print(msg: &str) {
 /// Suitable for check/hook result lines: `  ✓ <text>` or `  ✗ <text>`.
 pub fn result_line(msg: &str) {
     eprintln!("{INDENT}{msg}");
+}
+
+/// Return `true` when stderr is connected to a terminal.
+pub fn is_tty() -> bool {
+    std::io::stderr().is_terminal()
+}
+
+/// Print a pending line for a hook command before it starts executing.
+///
+/// On TTY: prints `  [index+1/total] > display` with no trailing newline,
+/// so the caller can overwrite it with `\r\x1b[K` when the command completes.
+///
+/// Non-TTY: prints `  > display` followed by a newline (no position tracking).
+pub fn pending(index: usize, total: usize, display: &str) {
+    if is_tty() {
+        eprint!("{INDENT}[{}/{}] > {display}", index + 1, total);
+    } else {
+        eprintln!("{INDENT}> {display}");
+    }
 }

--- a/spec/snapshots/hooks/run_glob_filtering.stderr.expected
+++ b/spec/snapshots/hooks/run_glob_filtering.stderr.expected
@@ -1,1 +1,2 @@
+  > true (*.txt)
   [..] true (*.txt)

--- a/spec/snapshots/hooks/run_pass_fail_advisory.stderr.expected
+++ b/spec/snapshots/hooks/run_pass_fail_advisory.stderr.expected
@@ -1,4 +1,7 @@
+  > true
   [..] true
+  > false
   [..] false (advisory, exit 1)
+  > false
   [..] false (exit 1)
 


### PR DESCRIPTION
## Summary

- Add `ui::is_tty()` using `std::io::IsTerminal` on stderr to detect TTY context
- Add `ui::pending(index, total, display)` to print a pre-execution indicator before each hook command
- Update `execute_and_print` in `run.rs` to accept `index`/`total` and call `ui::pending` before spawning; on TTY + ANSI enabled, overwrite the pending line with `\r\x1b[K` when done
- Track executed command index in the `run()` loop and pass it alongside `total = commands.len()` to `execute_and_print`
- Update two spec snapshots to include the new `  > <command>` pending lines emitted in non-TTY mode

## Changes

| File | Change |
|---|---|
| `crates/git-std/src/ui.rs` | Add `is_tty()` and `pending()` functions |
| `crates/git-std/src/cli/hooks/run.rs` | Wire pending indicator into `execute_and_print`, add `index`/`total` tracking in `run()` |
| `spec/snapshots/hooks/run_pass_fail_advisory.stderr.expected` | Update snapshot for new pending lines |
| `spec/snapshots/hooks/run_glob_filtering.stderr.expected` | Update snapshot for new pending line |

## Behaviour

**On TTY (colour enabled):**
```
  [2/5] > cargo clippy --workspace ...   ← pending (no newline)
  ✓ cargo clippy --workspace ...         ← result overwrites pending via \r\x1b[K
```

**On TTY (`--color never`) or non-TTY:**
```
  > cargo clippy --workspace ...         ← pending line (non-TTY has newline)
  ✓ cargo clippy --workspace ...         ← result on next line
```

## Test plan

- [x] All existing spec tests pass (`just check`)
- [x] `hooks_run_pass_fail_advisory` snapshot updated to include `  > <cmd>` pending lines
- [x] `hooks_run_glob_filtering` snapshot updated to include `  > <cmd>` pending line
- [x] Zero warnings from compiler, clippy, fmt, dprint, markdownlint

🤖 Generated with [Claude Code](https://claude.com/claude-code)