### PR TITLE
feat(git-std): add bootstrap subcommand for post-clone setup

### DIFF
--- a/.githooks/bootstrap.hooks
+++ b/.githooks/bootstrap.hooks
@@ -1,0 +1,13 @@
+# git-std hooks — bootstrap.hooks
+#
+# Commands run by `git std bootstrap` after built-in checks.
+# Prefix controls behavior:
+#
+#   !  required   fail bootstrap on failure
+#   ?  advisory   run command, never fail bootstrap
+#
+# Examples:
+#   ! npm install          # install dependencies
+#   ! pip install -r requirements.txt
+#   ? pre-commit install   # optional tool setup
+#

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Library crates are pure — no git2, no I/O, no terminal output — except
 `standard-version`, which performs file I/O for version file detection and
 updates.
 
-**Six subcommands**, each a separate concern:
+**Seven subcommands**, each a separate concern:
 
 | Subcommand            | Purpose                                                |
 | --------------------- | ------------------------------------------------------ |
@@ -51,6 +51,7 @@ updates.
 | `git std check`       | Commit message validation                              |
 | `git std bump`        | Version bump + changelog + commit + tag                |
 | `git std changelog`   | Changelog generation (incremental or full)             |
+| `git std bootstrap`   | Post-clone environment setup                           |
 | `git std hooks`       | Git hooks management (install/run/list/enable/disable) |
 | `git std completions` | Generate shell completion scripts                      |
 
@@ -161,3 +162,9 @@ when they reflect a genuine concern, but keep each module focused and small.
     use ANSI escape codes directly. Respect `NO_COLOR`.
 - **Comments:** doc comments on all public API items, brief inline comments on
   tricky internals only.
+
+<!-- git-std:bootstrap -->
+
+## Post-clone setup
+
+Run `./bootstrap` after `git clone` or `git worktree add`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ You need the Rust toolchain and a few extra tools:
 # Clone and build
 git clone https://github.com/driftsys/git-std.git
 cd git-std
