### PR TITLE
fix(bump): gate lock file sync on whether corresponding version file was updated

### DIFF
--- a/crates/git-std/src/cli/bump/apply.rs
+++ b/crates/git-std/src/cli/bump/apply.rs
@@ -65,30 +65,31 @@ pub(super) fn finalize_bump(
     if opts.dry_run {
         ui::blank();
 
-        let dry_cargo_updated = match standard_version::detect_version_files(workdir, &custom_files)
-        {
-            Ok(detected) if detected.is_empty() => {
-                ui::info("No version files detected");
-                false
-            }
-            Ok(detected) => {
-                ui::info("Would update:");
-                for f in &detected {
-                    let rel = f.path.strip_prefix(workdir).unwrap_or(&f.path).display();
-                    ui::item(
-                        &rel.to_string(),
-                        &format!("{} \u{2192} {new_version}", f.old_version),
-                    );
+        let updated_names: Vec<String> =
+            match standard_version::detect_version_files(workdir, &custom_files) {
+                Ok(detected) if detected.is_empty() => {
+                    ui::info("No version files detected");
+                    Vec::new()
                 }
-                detected.iter().any(|f| f.name.ends_with("Cargo.toml"))
-            }
-            Err(e) => {
-                ui::warning(&format!("cannot detect version files: {e}"));
-                false
-            }
-        };
+                Ok(detected) => {
+                    ui::info("Would update:");
+                    for f in &detected {
+                        let rel = f.path.strip_prefix(workdir).unwrap_or(&f.path).display();
+                        ui::item(
+                            &rel.to_string(),
+                            &format!("{} \u{2192} {new_version}", f.old_version),
+                        );
+                    }
+                    detected.into_iter().map(|f| f.name).collect()
+                }
+                Err(e) => {
+                    ui::warning(&format!("cannot detect version files: {e}"));
+                    Vec::new()
+                }
+            };
+        let updated_refs: Vec<&str> = updated_names.iter().map(|s| s.as_str()).collect();
 
-        lock_sync::dry_run_lock_files(workdir, dry_cargo_updated);
+        lock_sync::dry_run_lock_files(workdir, &updated_refs);
 
         if !opts.skip_changelog {
             ui::info(&format!(
@@ -121,10 +122,8 @@ pub(super) fn finalize_bump(
         };
 
     // Sync ecosystem lock files.
-    let cargo_updated = version_results
-        .iter()
-        .any(|r| r.name.ends_with("Cargo.toml"));
-    let synced_locks = lock_sync::sync_lock_files(workdir, cargo_updated);
+    let updated_names: Vec<&str> = version_results.iter().map(|r| r.name.as_str()).collect();
+    let synced_locks = lock_sync::sync_lock_files(workdir, &updated_names);
 
     // Generate/update changelog.
     if !opts.skip_changelog {

--- a/crates/git-std/src/cli/bump/lock_sync.rs
+++ b/crates/git-std/src/cli/bump/lock_sync.rs
@@ -8,10 +8,14 @@ use std::path::Path;
 
 use crate::ui;
 
-/// A known lock file entry: filename, sync args, and the required tool.
+/// A known lock file entry: filename, the version file that triggers sync,
+/// and the tool + args used to regenerate the lock file.
 struct LockEntry {
     /// Lock file name to look for at the repo root.
     filename: &'static str,
+    /// Version file name that must have been updated to trigger this sync.
+    /// Matched via `ends_with` so `crates/foo/Cargo.toml` matches `"Cargo.toml"`.
+    trigger: &'static str,
     /// Command name of the required tool (also used for PATH lookup).
     tool: &'static str,
     /// Arguments to pass to the tool.
@@ -21,65 +25,66 @@ struct LockEntry {
 /// All lock files git-std knows how to sync.
 const LOCK_ENTRIES: &[LockEntry] = &[
     LockEntry {
+        filename: "Cargo.lock",
+        trigger: "Cargo.toml",
+        tool: "cargo",
+        args: &["update", "--workspace"],
+    },
+    LockEntry {
         filename: "package-lock.json",
+        trigger: "package.json",
         tool: "npm",
         args: &["install", "--package-lock-only"],
     },
     LockEntry {
         filename: "yarn.lock",
+        trigger: "package.json",
         tool: "yarn",
         args: &["install", "--mode", "update-lockfile"],
     },
     LockEntry {
         filename: "pnpm-lock.yaml",
+        trigger: "package.json",
         tool: "pnpm",
         args: &["install", "--lockfile-only"],
     },
     LockEntry {
         filename: "deno.lock",
+        trigger: "deno.json",
         tool: "deno",
         args: &["install"],
     },
     LockEntry {
         filename: "uv.lock",
+        trigger: "pyproject.toml",
         tool: "uv",
         args: &["lock"],
     },
     LockEntry {
         filename: "poetry.lock",
+        trigger: "pyproject.toml",
         tool: "poetry",
         args: &["lock", "--no-update"],
     },
 ];
 
-/// Sync all ecosystem lock files found at `workdir`.
+/// Sync ecosystem lock files found at `workdir` whose trigger was updated.
 ///
-/// `cargo_updated` indicates whether `Cargo.toml` was part of the version
-/// bump; `Cargo.lock` is only synced in that case.
+/// `updated_names` lists the version file names that were part of the bump
+/// (e.g. `"Cargo.toml"`, `"crates/foo/Cargo.toml"`, `"package.json"`).
+/// A lock entry is only synced when at least one updated name ends with the
+/// entry's trigger AND the lock file exists on disk.
 ///
 /// Returns the list of lock file names that were successfully synced, for
 /// staging alongside the version files.
-pub(super) fn sync_lock_files(workdir: &Path, cargo_updated: bool) -> Vec<String> {
+pub(super) fn sync_lock_files(workdir: &Path, updated_names: &[&str]) -> Vec<String> {
     let mut synced = Vec::new();
 
-    // Handle Cargo.lock specially: only sync when Cargo.toml was updated.
-    if cargo_updated {
-        let cargo_lock = workdir.join("Cargo.lock");
-        if cargo_lock.exists() {
-            run_sync(
-                workdir,
-                "Cargo.lock",
-                "cargo",
-                &["update", "--workspace"],
-                &mut synced,
-            );
-        }
-    }
-
-    // All other lock files.
     for entry in LOCK_ENTRIES {
-        let path = workdir.join(entry.filename);
-        if path.exists() {
+        let triggered = updated_names
+            .iter()
+            .any(|name| name.ends_with(entry.trigger));
+        if triggered && workdir.join(entry.filename).exists() {
             run_sync(workdir, entry.filename, entry.tool, entry.args, &mut synced);
         }
     }
@@ -89,14 +94,13 @@ pub(super) fn sync_lock_files(workdir: &Path, cargo_updated: bool) -> Vec<String
 
 /// Emit dry-run messages for all lock files that would be synced.
 ///
-/// `cargo_updated` indicates whether `Cargo.toml` would have been updated.
-pub(super) fn dry_run_lock_files(workdir: &Path, cargo_updated: bool) {
-    if cargo_updated && workdir.join("Cargo.lock").exists() {
-        ui::info("Would sync:   Cargo.lock");
-    }
-
+/// `updated_names` lists the version file names that would have been updated.
+pub(super) fn dry_run_lock_files(workdir: &Path, updated_names: &[&str]) {
     for entry in LOCK_ENTRIES {
-        if workdir.join(entry.filename).exists() {
+        let triggered = updated_names
+            .iter()
+            .any(|name| name.ends_with(entry.trigger));
+        if triggered && workdir.join(entry.filename).exists() {
             ui::info(&format!("Would sync:   {}", entry.filename));
         }
     }
@@ -143,35 +147,45 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         // Should not panic or emit anything meaningful — we can't assert stderr
         // easily in unit tests, but we verify it doesn't crash.
-        dry_run_lock_files(dir.path(), false);
-        dry_run_lock_files(dir.path(), true);
+        dry_run_lock_files(dir.path(), &[]);
+        dry_run_lock_files(dir.path(), &["Cargo.toml"]);
     }
 
     /// sync_lock_files returns empty vec when no lock files are present.
     #[test]
     fn sync_no_lock_files() {
         let dir = tempfile::tempdir().unwrap();
-        let synced = sync_lock_files(dir.path(), false);
+        let synced = sync_lock_files(dir.path(), &[]);
         assert!(synced.is_empty());
     }
 
-    /// Cargo.lock is not synced when cargo_updated is false, even if file exists.
+    /// Cargo.lock is not synced when Cargo.toml was not updated, even if file exists.
     #[test]
     fn cargo_lock_skipped_when_not_updated() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("Cargo.lock"), "# placeholder\n").unwrap();
-        let synced = sync_lock_files(dir.path(), false);
-        // We don't expect Cargo.lock to be attempted (cargo_updated=false).
+        let synced = sync_lock_files(dir.path(), &[]);
+        // We don't expect Cargo.lock to be attempted (no trigger matched).
         assert!(!synced.contains(&"Cargo.lock".to_string()));
     }
 
-    /// dry_run_lock_files mentions Cargo.lock only when cargo_updated is true.
+    /// dry_run_lock_files mentions Cargo.lock only when Cargo.toml is in updated_names.
     #[test]
     fn dry_run_cargo_lock_conditional() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("Cargo.lock"), "# placeholder\n").unwrap();
         // Just verify no panic — stderr assertions covered by integration tests.
-        dry_run_lock_files(dir.path(), false);
-        dry_run_lock_files(dir.path(), true);
+        dry_run_lock_files(dir.path(), &[]);
+        dry_run_lock_files(dir.path(), &["Cargo.toml"]);
+    }
+
+    /// Lock files are not synced when their trigger version file was not updated.
+    #[test]
+    fn lock_file_skipped_when_trigger_not_updated() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("uv.lock"), "# placeholder\n").unwrap();
+        // No pyproject.toml in updated_names → uv.lock should not be synced.
+        let synced = sync_lock_files(dir.path(), &["Cargo.toml"]);
+        assert!(!synced.contains(&"uv.lock".to_string()));
     }
 }

--- a/crates/git-std/tests/bump.rs
+++ b/crates/git-std/tests/bump.rs
@@ -475,6 +475,21 @@ fn bump_missing_tool_lock_file_warns_and_continues() {
     let dir = tempfile::tempdir().unwrap();
     init_bump_repo(dir.path());
     create_tag(dir.path(), "v1.0.0");
+
+    // Write a pyproject.toml so the trigger for uv.lock is satisfied.
+    std::fs::write(
+        dir.path().join("pyproject.toml"),
+        "[project]\nname = \"test\"\nversion = \"1.0.0\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join(".git-std.toml"),
+        "[[version_files]]\npath = \"pyproject.toml\"\nregex = 'version = \"([^\"]+)\"'\n",
+    )
+    .unwrap();
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-m", "chore: add pyproject"]);
+
     add_commit(dir.path(), "a.txt", "fix: small fix");
 
     // Write a uv.lock — `uv` is very unlikely to be installed in CI.
@@ -500,6 +515,21 @@ fn bump_dry_run_shows_would_sync() {
     let dir = tempfile::tempdir().unwrap();
     init_bump_repo(dir.path());
     create_tag(dir.path(), "v1.0.0");
+
+    // Write a pyproject.toml so the trigger for uv.lock is satisfied.
+    std::fs::write(
+        dir.path().join("pyproject.toml"),
+        "[project]\nname = \"test\"\nversion = \"1.0.0\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join(".git-std.toml"),
+        "[[version_files]]\npath = \"pyproject.toml\"\nregex = 'version = \"([^\"]+)\"'\n",
+    )
+    .unwrap();
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-m", "chore: add pyproject"]);
+
     add_commit(dir.path(), "a.txt", "feat: new feature");
 
     // Write a uv.lock so the dry-run path has something to report.
@@ -513,4 +543,25 @@ fn bump_dry_run_shows_would_sync() {
         .success()
         .stderr(predicate::str::contains("Would sync"))
         .stderr(predicate::str::contains("uv.lock"));
+}
+
+/// dry-run with a lock file present does NOT mention "Would sync" when the
+/// trigger version file is not in the version_files list.
+#[test]
+fn bump_dry_run_skips_untriggered_lock_file() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "feat: new feature");
+
+    // Write a uv.lock on disk but NO pyproject.toml in version_files.
+    std::fs::write(dir.path().join("uv.lock"), "# placeholder\n").unwrap();
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Would sync:   uv.lock").not());
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -309,15 +309,15 @@ changelog, commit, and tag.
    entries pointing to subdirectory paths (e.g.
    `crates/my-crate/Cargo.toml`) are detected correctly.
 
-   | Version file     | Lock file           | Sync command                            |
-   | ---------------- | ------------------- | --------------------------------------- |
-   | `Cargo.toml`     | `Cargo.lock`        | `cargo update --workspace`              |
-   | `package.json`   | `package-lock.json` | `npm install --package-lock-only`       |
-   | `package.json`   | `yarn.lock`         | `yarn install --mode update-lockfile`   |
-   | `package.json`   | `pnpm-lock.yaml`    | `pnpm install --lockfile-only`          |
-   | `deno.json`      | `deno.lock`         | `deno install`                          |
-   | `pyproject.toml` | `uv.lock`           | `uv lock`                               |
-   | `pyproject.toml` | `poetry.lock`       | `poetry lock --no-update`               |
+   | Version file     | Lock file           | Sync command                          |
+   | ---------------- | ------------------- | ------------------------------------- |
+   | `Cargo.toml`     | `Cargo.lock`        | `cargo update --workspace`            |
+   | `package.json`   | `package-lock.json` | `npm install --package-lock-only`     |
+   | `package.json`   | `yarn.lock`         | `yarn install --mode update-lockfile` |
+   | `package.json`   | `pnpm-lock.yaml`    | `pnpm install --lockfile-only`        |
+   | `deno.json`      | `deno.lock`         | `deno install`                        |
+   | `pyproject.toml` | `uv.lock`           | `uv lock`                             |
+   | `pyproject.toml` | `poetry.lock`       | `poetry lock --no-update`             |
 
 9. Generate changelog section for this release via `standard-changelog`.
 10. Prepend the section to `CHANGELOG.md`.


### PR DESCRIPTION
## Summary

Epic: #289

Lock file sync was firing unconditionally for non-Cargo ecosystems. Now
each lock file only syncs when its corresponding version file was part
of the bump:

| Trigger version file | Lock files synced |
|---|---|
| `Cargo.toml` | `Cargo.lock` |
| `package.json` | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` |
| `deno.json` | `deno.lock` |
| `pyproject.toml` | `uv.lock`, `poetry.lock` |

- Added `trigger` field to `LockEntry`
- Moved Cargo.lock into `LOCK_ENTRIES` (no more special case)
- Changed `sync_lock_files` / `dry_run_lock_files` to accept `&[&str]` of updated names
- Gating uses `ends_with` so workspace paths like `crates/foo/Cargo.toml` match

Closes #290

## Test plan

- [x] `cargo test --all` — all pass
- [x] `cargo clippy --all-targets --all-features` — zero warnings
- [x] `cargo fmt -- --check` — pass
- [x] New test: `bump_dry_run_skips_untriggered_lock_file` — verifies lock file NOT synced when trigger absent
- [x] Updated existing lock sync tests for new signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)