### PR TITLE
fix(git-std): harden pre-commit stash dance

### DIFF
--- a/crates/git-std/src/cli/hooks/run.rs
+++ b/crates/git-std/src/cli/hooks/run.rs
@@ -155,6 +155,8 @@ fn stash_drop() {
 /// Re-stage the given files after a formatter has run.
 ///
 /// Runs `git add -- <files>` to pick up any formatting changes.
+/// Files that no longer exist on disk are skipped with a warning to
+/// prevent a formatter-caused deletion from being silently staged (#279).
 ///
 /// Returns `true` on success, `false` if the command fails. A failure means
 /// formatted changes would be silently lost — callers must treat this as a
@@ -163,9 +165,20 @@ fn restage_files(files: &[String]) -> bool {
     if files.is_empty() {
         return true;
     }
+    let mut existing: Vec<&String> = Vec::new();
+    for f in files {
+        if std::path::Path::new(f).exists() {
+            existing.push(f);
+        } else {
+            ui::warning(&format!("{f} was deleted by formatter — skipping restage"));
+        }
+    }
+    if existing.is_empty() {
+        return true;
+    }
     let mut cmd = Command::new("git");
     cmd.arg("add").arg("--");
-    for f in files {
+    for f in &existing {
         cmd.arg(f);
     }
     match cmd.status() {
@@ -377,9 +390,10 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
     };
 
     if use_stash_dance && stash_active && !stash_apply() {
-        ui::error("git stash apply failed — your working tree may have conflicts");
-        ui::hint("resolve conflicts manually, then re-run your commit");
+        ui::error("stash apply failed — working tree has conflicting unstaged changes");
+        ui::hint("commit or stash your unstaged changes first, then retry");
         stash_drop();
+        print_failure_hints(hook);
         return 1;
     }
 
@@ -443,6 +457,7 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
                         stash_drop();
                     }
                     ui::blank();
+                    print_failure_hints(hook);
                     return 1;
                 }
                 if stash_active {
@@ -480,6 +495,7 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
             if stash_active {
                 stash_drop();
             }
+            print_failure_hints(hook);
             return 1;
         }
 

--- a/crates/git-std/tests/hooks.rs
+++ b/crates/git-std/tests/hooks.rs
@@ -904,3 +904,181 @@ fn hooks_run_fix_mode_preserves_binary_files() {
         "staged binary content should be byte-identical after stash dance"
     );
 }
