### PR TITLE
fix(git-std): use human-first messages in bootstrap output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,10 @@ when they reflect a genuine concern, but keep each module focused and small.
   - Human output → stderr via `ui::` helpers. Never call `eprintln!` directly in
     command handlers.
   - Machine/pipeable output → stdout only.
+  - Messages are human-first: describe what was done in plain language
+    (e.g. "git hooks configured"), not internal details
+    (e.g. "core.hooksPath → .githooks"). Use past tense for completed actions.
+    Stay silent when nothing was done — don't report skips.
   - Prompts use `inquire`. Disable prompts when stdin is not a TTY (CI safety) —
     fail fast with a clear error instead of hanging.
   - Exit codes: `0` success, non-zero failure. Be consistent — a command either

--- a/crates/git-std/src/cli/bootstrap.rs
+++ b/crates/git-std/src/cli/bootstrap.rs
@@ -42,11 +42,7 @@ pub fn run(dry_run: bool) -> i32 {
     // Tier 2 — custom bootstrap.hooks
     if Path::new(BOOTSTRAP_HOOKS_FILE).exists() {
         if dry_run {
-            ui::result_line(&format!(
-                "{}  would run {}",
-                ui::pass(),
-                BOOTSTRAP_HOOKS_FILE
-            ));
+            ui::result_line(&format!("{}  custom bootstrap hooks executed", ui::pass()));
         } else {
             let code = super::hooks::run("bootstrap", &[]);
             if code != 0 {
@@ -62,18 +58,11 @@ pub fn run(dry_run: bool) -> i32 {
 fn check_hooks_path(dry_run: bool) -> bool {
     let hooks_dir = Path::new(".githooks");
     if !hooks_dir.exists() {
-        ui::result_line(&format!(
-            "{}  .githooks/ not found, skipping hooksPath",
-            ui::pass()
-        ));
         return true;
     }
 
     if dry_run {
-        ui::result_line(&format!(
-            "{}  would set core.hooksPath → .githooks",
-            ui::pass()
-        ));
+        ui::result_line(&format!("{}  git hooks configured", ui::pass()));
         return true;
     }
 
@@ -83,7 +72,7 @@ fn check_hooks_path(dry_run: bool) -> bool {
 
     match status {
         Ok(s) if s.success() => {
-            ui::result_line(&format!("{}  core.hooksPath → .githooks", ui::pass()));
+            ui::result_line(&format!("{}  git hooks configured", ui::pass()));
             true
         }
         _ => {
@@ -100,10 +89,6 @@ fn check_hooks_path(dry_run: bool) -> bool {
 fn check_lfs(dry_run: bool) -> bool {
     let attrs = Path::new(".gitattributes");
     if !attrs.exists() {
-        ui::result_line(&format!(
-            "{}  .gitattributes not found, skipping LFS",
-            ui::pass()
-        ));
         return true;
     }
 
@@ -116,10 +101,6 @@ fn check_lfs(dry_run: bool) -> bool {
     };
 
     if !content.lines().any(|line| line.contains("filter=lfs")) {
-        ui::result_line(&format!(
-            "{}  no LFS rules in .gitattributes, skipping",
-            ui::pass()
-        ));
         return true;
     }
 
@@ -137,10 +118,7 @@ fn check_lfs(dry_run: bool) -> bool {
     }
 
     if dry_run {
-        ui::result_line(&format!(
-            "{}  would run git lfs install + git lfs pull",
-            ui::pass()
-        ));
+        ui::result_line(&format!("{}  LFS objects downloaded", ui::pass()));
         return true;
     }
 
@@ -168,7 +146,7 @@ fn check_lfs(dry_run: bool) -> bool {
         return false;
     }
 
-    ui::result_line(&format!("{}  git lfs install + pull", ui::pass()));
+    ui::result_line(&format!("{}  LFS objects downloaded", ui::pass()));
     true
 }
 
@@ -176,18 +154,11 @@ fn check_lfs(dry_run: bool) -> bool {
 fn check_blame_ignore_revs(dry_run: bool) -> bool {
     let path = Path::new(".git-blame-ignore-revs");
     if !path.exists() {
-        ui::result_line(&format!(
-            "{}  .git-blame-ignore-revs not found, skipping",
-            ui::pass()
-        ));
         return true;
     }
 
     if dry_run {
-        ui::result_line(&format!(
-            "{}  would set blame.ignoreRevsFile → .git-blame-ignore-revs",
-            ui::pass()
-        ));
+        ui::result_line(&format!("{}  blame ignore revs configured", ui::pass()));
         return true;
     }
 
@@ -197,10 +168,7 @@ fn check_blame_ignore_revs(dry_run: bool) -> bool {
 
     match status {
         Ok(s) if s.success() => {
-            ui::result_line(&format!(
-                "{}  blame.ignoreRevsFile → .git-blame-ignore-revs",
-                ui::pass()
-            ));
+            ui::result_line(&format!("{}  blame ignore revs configured", ui::pass()));
             true
         }
         _ => {
@@ -270,12 +238,12 @@ pub fn install(force: bool) -> i32 {
     // Print summary
     ui::blank();
     for path in &created {
-        ui::result_line(&format!("{}  created {path}", ui::pass()));
+        ui::result_line(&format!("{}  {path} created", ui::pass()));
     }
     for path in &skipped {
         ui::result_line(&format!(
-            "{}  skipped {path} (already exists, use --force to overwrite)",
-            ui::pass()
+            "{}  {path} already exists (use --force to overwrite)",
+            ui::warn()
         ));
     }
 

--- a/crates/git-std/tests/bootstrap.rs
+++ b/crates/git-std/tests/bootstrap.rs
@@ -64,8 +64,8 @@ fn bootstrap_sets_hooks_path_when_githooks_exists() {
     let a = run_bootstrap(dir.path(), &[]).success();
     let err = stderr_text(&a);
     assert!(
-        err.contains("core.hooksPath"),
-        "should mention hooksPath, got: {err}"
+        err.contains("git hooks configured"),
+        "should confirm hooks configured, got: {err}"
     );
 
     let val = git(dir.path(), &["config", "core.hooksPath"]);
@@ -79,9 +79,10 @@ fn bootstrap_skips_hooks_path_when_no_githooks() {
 
     let a = run_bootstrap(dir.path(), &[]).success();
     let err = stderr_text(&a);
+    // No output when nothing to do
     assert!(
-        err.contains("skipping hooksPath"),
-        "should skip, got: {err}"
+        !err.contains("hooks"),
+        "should be silent on skip, got: {err}"
     );
 }
 
@@ -92,7 +93,8 @@ fn bootstrap_skips_lfs_when_no_gitattributes() {
 
     let a = run_bootstrap(dir.path(), &[]).success();
     let err = stderr_text(&a);
-    assert!(err.contains("skipping LFS"), "should skip LFS, got: {err}");
+    // No output when nothing to do
+    assert!(!err.contains("LFS"), "should be silent on skip, got: {err}");
 }
 
 #[test]
@@ -103,7 +105,7 @@ fn bootstrap_skips_lfs_when_no_filter_lfs() {
 
     let a = run_bootstrap(dir.path(), &[]).success();
     let err = stderr_text(&a);
-    assert!(err.contains("no LFS rules"), "should skip LFS, got: {err}");
+    assert!(!err.contains("LFS"), "should be silent on skip, got: {err}");
 }
 
 #[test]
@@ -115,8 +117,8 @@ fn bootstrap_sets_blame_ignore_revs() {
     let a = run_bootstrap(dir.path(), &[]).success();
     let err = stderr_text(&a);
     assert!(
-        err.contains("blame.ignoreRevsFile"),
-        "should set blame config, got: {err}"
+        err.contains("blame ignore revs configured"),
+        "should confirm blame config, got: {err}"
     );
 
     let val = git(dir.path(), &["config", "blame.ignoreRevsFile"]);
@@ -131,8 +133,8 @@ fn bootstrap_skips_blame_when_no_file() {
     let a = run_bootstrap(dir.path(), &[]).success();
     let err = stderr_text(&a);
     assert!(
-        err.contains(".git-blame-ignore-revs not found"),
-        "should skip, got: {err}"
+        !err.contains("blame"),
+        "should be silent on skip, got: {err}"
     );
 }
 
@@ -168,8 +170,8 @@ fn bootstrap_dry_run_no_side_effects() {
     let a = run_bootstrap(dir.path(), &["--dry-run"]).success();
     let err = stderr_text(&a);
     assert!(
-        err.contains("would set"),
-        "should mention 'would', got: {err}"
+        err.contains("configured"),
+        "should show what would be done, got: {err}"
     );
 
     // Verify no config was actually set
@@ -285,8 +287,8 @@ fn bootstrap_install_skips_existing_without_force() {
     let a = run_bootstrap_install(dir.path(), &[]).success();
     let err = stderr_text(&a);
     assert!(
-        err.contains("skipped"),
-        "should skip existing files, got: {err}"
+        err.contains("already exists"),
+        "should warn about existing files, got: {err}"
     );
 
     // Verify content unchanged


### PR DESCRIPTION
Refs #300

Replace technical jargon with plain language in bootstrap output, following [clig.dev](https://clig.dev) guidelines.

**Before:**
```
✓  core.hooksPath → .githooks
✓  .gitattributes not found, skipping LFS
✓  .git-blame-ignore-revs not found, skipping
```

**After:**
```
✓  git hooks configured
```
(silent when nothing to do)

Also adds clig.dev message style rules to AGENTS.md.