+./bootstrap          # post-clone setup (optional, requires git-std)
 just build
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ cargo install git-std
 
 ```bash
 git std hooks install                # set up hooks
+git std bootstrap install            # scaffold ./bootstrap for contributors
 git add .
 git std commit                       # interactive commit
 git std check --range main..HEAD     # validate commits
@@ -95,3 +96,9 @@ MIT
 [standard-version]: crates/standard-version/
 [standard-changelog]: crates/standard-changelog/
 [standard-githooks]: crates/standard-githooks/
+
+<!-- git-std:bootstrap -->
+
+## Post-clone setup
+
+Run `./bootstrap` after `git clone` or `git worktree add`.

--- a/bootstrap
+++ b/bootstrap
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Minimum git-std version required by this project.
+MIN_VERSION="0.4.2"
+REPO="driftsys/git-std"
+INSTALL_DIR="${GIT_STD_INSTALL_DIR:-$HOME/.local/bin}"
+
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+sha256_check() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "$1"
+  else
+    shasum -a 256 -c "$1"
+  fi
+}
+
+detect_target() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os" in
+    Linux)
+      case "$arch" in
+        x86_64)  echo "x86_64-unknown-linux-gnu" ;;
+        aarch64) echo "aarch64-unknown-linux-gnu" ;;
+        *)       die "unsupported architecture: $arch" ;;
+      esac
+      ;;
+    Darwin)
+      case "$arch" in
+        x86_64)  echo "x86_64-apple-darwin" ;;
+        arm64)   echo "aarch64-apple-darwin" ;;
+        *)       die "unsupported architecture: $arch" ;;
+      esac
+      ;;
+    *)
+      die "unsupported OS: $os (use WSL on Windows)"
+      ;;
+  esac
+}
+
+# Compare two semver strings. Returns 0 if $1 >= $2, 1 otherwise.
+version_gte() {
+  local IFS=.
+  local i a=($1) b=($2)
+  for ((i = 0; i < 3; i++)); do
+    local ai="${a[i]:-0}" bi="${b[i]:-0}"
+    if ((ai > bi)); then return 0; fi
+    if ((ai < bi)); then return 1; fi
+  done
+  return 0
+}
+
+ensure_git_std() {
+  if command -v git-std >/dev/null 2>&1; then
+    local current
+    current="$(git-std --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+    if version_gte "$current" "$MIN_VERSION"; then
+      return 0
+    fi
+    printf 'git-std %s found, need >= %s — upgrading\n' "$current" "$MIN_VERSION"
+  else
+    printf 'git-std not found — installing\n'
+  fi
+
+  local target base download_url version tmp_dir
+  target="$(detect_target)"
+
+  version="$(curl -sSf "https://api.github.com/repos/$REPO/releases/latest" \
+    | grep '"tag_name"' | head -1 | cut -d'"' -f4)"
+  [ -n "$version" ] || die "could not determine latest release"
+
+  base="git-std-$target"
+  download_url="https://github.com/$REPO/releases/download/$version/$base.tar.gz"
+  printf 'downloading %s\n' "$download_url"
+
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "${tmp_dir:-}"' EXIT
+
+  curl -sSfL "$download_url" -o "$tmp_dir/$base.tar.gz" \
+    || die "download failed — check that the release exists for $target"
+  curl -sSfL "$download_url.sha256" -o "$tmp_dir/$base.tar.gz.sha256" \
+    || die "checksum download failed"
+
+  (cd "$tmp_dir" && sha256_check "$base.tar.gz.sha256") \
+    || die "checksum verification failed"
+
+  tar -xzf "$tmp_dir/$base.tar.gz" -C "$tmp_dir"
+
+  mkdir -p "$INSTALL_DIR"
+  mv "$tmp_dir/git-std" "$INSTALL_DIR/git-std"
+  chmod +x "$INSTALL_DIR/git-std"
+
+  printf 'installed git-std %s to %s/git-std\n' "$version" "$INSTALL_DIR"
+}
+
+ensure_git_std
+exec git std bootstrap

--- a/crates/git-std/src/cli/bootstrap.rs
+++ b/crates/git-std/src/cli/bootstrap.rs
@@ -1,0 +1,550 @@
+//! `git std bootstrap` — post-clone environment setup.
+//!
+//! Two entry points:
+//! - `run(dry_run)` — detect convention files and configure the local environment.
+//! - `install(force)` — scaffold `./bootstrap` and `.githooks/bootstrap.hooks`.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::ui;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BOOTSTRAP_HOOKS_FILE: &str = ".githooks/bootstrap.hooks";
+const BOOTSTRAP_SCRIPT: &str = "bootstrap";
+const MARKER: &str = "<!-- git-std:bootstrap -->";
+const LFS_INSTALL_URL: &str = "https://git-lfs.github.com";
+
+// ---------------------------------------------------------------------------
+// git std bootstrap (run)
+// ---------------------------------------------------------------------------
+
+/// Run the built-in bootstrap checks and any custom `bootstrap.hooks`.
+///
+/// Returns the process exit code (`0` success, `1` failure).
+pub fn run(dry_run: bool) -> i32 {
+    let mut failed = false;
+
+    // Tier 1 — built-in checks
+    if !check_hooks_path(dry_run) {
+        failed = true;
+    }
+    if !check_lfs(dry_run) {
+        return 1; // hard failure — git-lfs missing
+    }
+    if !check_blame_ignore_revs(dry_run) {
+        failed = true;
+    }
+
+    // Tier 2 — custom bootstrap.hooks
+    if Path::new(BOOTSTRAP_HOOKS_FILE).exists() {
+        if dry_run {
+            ui::result_line(&format!(
+                "{}  would run {}",
+                ui::pass(),
+                BOOTSTRAP_HOOKS_FILE
+            ));
+        } else {
+            let code = super::hooks::run("bootstrap", &[]);
+            if code != 0 {
+                failed = true;
+            }
+        }
+    }
+
+    if failed { 1 } else { 0 }
+}
+
+/// Detect `.githooks/` and set `core.hooksPath`.
+fn check_hooks_path(dry_run: bool) -> bool {
+    let hooks_dir = Path::new(".githooks");
+    if !hooks_dir.exists() {
+        ui::result_line(&format!(
+            "{}  .githooks/ not found, skipping hooksPath",
+            ui::pass()
+        ));
+        return true;
+    }
+
+    if dry_run {
+        ui::result_line(&format!(
+            "{}  would set core.hooksPath → .githooks",
+            ui::pass()
+        ));
+        return true;
+    }
+
+    let status = Command::new("git")
+        .args(["config", "core.hooksPath", ".githooks"])
+        .status();
+
+    match status {
+        Ok(s) if s.success() => {
+            ui::result_line(&format!("{}  core.hooksPath → .githooks", ui::pass()));
+            true
+        }
+        _ => {
+            ui::error("failed to set core.hooksPath");
+            false
+        }
+    }
+}
+
+/// Detect `filter=lfs` in `.gitattributes` and run LFS setup.
+///
+/// Returns `false` only when LFS rules are detected but `git-lfs` is not
+/// installed — this is a hard failure (exit 1).
+fn check_lfs(dry_run: bool) -> bool {
+    let attrs = Path::new(".gitattributes");
+    if !attrs.exists() {
+        ui::result_line(&format!(
+            "{}  .gitattributes not found, skipping LFS",
+            ui::pass()
+        ));
+        return true;
+    }
+
+    let content = match std::fs::read_to_string(attrs) {
+        Ok(c) => c,
+        Err(e) => {
+            ui::error(&format!("cannot read .gitattributes: {e}"));
+            return false;
+        }
+    };
+
+    if !content.lines().any(|line| line.contains("filter=lfs")) {
+        ui::result_line(&format!(
+            "{}  no LFS rules in .gitattributes, skipping",
+            ui::pass()
+        ));
+        return true;
+    }
+
+    // LFS rules detected — check if git-lfs is installed
+    let lfs_available = Command::new("git")
+        .args(["lfs", "version"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    if !lfs_available {
+        ui::error("git-lfs is required but not installed");
+        ui::hint(&format!("install from {LFS_INSTALL_URL}"));
+        return false;
+    }
+
+    if dry_run {
+        ui::result_line(&format!(
+            "{}  would run git lfs install + git lfs pull",
+            ui::pass()
+        ));
+        return true;
+    }
+
+    // Run git lfs install
+    let install_ok = Command::new("git")
+        .args(["lfs", "install"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if !install_ok {
+        ui::error("git lfs install failed");
+        return false;
+    }
+
+    // Run git lfs pull
+    let pull_ok = Command::new("git")
+        .args(["lfs", "pull"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if !pull_ok {
+        ui::error("git lfs pull failed");
+        return false;
+    }
+
+    ui::result_line(&format!("{}  git lfs install + pull", ui::pass()));
+    true
+}
+
+/// Detect `.git-blame-ignore-revs` and set `blame.ignoreRevsFile`.
+fn check_blame_ignore_revs(dry_run: bool) -> bool {
+    let path = Path::new(".git-blame-ignore-revs");
+    if !path.exists() {
+        ui::result_line(&format!(
+            "{}  .git-blame-ignore-revs not found, skipping",
+            ui::pass()
+        ));
+        return true;
+    }
+
+    if dry_run {
+        ui::result_line(&format!(
+            "{}  would set blame.ignoreRevsFile → .git-blame-ignore-revs",
+            ui::pass()
+        ));
+        return true;
+    }
+
+    let status = Command::new("git")
+        .args(["config", "blame.ignoreRevsFile", ".git-blame-ignore-revs"])
+        .status();
+
+    match status {
+        Ok(s) if s.success() => {
+            ui::result_line(&format!(
+                "{}  blame.ignoreRevsFile → .git-blame-ignore-revs",
+                ui::pass()
+            ));
+            true
+        }
+        _ => {
+            ui::error("failed to set blame.ignoreRevsFile");
+            false
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// git std bootstrap install
+// ---------------------------------------------------------------------------
+
+/// Generate `./bootstrap` script and `.githooks/bootstrap.hooks` template.
+///
+/// Returns the process exit code (`0` success, `1` failure).
+pub fn install(force: bool) -> i32 {
+    let mut created = Vec::new();
+    let mut skipped = Vec::new();
+
+    // 1. Generate ./bootstrap
+    match write_bootstrap_script(force) {
+        FileResult::Created => created.push(BOOTSTRAP_SCRIPT),
+        FileResult::Skipped => skipped.push(BOOTSTRAP_SCRIPT),
+        FileResult::Error => return 1,
+    }
+
+    // 2. Generate .githooks/bootstrap.hooks
+    if let Err(e) = std::fs::create_dir_all(".githooks") {
+        ui::error(&format!("cannot create .githooks/: {e}"));
+        return 1;
+    }
+    match write_bootstrap_hooks(force) {
+        FileResult::Created => created.push(BOOTSTRAP_HOOKS_FILE),
+        FileResult::Skipped => skipped.push(BOOTSTRAP_HOOKS_FILE),
+        FileResult::Error => return 1,
+    }
+
+    // 3. Append post-clone reminder to AGENTS.md and README.md
+    let mut modified_docs: Vec<&str> = Vec::new();
+    for doc in &["AGENTS.md", "README.md"] {
+        if Path::new(doc).exists()
+            && let Err(e) = append_bootstrap_marker(doc)
+        {
+            ui::error(&format!("cannot update {doc}: {e}"));
+            return 1;
+        }
+        if Path::new(doc).exists() {
+            modified_docs.push(doc);
+        }
+    }
+
+    // 4. Stage all created/modified files so the executable bit is tracked
+    let mut stage_files: Vec<&str> = created.to_vec();
+    stage_files.extend(modified_docs);
+    if !stage_files.is_empty() {
+        let mut cmd = Command::new("git");
+        cmd.arg("add").arg("--");
+        for f in &stage_files {
+            cmd.arg(f);
+        }
+        if let Err(e) = cmd.status() {
+            ui::warning(&format!("git add failed: {e} — stage files manually"));
+        }
+    }
+
+    // Print summary
+    ui::blank();
+    for path in &created {
+        ui::result_line(&format!("{}  created {path}", ui::pass()));
+    }
+    for path in &skipped {
+        ui::result_line(&format!(
+            "{}  skipped {path} (already exists, use --force to overwrite)",
+            ui::pass()
+        ));
+    }
+
+    0
+}
+
+enum FileResult {
+    Created,
+    Skipped,
+    Error,
+}
+
+/// Write the `./bootstrap` shell wrapper.
+fn write_bootstrap_script(force: bool) -> FileResult {
+    let path = Path::new(BOOTSTRAP_SCRIPT);
+    if path.exists() && !force {
+        return FileResult::Skipped;
+    }
+
+    let script = generate_bootstrap_script();
+    if let Err(e) = std::fs::write(path, &script) {
+        ui::error(&format!("cannot write {BOOTSTRAP_SCRIPT}: {e}"));
+        return FileResult::Error;
+    }
+
+    // Make executable
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o755);
+        if let Err(e) = std::fs::set_permissions(path, perms) {
+            ui::error(&format!(
+                "cannot set permissions on {BOOTSTRAP_SCRIPT}: {e}"
+            ));
+            return FileResult::Error;
+        }
+    }
+
+    FileResult::Created
+}
+
+/// Write `.githooks/bootstrap.hooks` template.
+fn write_bootstrap_hooks(force: bool) -> FileResult {
+    let path = Path::new(BOOTSTRAP_HOOKS_FILE);
+    if path.exists() && !force {
+        return FileResult::Skipped;
+    }
+
+    let has_lfs = Path::new(".gitattributes")
+        .exists()
+        .then(|| std::fs::read_to_string(".gitattributes").unwrap_or_default())
+        .map(|c| c.lines().any(|l| l.contains("filter=lfs")))
+        .unwrap_or(false);
+
+    let template = generate_bootstrap_hooks_template(has_lfs);
+    if let Err(e) = std::fs::write(path, &template) {
+        ui::error(&format!("cannot write {BOOTSTRAP_HOOKS_FILE}: {e}"));
+        return FileResult::Error;
+    }
+
+    FileResult::Created
+}
+
+/// Append a post-clone reminder to a documentation file, idempotently.
+fn append_bootstrap_marker(path: &str) -> std::io::Result<()> {
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    if content.contains(MARKER) {
+        return Ok(());
+    }
+
+    use std::io::Write;
+    let note = format!(
+        "\n{MARKER}\n\
+         ## Post-clone setup\n\
+         \n\
+         Run `./bootstrap` after `git clone` or `git worktree add`.\n"
+    );
+    let mut file = std::fs::OpenOptions::new().append(true).open(path)?;
+    file.write_all(note.as_bytes())
+}
+
+// ---------------------------------------------------------------------------
+// Generated content
+// ---------------------------------------------------------------------------
+
+/// Generate the `./bootstrap` bash script content.
+fn generate_bootstrap_script() -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    format!(
+        r##"#!/usr/bin/env bash
+set -euo pipefail
+
+# Minimum git-std version required by this project.
+MIN_VERSION="{version}"
+REPO="driftsys/git-std"
+INSTALL_DIR="${{GIT_STD_INSTALL_DIR:-$HOME/.local/bin}}"
+
+die() {{ printf 'error: %s\n' "$1" >&2; exit 1; }}
+
+sha256_check() {{
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "$1"
+  else
+    shasum -a 256 -c "$1"
+  fi
+}}
+
+detect_target() {{
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os" in
+    Linux)
+      case "$arch" in
+        x86_64)  echo "x86_64-unknown-linux-gnu" ;;
+        aarch64) echo "aarch64-unknown-linux-gnu" ;;
+        *)       die "unsupported architecture: $arch" ;;
+      esac
+      ;;
+    Darwin)
+      case "$arch" in
+        x86_64)  echo "x86_64-apple-darwin" ;;
+        arm64)   echo "aarch64-apple-darwin" ;;
+        *)       die "unsupported architecture: $arch" ;;
+      esac
+      ;;
+    *)
+      die "unsupported OS: $os (use WSL on Windows)"
+      ;;
+  esac
+}}
+
+# Compare two semver strings. Returns 0 if $1 >= $2, 1 otherwise.
+version_gte() {{
+  local IFS=.
+  local i a=($1) b=($2)
+  for ((i = 0; i < 3; i++)); do
+    local ai="${{a[i]:-0}}" bi="${{b[i]:-0}}"
+    if ((ai > bi)); then return 0; fi
+    if ((ai < bi)); then return 1; fi
+  done
+  return 0
+}}
+
+ensure_git_std() {{
+  if command -v git-std >/dev/null 2>&1; then
+    local current
+    current="$(git-std --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+    if version_gte "$current" "$MIN_VERSION"; then
+      return 0
+    fi
+    printf 'git-std %s found, need >= %s — upgrading\n' "$current" "$MIN_VERSION"
+  else
+    printf 'git-std not found — installing\n'
+  fi
+
+  local target base download_url version tmp_dir
+  target="$(detect_target)"
+
+  version="$(curl -sSf "https://api.github.com/repos/$REPO/releases/latest" \
+    | grep '"tag_name"' | head -1 | cut -d'"' -f4)"
+  [ -n "$version" ] || die "could not determine latest release"
+
+  base="git-std-$target"
+  download_url="https://github.com/$REPO/releases/download/$version/$base.tar.gz"
+  printf 'downloading %s\n' "$download_url"
+
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "${{tmp_dir:-}}"' EXIT
+
+  curl -sSfL "$download_url" -o "$tmp_dir/$base.tar.gz" \
+    || die "download failed — check that the release exists for $target"
+  curl -sSfL "$download_url.sha256" -o "$tmp_dir/$base.tar.gz.sha256" \
+    || die "checksum download failed"
+
+  (cd "$tmp_dir" && sha256_check "$base.tar.gz.sha256") \
+    || die "checksum verification failed"
+
+  tar -xzf "$tmp_dir/$base.tar.gz" -C "$tmp_dir"
+
+  mkdir -p "$INSTALL_DIR"
+  mv "$tmp_dir/git-std" "$INSTALL_DIR/git-std"
+  chmod +x "$INSTALL_DIR/git-std"
+
+  printf 'installed git-std %s to %s/git-std\n' "$version" "$INSTALL_DIR"
+}}
+
+ensure_git_std
+exec git std bootstrap
+"##
+    )
+}
+
+/// Generate the `.githooks/bootstrap.hooks` template.
+fn generate_bootstrap_hooks_template(has_lfs: bool) -> String {
+    let lfs_example = if has_lfs {
+        "# LFS detected — uncomment to pull large files:\n\
+         # ! git lfs pull\n\
+         #\n"
+    } else {
+        ""
+    };
+
+    format!(
+        "# git-std hooks — bootstrap.hooks\n\
+         #\n\
+         # Commands run by `git std bootstrap` after built-in checks.\n\
+         # Prefix controls behavior:\n\
+         #\n\
+         #   !  required   fail bootstrap on failure\n\
+         #   ?  advisory   run command, never fail bootstrap\n\
+         #\n\
+         # Examples:\n\
+         #   ! npm install          # install dependencies\n\
+         #   ! pip install -r requirements.txt\n\
+         #   ? pre-commit install   # optional tool setup\n\
+         #\n\
+         {lfs_example}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bootstrap_script_contains_min_version() {
+        let script = generate_bootstrap_script();
+        let version = env!("CARGO_PKG_VERSION");
+        assert!(script.contains(&format!("MIN_VERSION=\"{version}\"")));
+    }
+
+    #[test]
+    fn bootstrap_script_starts_with_shebang() {
+        let script = generate_bootstrap_script();
+        assert!(script.starts_with("#!/usr/bin/env bash"));
+    }
+
+    #[test]
+    fn bootstrap_script_delegates_to_git_std() {
+        let script = generate_bootstrap_script();
+        assert!(script.contains("exec git std bootstrap"));
+    }
+
+    #[test]
+    fn bootstrap_hooks_template_has_header() {
+        let t = generate_bootstrap_hooks_template(false);
+        assert!(t.contains("bootstrap.hooks"));
+        assert!(t.contains("!  required"));
+        assert!(t.contains("?  advisory"));
+    }
+
+    #[test]
+    fn bootstrap_hooks_template_includes_lfs_when_detected() {
+        let t = generate_bootstrap_hooks_template(true);
+        assert!(t.contains("LFS detected"));
+        assert!(t.contains("git lfs pull"));
+    }
+
+    #[test]
+    fn bootstrap_hooks_template_no_lfs_when_absent() {
+        let t = generate_bootstrap_hooks_template(false);
+        assert!(!t.contains("LFS detected"));
+    }
+
+    #[test]
+    fn marker_is_html_comment() {
+        assert!(MARKER.starts_with("<!--"));
+        assert!(MARKER.ends_with("-->"));
+    }
+}

--- a/crates/git-std/src/cli/mod.rs
+++ b/crates/git-std/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod bootstrap;
 pub mod bump;
 pub mod changelog;
 pub mod check;

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -129,6 +129,14 @@ enum Command {
         #[arg(long)]
         range: Option<String>,
     },
+    /// Post-clone environment setup.
+    Bootstrap {
+        #[command(subcommand)]
+        subcommand: Option<BootstrapCommand>,
+        /// Print what would be done without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Git hooks management.
     Hooks {
         #[command(subcommand)]
@@ -143,6 +151,17 @@ enum Command {
     Completions {
         /// Target shell.
         shell: Shell,
+    },
+}
+
+/// Bootstrap subcommands.
+#[derive(Subcommand)]
+enum BootstrapCommand {
+    /// Generate bootstrap script and hooks template.
+    Install {
+        /// Overwrite existing files.
+        #[arg(long)]
+        force: bool,
     },
 }
 
@@ -309,6 +328,16 @@ fn main() {
                 minor,
             };
             let code = cli::bump::run(&project_config, &opts);
+            std::process::exit(code);
+        }
+        Command::Bootstrap {
+            subcommand,
+            dry_run,
+        } => {
+            let code = match subcommand {
+                Some(BootstrapCommand::Install { force }) => cli::bootstrap::install(force),
+                None => cli::bootstrap::run(dry_run),
+            };
             std::process::exit(code);
         }
         Command::Hooks { subcommand } => {

--- a/crates/git-std/tests/bootstrap.rs
+++ b/crates/git-std/tests/bootstrap.rs
@@ -1,0 +1,408 @@
+use std::path::Path;
+
+use assert_cmd::Command;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let output = std::process::Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn init_repo(dir: &Path) {
+    git(dir, &["init"]);
+    git(dir, &["config", "user.name", "Test"]);
+    git(dir, &["config", "user.email", "test@test.com"]);
+}
+
+fn run_bootstrap(dir: &Path, extra_args: &[&str]) -> assert_cmd::assert::Assert {
+    let mut args = vec!["--color", "never", "bootstrap"];
+    args.extend_from_slice(extra_args);
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(&args)
+        .current_dir(dir)
+        .assert()
+}
+
+fn run_bootstrap_install(dir: &Path, extra_args: &[&str]) -> assert_cmd::assert::Assert {
+    let mut args = vec!["--color", "never", "bootstrap", "install"];
+    args.extend_from_slice(extra_args);
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(&args)
+        .current_dir(dir)
+        .assert()
+}
+
+fn stderr_text(assert: &assert_cmd::assert::Assert) -> String {
+    String::from_utf8_lossy(&assert.get_output().stderr).to_string()
+}
+
+// ===========================================================================
+// #294 — git std bootstrap (run)
+// ===========================================================================
+
+#[test]
+fn bootstrap_sets_hooks_path_when_githooks_exists() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    std::fs::create_dir_all(dir.path().join(".githooks")).unwrap();
+
+    let a = run_bootstrap(dir.path(), &[]).success();
+    let err = stderr_text(&a);
+    assert!(
+        err.contains("core.hooksPath"),
+        "should mention hooksPath, got: {err}"
+    );
+
+    let val = git(dir.path(), &["config", "core.hooksPath"]);
+    assert_eq!(val, ".githooks");
+}
+
+#[test]
+fn bootstrap_skips_hooks_path_when_no_githooks() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    let a = run_bootstrap(dir.path(), &[]).success();
+    let err = stderr_text(&a);
+    assert!(
+        err.contains("skipping hooksPath"),
+        "should skip, got: {err}"
+    );
+}
+
+#[test]
+fn bootstrap_skips_lfs_when_no_gitattributes() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    let a = run_bootstrap(dir.path(), &[]).success();
+    let err = stderr_text(&a);
+    assert!(err.contains("skipping LFS"), "should skip LFS, got: {err}");
+}
+
+#[test]
+fn bootstrap_skips_lfs_when_no_filter_lfs() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    std::fs::write(dir.path().join(".gitattributes"), "*.bin binary\n").unwrap();
+
+    let a = run_bootstrap(dir.path(), &[]).success();
+    let err = stderr_text(&a);
+    assert!(err.contains("no LFS rules"), "should skip LFS, got: {err}");
+}
+
+#[test]
+fn bootstrap_sets_blame_ignore_revs() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    std::fs::write(dir.path().join(".git-blame-ignore-revs"), "# revs\n").unwrap();
+
+    let a = run_bootstrap(dir.path(), &[]).success();
+    let err = stderr_text(&a);
+    assert!(
+        err.contains("blame.ignoreRevsFile"),
+        "should set blame config, got: {err}"
+    );
+
+    let val = git(dir.path(), &["config", "blame.ignoreRevsFile"]);
+    assert_eq!(val, ".git-blame-ignore-revs");
+}
+
+#[test]
+fn bootstrap_skips_blame_when_no_file() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    let a = run_bootstrap(dir.path(), &[]).success();
+    let err = stderr_text(&a);
+    assert!(
+        err.contains(".git-blame-ignore-revs not found"),
+        "should skip, got: {err}"
+    );
+}
+
+#[test]
+fn bootstrap_runs_custom_hooks() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    let hooks_dir = dir.path().join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    std::fs::write(hooks_dir.join("bootstrap.hooks"), "! echo bootstrap-ran\n").unwrap();
+
+    let a = run_bootstrap(dir.path(), &[]).success();
+
+    let stdout = String::from_utf8_lossy(&a.get_output().stdout);
+    let stderr = stderr_text(&a);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("bootstrap-ran"),
+        "custom hook should execute, got: {combined}"
+    );
+}
+
+#[test]
+fn bootstrap_dry_run_no_side_effects() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    let hooks_dir = dir.path().join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    std::fs::write(dir.path().join(".git-blame-ignore-revs"), "# revs\n").unwrap();
+
+    let a = run_bootstrap(dir.path(), &["--dry-run"]).success();
+    let err = stderr_text(&a);
+    assert!(
+        err.contains("would set"),
+        "should mention 'would', got: {err}"
+    );
+
+    // Verify no config was actually set
+    let output = std::process::Command::new("git")
+        .current_dir(dir.path())
+        .args(["config", "core.hooksPath"])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "hooksPath should not be set in dry-run"
+    );
+}
+
+#[test]
+fn bootstrap_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    let hooks_dir = dir.path().join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    std::fs::write(dir.path().join(".git-blame-ignore-revs"), "# revs\n").unwrap();
+
+    // Run twice
+    run_bootstrap(dir.path(), &[]).success();
+    run_bootstrap(dir.path(), &[]).success();
+
+    // Both should succeed and leave valid config
+    let hooks_path = git(dir.path(), &["config", "core.hooksPath"]);
+    assert_eq!(hooks_path, ".githooks");
+    let blame = git(dir.path(), &["config", "blame.ignoreRevsFile"]);
+    assert_eq!(blame, ".git-blame-ignore-revs");
+}
+
+#[test]
+fn bootstrap_exits_zero_with_nothing_to_do() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    run_bootstrap(dir.path(), &[]).success();
+}
+
+// ===========================================================================
+// #295 — git std bootstrap install
+// ===========================================================================
+
+#[test]
+fn bootstrap_install_creates_files() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    run_bootstrap_install(dir.path(), &[]).success();
+
+    // ./bootstrap exists and is executable
+    let script = dir.path().join("bootstrap");
+    assert!(script.exists(), "bootstrap script should exist");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&script).unwrap().permissions().mode();
+        assert!(mode & 0o111 != 0, "bootstrap should be executable");
+    }
+
+    // .githooks/bootstrap.hooks exists
+    let hooks = dir.path().join(".githooks/bootstrap.hooks");
+    assert!(hooks.exists(), "bootstrap.hooks should exist");
+
+    // Created files are staged in the git index
+    let staged = git(dir.path(), &["diff", "--cached", "--name-only"]);
+    assert!(
+        staged.contains("bootstrap"),
+        "bootstrap should be staged, got: {staged}"
+    );
+    assert!(
+        staged.contains("bootstrap.hooks"),
+        "bootstrap.hooks should be staged, got: {staged}"
+    );
+
+    // Executable bit is tracked in the index
+    let ls = git(dir.path(), &["ls-files", "-s", "bootstrap"]);
+    assert!(
+        ls.starts_with("100755"),
+        "bootstrap should be 100755 in index, got: {ls}"
+    );
+}
+
+#[test]
+fn bootstrap_install_min_version_matches_crate() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    run_bootstrap_install(dir.path(), &[]).success();
+
+    let script = std::fs::read_to_string(dir.path().join("bootstrap")).unwrap();
+    let version = env!("CARGO_PKG_VERSION");
+    assert!(
+        script.contains(&format!("MIN_VERSION=\"{version}\"")),
+        "MIN_VERSION should match crate version"
+    );
+}
+
+#[test]
+fn bootstrap_install_skips_existing_without_force() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    // Create existing files
+    std::fs::write(dir.path().join("bootstrap"), "existing\n").unwrap();
+    std::fs::create_dir_all(dir.path().join(".githooks")).unwrap();
+    std::fs::write(dir.path().join(".githooks/bootstrap.hooks"), "existing\n").unwrap();
+
+    let a = run_bootstrap_install(dir.path(), &[]).success();
+    let err = stderr_text(&a);
+    assert!(
+        err.contains("skipped"),
+        "should skip existing files, got: {err}"
+    );
+
+    // Verify content unchanged
+    let content = std::fs::read_to_string(dir.path().join("bootstrap")).unwrap();
+    assert_eq!(content, "existing\n");
+}
+
+#[test]
+fn bootstrap_install_overwrites_with_force() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    // Create existing files
+    std::fs::write(dir.path().join("bootstrap"), "old\n").unwrap();
+    std::fs::create_dir_all(dir.path().join(".githooks")).unwrap();
+    std::fs::write(dir.path().join(".githooks/bootstrap.hooks"), "old\n").unwrap();
+
+    run_bootstrap_install(dir.path(), &["--force"]).success();
+
+    // Verify content was replaced
+    let content = std::fs::read_to_string(dir.path().join("bootstrap")).unwrap();
+    assert!(content.contains("MIN_VERSION"), "should have new content");
+}
+
+#[test]
+fn bootstrap_install_appends_marker_to_docs() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    std::fs::write(dir.path().join("README.md"), "# My Project\n").unwrap();
+    std::fs::write(dir.path().join("AGENTS.md"), "# Agents\n").unwrap();
+
+    run_bootstrap_install(dir.path(), &[]).success();
+
+    let readme = std::fs::read_to_string(dir.path().join("README.md")).unwrap();
+    assert!(
+        readme.contains("<!-- git-std:bootstrap -->"),
+        "README should have marker"
+    );
+    assert!(
+        readme.contains("./bootstrap"),
+        "README should mention ./bootstrap"
+    );
+
+    let agents = std::fs::read_to_string(dir.path().join("AGENTS.md")).unwrap();
+    assert!(
+        agents.contains("<!-- git-std:bootstrap -->"),
+        "AGENTS should have marker"
+    );
+}
+
+#[test]
+fn bootstrap_install_does_not_double_append() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    std::fs::write(dir.path().join("README.md"), "# My Project\n").unwrap();
+
+    // Run twice
+    run_bootstrap_install(dir.path(), &["--force"]).success();
+    run_bootstrap_install(dir.path(), &["--force"]).success();
+
+    let readme = std::fs::read_to_string(dir.path().join("README.md")).unwrap();
+    let count = readme.matches("<!-- git-std:bootstrap -->").count();
+    assert_eq!(count, 1, "marker should appear exactly once, found {count}");
+}
+
+// ===========================================================================
+// commit-msg default template (#294 AC)
+// ===========================================================================
+
+#[test]
+fn hooks_install_generates_commit_msg_with_check_command() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    // Run hooks install with env var to avoid interactive prompt
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["--color", "never", "hooks", "install"])
+        .env("GIT_STD_HOOKS_ENABLE", "commit-msg")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let hooks_file = dir.path().join(".githooks/commit-msg.hooks");
+    assert!(hooks_file.exists(), "commit-msg.hooks should exist");
+
+    let content = std::fs::read_to_string(&hooks_file).unwrap();
+    assert!(
+        content.contains("! git std check --file {msg}"),
+        "commit-msg.hooks should have default check command, got:\n{content}"
+    );
+}
+
+#[test]
+fn hooks_install_commit_msg_shim_is_active() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["--color", "never", "hooks", "install"])
+        .env("GIT_STD_HOOKS_ENABLE", "commit-msg")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // The active shim (no .off extension) should exist
+    let shim = dir.path().join(".githooks/commit-msg");
+    assert!(shim.exists(), "commit-msg shim should be active (no .off)");
+
+    // The .off file should NOT exist
+    let off = dir.path().join(".githooks/commit-msg.off");
+    assert!(
+        !off.exists(),
+        "commit-msg.off should not exist when enabled"
+    );
+}

--- a/crates/standard-githooks/src/shim.rs
+++ b/crates/standard-githooks/src/shim.rs
@@ -34,6 +34,8 @@ pub fn generate_shim(hook_name: &str) -> String {
 /// Generate the `.hooks` template file content for a given hook name.
 ///
 /// Includes a full header comment explaining the prefix system with examples.
+/// For `commit-msg`, adds a default validation command that is active out of
+/// the box.
 pub fn generate_hooks_template(hook_name: &str) -> String {
     let fix_line = if hook_name == "pre-commit" {
         "#   ~  fix       auto-format staged files and re-stage (pre-commit only)\n\
@@ -41,6 +43,13 @@ pub fn generate_hooks_template(hook_name: &str) -> String {
     } else {
         ""
     };
+
+    let default_commands = if hook_name == "commit-msg" {
+        "! git std check --file {msg}\n"
+    } else {
+        ""
+    };
+
     format!(
         "# git-std hooks — {hook_name}.hooks\n\
          #\n\
@@ -61,7 +70,8 @@ pub fn generate_hooks_template(hook_name: &str) -> String {
          # Enable/disable this hook:\n\
          #   git std hooks enable {hook_name}\n\
          #   git std hooks disable {hook_name}\n\
-         #\n"
+         #\n\
+         {default_commands}"
     )
 }
 
@@ -95,6 +105,18 @@ mod tests {
     fn hooks_template_no_fix_line_for_non_precommit() {
         let t = generate_hooks_template("commit-msg");
         assert!(!t.contains("~  fix"));
+    }
+
+    #[test]
+    fn commit_msg_template_has_default_check_command() {
+        let t = generate_hooks_template("commit-msg");
+        assert!(t.contains("! git std check --file {msg}"));
+    }
+
+    #[test]
+    fn non_commit_msg_template_has_no_default_commands() {
+        let t = generate_hooks_template("pre-push");
+        assert!(!t.contains("git std check"));
     }
 
     #[test]

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -63,7 +63,7 @@ dependencies.
 
 ### 1.3 Scope
 
-git-std covers four concerns:
+git-std covers five concerns:
 
 | Concern                      | Subcommand                                                         |
 | ---------------------------- | ------------------------------------------------------------------ |
@@ -71,6 +71,7 @@ git-std covers four concerns:
 | Commit message validation    | `git std check`                                                    |
 | Version bump + changelog     | `git std bump`, `git std changelog`                                |
 | Git hooks management         | `git std hooks install`, `git std hooks run`, `git std hooks list` |
+| Post-clone bootstrap         | `git std bootstrap`, `git std bootstrap install`                   |
 | Shell completions            | `git std completions`                                              |
 
 **Out of scope:** repo scaffolding, directory structure
@@ -663,7 +664,65 @@ cargo test --workspace --lib *.rs
 ! git std check --file {msg}
 ```
 
