### PR TITLE
fix(git-std): always allow release scope in lint config

### DIFF
--- a/crates/git-std/src/config/mod.rs
+++ b/crates/git-std/src/config/mod.rs
@@ -166,6 +166,15 @@ impl ProjectConfig {
                 }
                 ScopesConfig::List(list) => (Some(list.clone()), true),
             };
+            // `chore(release)` is the standard commit message produced by
+            // `git std bump`. Always allow it so the tool's own commits
+            // pass validation regardless of the configured scope list.
+            let scopes = scopes.map(|mut s| {
+                if !s.iter().any(|v| v == "release") {
+                    s.push("release".to_string());
+                }
+                s
+            });
             standard_commit::LintConfig {
                 types: Some(self.types.clone()),
                 scopes,

--- a/crates/git-std/src/config/tests.rs
+++ b/crates/git-std/src/config/tests.rs
@@ -67,7 +67,7 @@ fn to_lint_config_strict() {
     };
     let lint = config.to_lint_config(true, dir.path());
     assert_eq!(lint.types, Some(vec!["feat".into()]));
-    assert_eq!(lint.scopes, Some(vec!["auth".into()]));
+    assert_eq!(lint.scopes, Some(vec!["auth".into(), "release".into()]));
     assert!(lint.require_scope);
 }
 
@@ -108,7 +108,7 @@ fn to_lint_config_strict_from_config() {
     // strict=true in config, flag=false → still strict
     let lint = config.to_lint_config(false, dir.path());
     assert_eq!(lint.types, Some(vec!["feat".into()]));
-    assert_eq!(lint.scopes, Some(vec!["auth".into()]));
+    assert_eq!(lint.scopes, Some(vec!["auth".into(), "release".into()]));
     assert!(lint.require_scope);
 }
 
@@ -224,7 +224,10 @@ fn to_lint_config_auto_discovers_scopes() {
         ..Default::default()
     };
     let lint = config.to_lint_config(true, dir.path());
-    assert_eq!(lint.scopes, Some(vec!["api".into(), "auth".into()]));
+    assert_eq!(
+        lint.scopes,
+        Some(vec!["api".into(), "auth".into(), "release".into()])
+    );
     assert!(lint.require_scope);
 }
 
@@ -451,6 +454,37 @@ calver_format = "YYYY.INVALID"
     assert_eq!(config.scheme, Scheme::Semver);
     // Invalid format is kept as-is because scheme is not calver.
     assert_eq!(config.versioning.calver_format, "YYYY.INVALID");
+}
+
+#[test]
+fn release_scope_always_allowed_with_explicit_list() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = ProjectConfig {
+        types: vec!["feat".into()],
+        scopes: ScopesConfig::List(vec!["api".into()]),
+        ..Default::default()
+    };
+    let lint = config.to_lint_config(true, dir.path());
+    let scopes = lint.scopes.unwrap();
+    assert!(scopes.contains(&"release".to_string()));
+}
+
+#[test]
+fn release_scope_not_duplicated_when_already_present() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = ProjectConfig {
+        types: vec!["feat".into()],
+        scopes: ScopesConfig::List(vec!["release".into(), "api".into()]),
+        ..Default::default()
+    };
+    let lint = config.to_lint_config(true, dir.path());
+    let count = lint
+        .scopes
+        .unwrap()
+        .iter()
+        .filter(|s| *s == "release")
+        .count();
+    assert_eq!(count, 1);
 }
 
 #[test]

--- a/spec/snapshots/check/strict_rejects_unknown_scope.stderr.expected
+++ b/spec/snapshots/check/strict_rejects_unknown_scope.stderr.expected
@@ -1,3 +1,3 @@
-[..]scope 'unknown' is not in the allowed list: auth, api
+✗ scope 'unknown' is not in the allowed list: auth, api, release
   Expected: <type>(<scope>): <description>
   Got:      feat(unknown): add login


### PR DESCRIPTION
## Problem

When `scopes = "auto"` or an explicit scope list is configured with `strict = true`, running `git std bump` fails because the generated `chore(release): {version}` commit message uses the `release` scope, which is not in the auto-discovered or configured scope list.

The tool blocks its own commits.

## Solution

Always append `"release"` to the allowed scopes list in `to_lint_config()` when scopes are enforced. This is safe because `chore(release)` is the de facto Conventional Commits convention for release commits (used by standard-version, semantic-release, lerna, release-please).

The scope is only added when a scope list exists (i.e. `ScopesConfig::Auto` with discovered scopes or `ScopesConfig::List`). It is not duplicated if already present.

## Changes

- `crates/git-std/src/config/mod.rs`: Append `"release"` to scopes after discovery/config resolution
- `crates/git-std/src/config/tests.rs`: Update existing assertions, add two new tests (`release_scope_always_allowed_with_explicit_list`, `release_scope_not_duplicated_when_already_present`)
- `spec/snapshots/check/strict_rejects_unknown_scope.stderr.expected`: Updated to reflect `release` in error output