### PR TITLE
ci: add CI gate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,21 @@ jobs:
           chmod +x /usr/local/bin/convco
       - run: convco check ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
 
+  ci:
+    name: CI
+    if: always()
+    needs: [fmt, dprint, clippy, test, convco]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          for r in $results; do
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              exit 1
+            fi
+          done
+
   build-release:
     name: Build (${{ matrix.target }})
     if: github.event_name == 'push'


### PR DESCRIPTION
## Summary

- Branch protection requires a check named `CI`, but no job reported that name — individual jobs report as `Format`, `Clippy`, `Test`, etc.
- This blocked dependabot PRs (e.g. #271) from merging even with all checks green
- Add a summary gate job that depends on all check jobs and reports a single `CI` status

## Test plan

- [ ] This PR itself should show a `CI` check in its status checks
- [ ] Once merged, dependabot PR #271 should become mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)