-### 2.7 `git std completions`
+### 2.7 `git std bootstrap`
+
+Post-clone environment setup. Detects convention files
+in the repository and configures the local environment.
+
+#### 2.7.1 Built-in checks
+
+| Convention file          | Action                                                   | Condition             |
+| ------------------------ | -------------------------------------------------------- | --------------------- |
+| `.githooks/`             | `git config core.hooksPath .githooks`                    | directory exists      |
+| `.gitattributes`         | `git lfs install` + `git lfs pull`                       | contains `filter=lfs` |
+| `.git-blame-ignore-revs` | `git config blame.ignoreRevsFile .git-blame-ignore-revs` | file exists           |
+
+If LFS rules are detected but `git-lfs` is not installed,
+prints an error with install URL and exits 1.
+
+#### 2.7.2 Custom commands (`.githooks/bootstrap.hooks`)
+
+After built-in checks, runs `.githooks/bootstrap.hooks`
+through the existing hooks runner if the file exists.
+Uses the standard `.hooks` file format:
+
+- `!` prefix = required (fail bootstrap on failure)
+- `?` prefix = advisory (best-effort)
+- No prefix = default mode
+
+#### 2.7.3 `git std bootstrap install`
+
+Scaffolds bootstrap files for a project maintainer to
+commit:
+
+1. Generates `./bootstrap` at repo root — a bash script
+   that checks `MIN_VERSION`, installs git-std from
+   GitHub Releases if missing or outdated, then runs
+   `git std bootstrap`.
+2. Generates `.githooks/bootstrap.hooks` with a commented
+   template.
+3. Appends a post-clone reminder to `AGENTS.md` and
+   `README.md` (idempotent, uses HTML comment marker).
+
+**Flags:**
+
+| Flag      | Description              |
+| --------- | ------------------------ |
+| `--force` | Overwrite existing files |
+
+**Flags for `git std bootstrap`:**
+
+| Flag        | Description                             |
+| ----------- | --------------------------------------- |
+| `--dry-run` | Print what would be done without acting |
+
+**Exit codes:** `0` success (including nothing to do),
+`1` failure.
+
+All steps are idempotent — running twice produces the
+same result.
+
+### 2.8 `git std completions`
 
 Generate shell completion scripts for bash, zsh, or fish.
 
