### PR TITLE
fix(install): handle unbound tmp_dir in cleanup trap

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 REPO="driftsys/git-std"
 INSTALL_DIR="${GIT_STD_INSTALL_DIR:-$HOME/.local/bin}"
+tmp_dir=""
 
 die() { printf 'error: %s\n' "$1" >&2; exit 1; }
 
@@ -41,7 +42,7 @@ detect_target() {
 }
 
 main() {
-  local target version download_url tmp_dir base
+  local target version download_url base
 
   target="$(detect_target)"
   printf 'detected target: %s\n' "$target"
@@ -57,7 +58,7 @@ main() {
   printf 'downloading %s\n' "$download_url"
 
   tmp_dir="$(mktemp -d)"
-  trap 'rm -rf "$tmp_dir"' EXIT
+  trap 'rm -rf "${tmp_dir:-}"' EXIT
 
   curl -sSfL "$download_url" -o "$tmp_dir/$base.tar.gz" \
     || die "download failed — check that the release exists for $target"


### PR DESCRIPTION
## Summary

- `tmp_dir` was `local` to `main()`, so the EXIT trap fired after `main()` returned and hit an unbound variable under `set -u`
- Move `tmp_dir=""` to script-level scope so it survives past `main()`
- Use `${tmp_dir:-}` in the trap as a belt-and-suspenders guard

Closes #267

## Test plan

- [ ] `curl -fsSL .../install.sh | bash` exits 0 on success
- [ ] Trap still cleans up the temp directory
- [ ] `shellcheck install.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)