+
+/// #277 + #278 — Fix-mode failure prints actionable hints.
+///
+/// When a `~` fix command fails, the output must include hint lines telling
+/// the user how to skip the hook, skip all hooks, and disable the command.
+#[test]
+fn hooks_run_fix_mode_failure_prints_hints() {
+    let dir = tempfile::tempdir().unwrap();
+    init_hooks_repo(dir.path());
+
+    std::fs::write(dir.path().join("file.txt"), "content\n").unwrap();
+    git(dir.path(), &["add", "file.txt"]);
+
+    let hooks_dir = dir.path().join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    std::fs::write(hooks_dir.join("pre-commit.hooks"), "~ false\n").unwrap();
+
+    let assert = Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["--color", "never", "hooks", "run", "pre-commit"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1);
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+
+    assert!(
+        stderr.contains("hint: to skip this hook:"),
+        "should print skip-hook hint, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("--no-verify"),
+        "should mention --no-verify, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("GIT_STD_SKIP_HOOKS=1"),
+        "should mention GIT_STD_SKIP_HOOKS, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(".githooks/pre-commit.hooks"),
+        "should reference the hooks file, got:\n{stderr}"
+    );
+}
+
+/// #279 — Formatter-deleted files are not re-staged as deletions.
+///
+/// If a fix-mode formatter deletes a file that was staged for modification,
+/// `restage_files()` should skip it with a warning instead of silently
+/// staging a deletion.
+#[test]
+fn hooks_run_fix_mode_skips_restage_of_formatter_deleted_files() {
+    let dir = tempfile::tempdir().unwrap();
+    init_hooks_repo(dir.path());
+
+    // Create and commit a file.
+    std::fs::write(dir.path().join("victim.txt"), "original\n").unwrap();
+    std::fs::write(dir.path().join("survivor.txt"), "keep\n").unwrap();
+    git(dir.path(), &["add", "victim.txt", "survivor.txt"]);
+    git(dir.path(), &["commit", "-m", "initial"]);
+
+    // Stage modifications.
+    std::fs::write(dir.path().join("victim.txt"), "modified\n").unwrap();
+    std::fs::write(dir.path().join("survivor.txt"), "also modified\n").unwrap();
+    git(dir.path(), &["add", "victim.txt", "survivor.txt"]);
+
+    let hooks_dir = dir.path().join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    // Formatter that deletes victim.txt.
+    std::fs::write(hooks_dir.join("pre-commit.hooks"), "~ rm -f victim.txt\n").unwrap();
+
+    let assert = Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["--color", "never", "hooks", "run", "pre-commit"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+
+    // Warning about the deleted file.
+    assert!(
+        stderr.contains("victim.txt") && stderr.contains("deleted by formatter"),
+        "should warn about formatter-deleted file, got:\n{stderr}"
+    );
+
+    // victim.txt should NOT be staged as a deletion.
+    let deletions = std::process::Command::new("git")
+        .args(["diff", "--cached", "--name-only", "--diff-filter=D"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let deleted = String::from_utf8_lossy(&deletions.stdout);
+    assert!(
+        !deleted.contains("victim.txt"),
+        "victim.txt should not be staged as deletion, got:\n{deleted}"
+    );
+
+    // survivor.txt should still be staged.
+    let staged = std::process::Command::new("git")
+        .args(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let staged_files = String::from_utf8_lossy(&staged.stdout);
+    assert!(
+        staged_files.contains("survivor.txt"),
+        "survivor.txt should still be staged, got:\n{staged_files}"
+    );
+}
+
+/// #283 — Fix mode rejects submodule entries.
+///
+/// When a submodule is staged and fix-mode commands exist, the hook
+/// should reject execution with a clear error and hint.
+#[test]
+fn hooks_run_fix_mode_rejects_staged_submodules() {
+    let dir = tempfile::tempdir().unwrap();
+    init_hooks_repo(dir.path());
+
+    // Create a bare repo to use as a submodule source.
+    let sub_source = tempfile::tempdir().unwrap();
+    git(sub_source.path(), &["init", "--bare"]);
+
+    // We need a commit in the bare repo for submodule add to work.
+    let sub_work = tempfile::tempdir().unwrap();
+    git(sub_work.path(), &["init"]);
+    git(sub_work.path(), &["config", "user.name", "Test"]);
+    git(sub_work.path(), &["config", "user.email", "test@test.com"]);
+    std::fs::write(sub_work.path().join("readme.txt"), "sub\n").unwrap();
+    git(sub_work.path(), &["add", "readme.txt"]);
+    git(sub_work.path(), &["commit", "-m", "init sub"]);
+    git(
+        sub_work.path(),
+        &[
+            "remote",
+            "add",
+            "origin",
+            sub_source.path().to_str().unwrap(),
+        ],
+    );
+    git(sub_work.path(), &["push", "origin", "HEAD"]);
+
+    // Add the submodule to the main repo.
+    let sub_url = sub_source.path().to_str().unwrap();
+    let output = std::process::Command::new("git")
+        .args(["submodule", "add", sub_url, "submod"])
+        .current_dir(dir.path())
+        .env("GIT_ALLOW_PROTOCOL", "file")
+        .output()
+        .unwrap();
+    if !output.status.success() {
+        // If submodule add is unsupported in this git version, skip the test.
+        eprintln!(
+            "skipping: git submodule add failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return;
+    }
+
+    let hooks_dir = dir.path().join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    std::fs::write(hooks_dir.join("pre-commit.hooks"), "~ true\n").unwrap();
+
+    let assert = Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["--color", "never", "hooks", "run", "pre-commit"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1);
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+
+    // Should report that fix mode doesn't support submodules.
+    assert!(
+        stderr.contains("submodule"),
+        "should mention submodules in error, got:\n{stderr}"
+    );
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -63,7 +63,7 @@ dependencies.
 
 ### 1.3 Scope
 
-git-std covers five concerns:
+git-std covers six concerns:
 
 | Concern                      | Subcommand                                                         |
 | ---------------------------- | ------------------------------------------------------------------ |


### PR DESCRIPTION
Epic: #276

## Summary

Hardens the pre-commit stash dance with defensive checks and integration tests for the remaining open stories in #276.

### Code changes (`run.rs`)

- **#279 — Formatter-deleted files:** `restage_files()` now checks if each file still exists on disk before `git add`. Files deleted by a formatter are skipped with a warning instead of causing a silent failure.
- **#278 — Stash apply conflict:** Updated the error message to be actionable ("stash apply failed — working tree has conflicting unstaged changes") with a hint to commit or stash unstaged changes first. Added `print_failure_hints()` call.
- **#277 — Hints on all failure paths:** Added `print_failure_hints()` to two missing `return 1` paths (fail-fast restage failure, post-loop restage failure) so every hook failure exit prints the 3-line hint block.

### Integration tests (`hooks.rs`)

| Test | Story |
|------|-------|
| `hooks_run_fix_mode_failure_prints_hints` | #277, #278 |
| `hooks_run_fix_mode_skips_restage_of_formatter_deleted_files` | #279 |
| `hooks_run_fix_mode_rejects_staged_submodules` | #283 |

Tests for #280 (renamed files), #281 (formatter-created files), and #282 (binary files) already existed.

### Note on #278 stash apply conflict test

The current stash dance uses `git stash push --quiet` without `--keep-index`. This means `stash apply` after `stash push` on a clean tree should always succeed — the conflict scenario described in #278 cannot be triggered with the current implementation. The defensive abort path is tested indirectly through the fix-mode failure test. A proper stash apply conflict test would require adding `--keep-index` to `stash_push()`, which is a separate concern.

Also fixes the SPEC.md concern count from "five" to "six" after bootstrap was added (#296).

## Checklist

- [x] Implementation
- [x] Integration tests (3 new + existing)
- [x] `cargo test` — all pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — clean