### PR TITLE
fix(hooks): preserve staged deletions in pre-commit fix mode

### DIFF
--- a/crates/git-std/src/cli/hooks/run.rs
+++ b/crates/git-std/src/cli/hooks/run.rs
@@ -56,6 +56,44 @@ fn fetch_staged_files() -> Vec<String> {
     }
 }
 
+/// Fetch the list of files staged for deletion.
+///
+/// Returns file paths with `D` status in the index (i.e. `git rm`'d files).
+/// Used by fix mode to preserve deletions across the stash dance.
+fn fetch_staged_deletions() -> Vec<String> {
+    match Command::new("git")
+        .args(["diff", "--cached", "--name-only", "--diff-filter=D"])
+        .output()
+    {
+        Ok(o) => String::from_utf8_lossy(&o.stdout)
+            .lines()
+            .map(String::from)
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Re-apply staged deletions after the stash dance.
+///
+/// Runs `git rm --cached --quiet -- <files>` to restore the deletion state
+/// in the index without touching the working tree. This undoes the effect
+/// of `stash apply` which restores deleted files.
+fn restage_deletions(files: &[String]) {
+    if files.is_empty() {
+        return;
+    }
+    let mut cmd = Command::new("git");
+    cmd.args(["rm", "--cached", "--quiet", "--force", "--"]);
+    for f in files {
+        cmd.arg(f);
+    }
+    if let Err(e) = cmd.status() {
+        ui::warning(&format!(
+            "git rm --cached failed after fix-mode stash dance: {e}"
+        ));
+    }
+}
+
 /// Fetch the list of unstaged (working-tree-modified) file paths.
 ///
 /// Returns file paths that differ between index and working tree.
@@ -258,6 +296,15 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
         ui::warning("~ prefix is only supported in pre-commit — treating as !");
     }
 
+    // Capture files staged for deletion before the stash dance.
+    // The stash dance restores deleted files to disk; we must re-delete them
+    // in the index afterwards to preserve the user's `git rm` intent (#268).
+    let staged_deletions: Vec<String> = if use_stash_dance {
+        fetch_staged_deletions()
+    } else {
+        Vec::new()
+    };
+
     // Perform the stash dance if needed.
     // stash_active tracks whether a stash entry was actually created.
     let stash_active = if use_stash_dance {
@@ -330,6 +377,7 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
             // Re-stage formatted files and clean up stash before returning.
             if use_stash_dance {
                 restage_files(&staged_files);
+                restage_deletions(&staged_deletions);
                 if stash_active {
                     stash_drop();
                 }
@@ -361,6 +409,9 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
         // was created (no stash means no unstaged changes to protect, but
         // re-staging is still needed to pick up formatter output).
         restage_files(&staged_files);
+
+        // Restore staged deletions that the stash dance may have undone (#268).
+        restage_deletions(&staged_deletions);
 
         if stash_active {
             // Warn about any unstaged files that the formatter also touched.

--- a/crates/git-std/tests/hooks.rs
+++ b/crates/git-std/tests/hooks.rs
@@ -564,6 +564,114 @@ fn hooks_run_fix_mode_non_pre_commit_failing_command_fails() {
         .code(1);
 }
 
+/// #268 — Fix mode preserves staged deletions.
+///
+/// When a file is staged for deletion (`git rm`), a `~` fix command must not
+/// undo the deletion. After the hook runs, the file should still be staged
+/// for deletion in the index.
+#[test]
+fn hooks_run_fix_mode_preserves_staged_deletions() {
+    let dir = tempfile::tempdir().unwrap();
+    init_hooks_repo(dir.path());
+
+    // Create and commit a file so we can delete it later.
+    std::fs::write(dir.path().join("to-delete.txt"), "content\n").unwrap();
+    std::fs::write(dir.path().join("to-keep.txt"), "keep\n").unwrap();
+    git(dir.path(), &["add", "to-delete.txt", "to-keep.txt"]);
+    git(dir.path(), &["commit", "-m", "initial"]);
+
+    // Stage the file for deletion.
+    git(dir.path(), &["rm", "to-delete.txt"]);
+
+    // Also stage a modification so the fix command has something to work with.
+    std::fs::write(dir.path().join("to-keep.txt"), "modified\n").unwrap();
+    git(dir.path(), &["add", "to-keep.txt"]);
+
+    let hooks_dir = dir.path().join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    // A no-op formatter that succeeds without modifying files.
+    std::fs::write(hooks_dir.join("pre-commit.hooks"), "~ true\n").unwrap();
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["--color", "never", "hooks", "run", "pre-commit"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // Verify the deletion is still staged in the index.
+    let status_output = std::process::Command::new("git")
+        .args(["diff", "--cached", "--name-only", "--diff-filter=D"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let deleted = String::from_utf8_lossy(&status_output.stdout);
+    assert!(
+        deleted.contains("to-delete.txt"),
+        "to-delete.txt should still be staged for deletion after fix-mode hook, got:\n{deleted}"
+    );
+
+    // Verify the kept file is still staged.
+    let status_output = std::process::Command::new("git")
+        .args(["diff", "--cached", "--name-only", "--diff-filter=M"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let modified = String::from_utf8_lossy(&status_output.stdout);
+    assert!(
+        modified.contains("to-keep.txt"),
+        "to-keep.txt should still be staged after fix-mode hook, got:\n{modified}"
+    );
+}
+
+/// #268 — Deleted files are not passed as $@ to fix commands.
+///
+/// Files staged for deletion should not appear in the positional parameters
+/// passed to fix-mode commands, since formatters cannot operate on deleted files.
+#[test]
+fn hooks_run_fix_mode_excludes_deleted_files_from_args() {
+    let dir = tempfile::tempdir().unwrap();
+    init_hooks_repo(dir.path());
+
+    // Create and commit files.
+    std::fs::write(dir.path().join("deleted.txt"), "gone\n").unwrap();
+    std::fs::write(dir.path().join("kept.txt"), "here\n").unwrap();
+    git(dir.path(), &["add", "deleted.txt", "kept.txt"]);
+    git(dir.path(), &["commit", "-m", "initial"]);
+
+    // Stage one for deletion, modify the other.
+    git(dir.path(), &["rm", "deleted.txt"]);
+    std::fs::write(dir.path().join("kept.txt"), "modified\n").unwrap();
+    git(dir.path(), &["add", "kept.txt"]);
+
+    let hooks_dir = dir.path().join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    // Echo $@ so we can verify which files are passed.
+    std::fs::write(hooks_dir.join("pre-commit.hooks"), "~ echo \"args: $@\"\n").unwrap();
+
+    let assert = Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["--color", "never", "hooks", "run", "pre-commit"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    // kept.txt should be in $@.
+    assert!(
+        combined.contains("kept.txt"),
+        "kept.txt should appear in $@, got:\n{combined}"
+    );
+    // deleted.txt should NOT be in $@ (already excluded by ACMR filter).
+    assert!(
+        !combined.contains("deleted.txt"),
+        "deleted.txt should not appear in $@, got:\n{combined}"
+    );
+}
+
 /// #197 — No stash dance when no `~` commands are present.
 ///
 /// A plain pre-commit hook with no `~` commands should not attempt any stash


### PR DESCRIPTION
## Summary

- Stash dance in fix mode (`~` prefix) was undoing `git rm` staged deletions — stash push cleared the deletion from the index, stash apply restored the file, and `git add` re-staged it
- Capture staged deletions (`git diff --cached --diff-filter=D`) before the stash dance
- Restore them (`git rm --cached --quiet --force`) after `restage_files()` in both normal and fail-fast paths
- 2 new integration tests covering deletion preservation and arg exclusion

Closes #268

## Test plan

- [ ] `cargo test -p git-std hooks` — all 15 hooks tests pass
- [ ] `cargo clippy` / `cargo fmt --check` clean
- [ ] Manual: `git rm` a file, commit with a `~` hook configured — deletion is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)