@@ -686,7 +745,7 @@ eval "$(git std completions zsh)"
 git std completions fish | source
 ```
 
-### 2.8 Global Flags
+### 2.9 Global Flags
 
 | Flag               | Description                         |
 | ------------------ | ----------------------------------- |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -138,6 +138,39 @@ git std hooks disable <hook>   # deactivate a hook (rename shim → .off)
 **Known hook types:** `pre-commit`, `commit-msg`, `pre-push`,
 `post-commit`, `prepare-commit-msg`, `post-merge`.
 
+## `git std bootstrap`
+
+Post-clone environment setup. Detects convention files and
+configures the local environment.
+
+```bash
+git std bootstrap              # run built-in checks + bootstrap.hooks
+git std bootstrap --dry-run    # print what would be done
+git std bootstrap install      # scaffold bootstrap files for contributors
+```
+
+**Built-in checks:**
+
+| Convention file          | Action                                                   |
+| ------------------------ | -------------------------------------------------------- |
+| `.githooks/`             | `git config core.hooksPath .githooks`                    |
+| `.gitattributes`         | `git lfs install` + `git lfs pull` (if `filter=lfs`)     |
+| `.git-blame-ignore-revs` | `git config blame.ignoreRevsFile .git-blame-ignore-revs` |
+
+After built-in checks, runs `.githooks/bootstrap.hooks` if present.
+
+**`bootstrap install` flags:**
+
+| Flag      | Description              |
+| --------- | ------------------------ |
+| `--force` | Overwrite existing files |
+
+**`bootstrap` flags:**
+
+| Flag        | Description                             |
+| ----------- | --------------------------------------- |
+| `--dry-run` | Print what would be done without acting |
+
 ## `git std completions`
 
 Generate shell completion scripts.

--- a/spec/tests/cmd/general/help.stdout
+++ b/spec/tests/cmd/general/help.stdout
@@ -7,9 +7,9 @@ Commands:
   check        Validate commit messages
   bump         Version bump, changelog, commit, and tag
   changelog    Generate a changelog (incremental by default, --full to regenerate)
+  bootstrap    Post-clone environment setup
   hooks        Git hooks management
   config       Inspect effective git-std configuration
   completions  Generate shell completion scripts
   help         Print this message or the help of the given subcommand(s)
-
 ...


### PR DESCRIPTION
Epic: #293

## Summary

Add `git std bootstrap` (run post-clone checks) and `git std bootstrap install` (scaffold bootstrap files).

### `git std bootstrap`
- Detects `.githooks/` → sets `core.hooksPath`
- Detects `filter=lfs` in `.gitattributes` → runs `git lfs install` + `git lfs pull` (errors if git-lfs missing)
- Detects `.git-blame-ignore-revs` → sets `blame.ignoreRevsFile`
- Runs `.githooks/bootstrap.hooks` via existing hooks runner
- `--dry-run` prints plan without side effects
- All steps idempotent

### `git std bootstrap install`
- Generates `./bootstrap` shell wrapper (pins `MIN_VERSION`, installs from GitHub Releases)
- Generates `.githooks/bootstrap.hooks` template
- Auto-stages created files with `git add` (preserves `100755` executable bit)
- Appends post-clone reminder to `AGENTS.md` / `README.md` (idempotent marker)
- `--force` to overwrite existing files

### commit-msg default template
- `generate_hooks_template` now includes `! git std check --file {msg}` for `commit-msg`
- `hooks install` ships a working commit message validation out of the box

## Test coverage

18 integration tests covering all acceptance criteria from #294 and #295, plus unit tests for generated content.

## Docs

Updated SPEC.md, USAGE.md, README.md, CONTRIBUTING.md, AGENTS.md (#296).

Closes #294, closes #295, closes #296