### PR TITLE
fix(hooks): harden restage_deletions and deduplicate staged queries

### DIFF
--- a/crates/git-std/src/cli/hooks/run.rs
+++ b/crates/git-std/src/cli/hooks/run.rs
@@ -39,30 +39,18 @@ fn fetch_file_list(hook: &str) -> Option<Vec<String>> {
     }
 }
 
-/// Fetch the list of staged file paths (for pre-commit stash dance and $@ passing).
+/// Fetch staged file paths matching the given `--diff-filter`.
 ///
-/// Returns all staged files (added, copied, modified, renamed) relative to the
-/// working tree root. Returns an empty vec on failure.
-fn fetch_staged_files() -> Vec<String> {
+/// Returns file paths from `git diff --cached --name-only --diff-filter=<filter>`
+/// relative to the working tree root. Returns an empty vec on failure.
+fn fetch_staged(filter: &str) -> Vec<String> {
     match Command::new("git")
-        .args(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
-        .output()
-    {
-        Ok(o) => String::from_utf8_lossy(&o.stdout)
-            .lines()
-            .map(String::from)
-            .collect(),
-        Err(_) => Vec::new(),
-    }
-}
-
-/// Fetch the list of files staged for deletion.
-///
-/// Returns file paths with `D` status in the index (i.e. `git rm`'d files).
-/// Used by fix mode to preserve deletions across the stash dance.
-fn fetch_staged_deletions() -> Vec<String> {
-    match Command::new("git")
-        .args(["diff", "--cached", "--name-only", "--diff-filter=D"])
+        .args([
+            "diff",
+            "--cached",
+            "--name-only",
+            &format!("--diff-filter={filter}"),
+        ])
         .output()
     {
         Ok(o) => String::from_utf8_lossy(&o.stdout)
@@ -78,19 +66,34 @@ fn fetch_staged_deletions() -> Vec<String> {
 /// Runs `git rm --cached --quiet -- <files>` to restore the deletion state
 /// in the index without touching the working tree. This undoes the effect
 /// of `stash apply` which restores deleted files.
-fn restage_deletions(files: &[String]) {
+///
+/// Returns `true` on success, `false` if the command fails. A failure means
+/// the user's `git rm` intent would be silently lost — callers must treat
+/// this as a fatal error.
+fn restage_deletions(files: &[String]) -> bool {
     if files.is_empty() {
-        return;
+        return true;
     }
     let mut cmd = Command::new("git");
     cmd.args(["rm", "--cached", "--quiet", "--force", "--"]);
     for f in files {
         cmd.arg(f);
     }
-    if let Err(e) = cmd.status() {
-        ui::warning(&format!(
-            "git rm --cached failed after fix-mode stash dance: {e}"
-        ));
+    match cmd.status() {
+        Ok(s) if s.success() => true,
+        Ok(s) => {
+            let code = s.code().unwrap_or(-1);
+            ui::error(&format!(
+                "git rm --cached failed (exit {code}) — staged deletions may be lost"
+            ));
+            false
+        }
+        Err(e) => {
+            ui::error(&format!(
+                "git rm --cached failed after fix-mode stash dance: {e}"
+            ));
+            false
+        }
     }
 }
 
@@ -281,7 +284,7 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
 
     // For pre-commit: fetch staged files for $@ passing and stash dance.
     let staged_files: Vec<String> = if hook == "pre-commit" {
-        fetch_staged_files()
+        fetch_staged("ACMR")
     } else {
         Vec::new()
     };
@@ -300,7 +303,7 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
     // The stash dance restores deleted files to disk; we must re-delete them
     // in the index afterwards to preserve the user's `git rm` intent (#268).
     let staged_deletions: Vec<String> = if use_stash_dance {
-        fetch_staged_deletions()
+        fetch_staged("D")
     } else {
         Vec::new()
     };
@@ -377,7 +380,15 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
             // Re-stage formatted files and clean up stash before returning.
             if use_stash_dance {
                 restage_files(&staged_files);
-                restage_deletions(&staged_deletions);
+                if !restage_deletions(&staged_deletions) {
+                    // Already returning 1 for the fail-fast failure, but
+                    // ensure the stash is cleaned up before returning.
+                    if stash_active {
+                        stash_drop();
+                    }
+                    ui::blank();
+                    return 1;
+                }
                 if stash_active {
                     stash_drop();
                 }
@@ -411,7 +422,12 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
         restage_files(&staged_files);
 
         // Restore staged deletions that the stash dance may have undone (#268).
-        restage_deletions(&staged_deletions);
+        if !restage_deletions(&staged_deletions) {
+            if stash_active {
+                stash_drop();
+            }
+            return 1;
+        }
 
         if stash_active {
             // Warn about any unstaged files that the formatter also touched.

--- a/crates/git-std/tests/hooks.rs
+++ b/crates/git-std/tests/hooks.rs
@@ -702,3 +702,50 @@ fn hooks_run_no_stash_dance_without_fix_commands() {
         "no stash messages expected for hook without ~ commands, got:\n{stderr}"
     );
 }
+
+/// #268 — Fix mode preserves staged deletions on fail-fast early exit.
+///
+/// When a `~` fix command fails, the hook aborts early (fail-fast). Staged
+/// deletions must still be preserved in the index after the early exit.
+#[test]
+fn hooks_run_fix_mode_preserves_staged_deletions_on_failfast() {
+    let dir = tempfile::tempdir().unwrap();
+    init_hooks_repo(dir.path());
+
+    // Create and commit two files so we can delete one and modify the other.
+    std::fs::write(dir.path().join("to-delete.txt"), "content\n").unwrap();
+    std::fs::write(dir.path().join("to-keep.txt"), "keep\n").unwrap();
+    git(dir.path(), &["add", "to-delete.txt", "to-keep.txt"]);
+    git(dir.path(), &["commit", "-m", "initial"]);
+
+    // Stage the file for deletion.
+    git(dir.path(), &["rm", "to-delete.txt"]);
+
+    // Stage a modification so the fix command has something to work with.
+    std::fs::write(dir.path().join("to-keep.txt"), "modified\n").unwrap();
+    git(dir.path(), &["add", "to-keep.txt"]);
+
+    let hooks_dir = dir.path().join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    // A fix command that always fails — triggers fail-fast early exit.
+    std::fs::write(hooks_dir.join("pre-commit.hooks"), "~ false\n").unwrap();
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["--color", "never", "hooks", "run", "pre-commit"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1);
+
+    // Verify the deletion is still staged in the index after fail-fast.
+    let status_output = std::process::Command::new("git")
+        .args(["diff", "--cached", "--name-only", "--diff-filter=D"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let deleted = String::from_utf8_lossy(&status_output.stdout);
+    assert!(
+        deleted.contains("to-delete.txt"),
+        "to-delete.txt should still be staged for deletion after fail-fast, got:\n{deleted}"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #273 addressing review feedback:

- **P1**: `restage_deletions` now returns `bool` and propagates failure — if `git rm --cached` fails, the hook exits 1 instead of silently losing the deletion
- **P2**: Added `hooks_run_fix_mode_preserves_staged_deletions_on_failfast` test covering the fail-fast early exit path
- **P2**: Deduplicated `fetch_staged_files` and `fetch_staged_deletions` into a single `fetch_staged(filter)` helper

## Test plan

- [ ] `cargo test -p git-std` — all tests pass including new fail-fast test
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)