### PR TITLE
refactor(git-std): neutralize stable advance section label

### DIFF
--- a/crates/git-std/src/cli/bump/stable.rs
+++ b/crates/git-std/src/cli/bump/stable.rs
@@ -167,7 +167,7 @@ pub(super) fn run_stable(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
     }
 
     ui::blank();
-    ui::info(&format!("Advancing {original_branch}..."));
+    ui::info(&format!("Advancing {original_branch}:"));
     ui::detail(&format!(
         "{} ({bump_kind})",
         format!("{cur_ver} \u{2192} {new_version}").bold(),


### PR DESCRIPTION
Epic: #293

## Summary

Resolve #303 by replacing the last in-progress style message in the stable bump execution path.

- Before: Advancing {branch}...
- After:  Advancing {branch}:

This keeps output consistent with human-first wording and avoids implying an in-progress state that is never later updated.

## Scope

- 1-line change in crates/git-std/src/cli/bump/stable.rs
- No behavior change

## Validation

- cargo test -p git-std bump_stable -- --nocapture

Closes #303