### PR TITLE
feat(standard-commit): add process commit detection and revert type

### DIFF
--- a/crates/git-std/src/cli/check.rs
+++ b/crates/git-std/src/cli/check.rs
@@ -29,6 +29,8 @@ struct CheckResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     breaking: Option<bool>,
     errors: Vec<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    skipped: bool,
 }
 
 /// Run the `check` subcommand with an inline message. Returns the exit code.
@@ -77,6 +79,7 @@ fn run_json(message: &str, lint_config: Option<&LintConfig>) -> i32 {
                 description: None,
                 breaking: None,
                 errors: errors.iter().map(|e| e.to_string()).collect(),
+                skipped: false,
             }
         }
     } else {
@@ -89,6 +92,7 @@ fn run_json(message: &str, lint_config: Option<&LintConfig>) -> i32 {
                 description: None,
                 breaking: None,
                 errors: vec![e.to_string()],
+                skipped: false,
             },
         }
     };
@@ -108,6 +112,7 @@ fn build_valid_result(message: &str) -> CheckResult {
             description: Some(commit.description),
             breaking: Some(commit.is_breaking),
             errors: vec![],
+            skipped: false,
         },
         Err(_) => CheckResult {
             valid: true,
@@ -116,6 +121,7 @@ fn build_valid_result(message: &str) -> CheckResult {
             description: None,
             breaking: None,
             errors: vec![],
+            skipped: false,
         },
     }
 }
@@ -156,8 +162,16 @@ pub fn run_range(range: &str, lint_config: Option<&LintConfig>, format: OutputFo
 
     let total = commits.len();
     let mut failures = 0;
+    let mut skipped = 0;
     for (oid, message) in &commits {
         let short = &oid[..7];
+
+        if standard_commit::is_process_commit(message) {
+            ui::result_line(&format!("~ {} {}", short, first_line(message).dim(),));
+            skipped += 1;
+            continue;
+        }
+
         let valid = if let Some(config) = lint_config {
             let errors = standard_commit::lint(message, config);
             if errors.is_empty() {
@@ -202,9 +216,14 @@ pub fn run_range(range: &str, lint_config: Option<&LintConfig>, format: OutputFo
         }
     }
 
-    let valid_count = total - failures;
+    let checked = total - skipped;
+    let valid_count = checked - failures;
     ui::blank();
-    ui::summary_counts(valid_count, total);
+    if skipped > 0 {
+        eprintln!("{valid_count}/{checked} valid  ({skipped} skipped)");
+    } else {
+        ui::summary_counts(valid_count, checked);
+    }
 
     if failures > 0 { 1 } else { 0 }
 }
@@ -215,6 +234,19 @@ fn run_range_json(commits: &[(String, String)], lint_config: Option<&LintConfig>
     let mut any_invalid = false;
 
     for (_oid, message) in commits {
+        if standard_commit::is_process_commit(message) {
+            results.push(CheckResult {
+                valid: true,
+                r#type: None,
+                scope: None,
+                description: None,
+                breaking: None,
+                errors: vec![],
+                skipped: true,
+            });
+            continue;
+        }
+
         let result = if let Some(config) = lint_config {
             let errors = standard_commit::lint(message, config);
             if errors.is_empty() {
@@ -227,6 +259,7 @@ fn run_range_json(commits: &[(String, String)], lint_config: Option<&LintConfig>
                     description: None,
                     breaking: None,
                     errors: errors.iter().map(|e| e.to_string()).collect(),
+                    skipped: false,
                 }
             }
         } else {
@@ -239,6 +272,7 @@ fn run_range_json(commits: &[(String, String)], lint_config: Option<&LintConfig>
                     description: None,
                     breaking: None,
                     errors: vec![e.to_string()],
+                    skipped: false,
                 },
             }
         };

--- a/crates/git-std/src/config/load.rs
+++ b/crates/git-std/src/config/load.rs
@@ -9,7 +9,7 @@ const CONFIG_FILE: &str = ".git-std.toml";
 
 /// Default conventional commit types used when `.git-std.toml` has no `types` list.
 pub(crate) const DEFAULT_TYPES: &[&str] = &[
-    "feat", "fix", "docs", "style", "refactor", "perf", "test", "chore", "ci", "build",
+    "feat", "fix", "docs", "style", "refactor", "perf", "test", "chore", "ci", "build", "revert",
 ];
 
 pub(crate) fn default_types() -> Vec<String> {

--- a/crates/standard-changelog/src/model.rs
+++ b/crates/standard-changelog/src/model.rs
@@ -67,6 +67,7 @@ impl Default for ChangelogConfig {
                 ("feat".to_string(), "Features".to_string()),
                 ("fix".to_string(), "Bug Fixes".to_string()),
                 ("perf".to_string(), "Performance".to_string()),
+                ("revert".to_string(), "Reverts".to_string()),
                 ("refactor".to_string(), "Refactoring".to_string()),
                 ("docs".to_string(), "Documentation".to_string()),
             ],
@@ -97,6 +98,7 @@ mod tests {
                 ("feat".to_string(), "Features".to_string()),
                 ("fix".to_string(), "Bug Fixes".to_string()),
                 ("perf".to_string(), "Performance".to_string()),
+                ("revert".to_string(), "Reverts".to_string()),
                 ("refactor".to_string(), "Refactoring".to_string()),
                 ("docs".to_string(), "Documentation".to_string()),
             ]

--- a/crates/standard-commit/src/lib.rs
+++ b/crates/standard-commit/src/lib.rs
@@ -9,11 +9,13 @@
 //! - [`parse`] — parse a commit message into a [`ConventionalCommit`]
 //! - [`lint`] — validate a message against a [`LintConfig`]
 //! - [`format`] — render a [`ConventionalCommit`] back to a well-formed string
+//! - [`is_process_commit`] — detect automatically generated commits (merges,
+//!   reverts, fixups) that should be skipped during validation
 //!
 //! # Example
 //!
 //! ```
-//! use standard_commit::{parse, format, lint, LintConfig};
+//! use standard_commit::{parse, format, lint, LintConfig, is_process_commit};
 //!
 //! let commit = parse("feat(auth): add OAuth2 PKCE flow").unwrap();
 //! assert_eq!(commit.r#type, "feat");
@@ -25,12 +27,18 @@
 //! // Lint with default rules
 //! let errors = lint("feat: add login", &LintConfig::default());
 //! assert!(errors.is_empty());
+//!
+//! // Process commit detection
+//! assert!(is_process_commit("Merge pull request #42 from owner/branch"));
+//! assert!(!is_process_commit("feat: add login"));
 //! ```
 
 mod format;
 mod lint;
 mod parse;
+mod process;
 
 pub use format::format;
 pub use lint::{LintConfig, LintError, lint};
 pub use parse::{ConventionalCommit, Footer, ParseError, parse};
+pub use process::is_process_commit;

--- a/crates/standard-commit/src/process.rs
+++ b/crates/standard-commit/src/process.rs
@@ -1,0 +1,182 @@
+/// Returns `true` if the commit message looks like an automatically generated
+/// process commit — merge, revert, fixup, squash, or initial commit.
+///
+/// Detection is based on the first line (subject) of the message only, using
+/// well-known prefix patterns from GitHub, GitLab, Gerrit, and git itself.
+/// No git parent-count check is performed; this works across all input modes.
+///
+/// # Process commit patterns
+///
+/// | Pattern                          | Source             |
+/// | -------------------------------- | ------------------ |
+/// | `Merge pull request #N …`        | GitHub             |
+/// | `Merge branch '…'`               | GitHub/GitLab/git  |
+/// | `Merge tag '…'`                  | git                |
+/// | `Merge remote-tracking branch …` | git                |
+/// | `Merge "…"`                      | Gerrit             |
+/// | `Merge changes …`                | Gerrit             |
+/// | `Revert "…"`                     | `git revert`       |
+/// | `fixup! …`                       | `git commit --fixup`   |
+/// | `squash! …`                      | `git commit --squash`  |
+/// | `Initial commit`                 | GitHub / convention |
+///
+/// # Examples
+///
+/// ```
+/// use standard_commit::is_process_commit;
+///
+/// assert!(is_process_commit("Merge pull request #42 from owner/branch"));
+/// assert!(is_process_commit("Revert \"feat: add login\""));
+/// assert!(is_process_commit("fixup! fix: handle timeout"));
+/// assert!(!is_process_commit("feat: add login"));
+/// assert!(!is_process_commit("chore: update deps"));
+/// ```
+pub fn is_process_commit(message: &str) -> bool {
+    let subject = message.lines().next().unwrap_or("").trim();
+    is_process_subject(subject)
+}
+
+fn is_process_subject(subject: &str) -> bool {
+    // Merge patterns (case-sensitive — git always capitalises "Merge")
+    if subject.starts_with("Merge pull request #") {
+        return true;
+    }
+    if subject.starts_with("Merge branch '") {
+        return true;
+    }
+    if subject.starts_with("Merge tag '") {
+        return true;
+    }
+    if subject.starts_with("Merge remote-tracking branch ") {
+        return true;
+    }
+    // Gerrit: `Merge "..."` and `Merge changes ...`
+    if subject.starts_with("Merge \"") {
+        return true;
+    }
+    if subject.starts_with("Merge changes ") {
+        return true;
+    }
+    // git revert: `Revert "..."`
+    if subject.starts_with("Revert \"") {
+        return true;
+    }
+    // git commit --fixup / --squash
+    if subject.starts_with("fixup! ") {
+        return true;
+    }
+    if subject.starts_with("squash! ") {
+        return true;
+    }
+    // Initial commit (GitHub new-repo default and common convention)
+    if subject == "Initial commit" {
+        return true;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Merge patterns ---
+
+    #[test]
+    fn github_merge_pull_request() {
+        assert!(is_process_commit(
+            "Merge pull request #42 from owner/feature-branch"
+        ));
+    }
+
+    #[test]
+    fn merge_branch() {
+        assert!(is_process_commit("Merge branch 'main' into feature"));
+        assert!(is_process_commit("Merge branch 'develop'"));
+    }
+
+    #[test]
+    fn merge_tag() {
+        assert!(is_process_commit("Merge tag 'v1.2.3'"));
+    }
+
+    #[test]
+    fn merge_remote_tracking_branch() {
+        assert!(is_process_commit(
+            "Merge remote-tracking branch 'origin/main'"
+        ));
+    }
+
+    #[test]
+    fn gerrit_merge_quoted() {
+        assert!(is_process_commit("Merge \"feat: add login\""));
+    }
+
+    #[test]
+    fn gerrit_merge_changes() {
+        assert!(is_process_commit("Merge changes Iabc1234,Idef5678"));
+    }
+
+    // --- Revert ---
+
+    #[test]
+    fn git_revert() {
+        assert!(is_process_commit("Revert \"feat: add login\""));
+        assert!(is_process_commit("Revert \"fix(auth): handle timeout\""));
+    }
+
+    // --- Fixup / squash ---
+
+    #[test]
+    fn fixup_commit() {
+        assert!(is_process_commit("fixup! fix: handle timeout"));
+        assert!(is_process_commit("fixup! feat(auth): add OAuth2 PKCE"));
+    }
+
+    #[test]
+    fn squash_commit() {
+        assert!(is_process_commit("squash! feat: add login"));
+    }
+
+    // --- Initial commit ---
+
+    #[test]
+    fn initial_commit() {
+        assert!(is_process_commit("Initial commit"));
+    }
+
+    // --- Conventional commits are NOT process commits ---
+
+    #[test]
+    fn conventional_feat_is_not_process() {
+        assert!(!is_process_commit("feat: add login"));
+    }
+
+    #[test]
+    fn conventional_fix_is_not_process() {
+        assert!(!is_process_commit("fix(auth): handle expired tokens"));
+    }
+
+    #[test]
+    fn revert_type_conventional_is_not_process() {
+        // `revert(scope): ...` follows CC format and is NOT a process commit
+        assert!(!is_process_commit("revert(auth): undo broken migration"));
+    }
+
+    #[test]
+    fn bare_merge_word_is_not_process() {
+        // Loose "Merge" without a recognised pattern should not match
+        assert!(!is_process_commit("Merge: resolve conflict"));
+    }
+
+    #[test]
+    fn lowercase_initial_commit_is_not_process() {
+        assert!(!is_process_commit("initial commit"));
+    }
+
+    #[test]
+    fn multiline_message_uses_subject_only() {
+        let msg = "feat: add login\n\nMerge pull request #1 from owner/branch";
+        assert!(!is_process_commit(msg));
+    }
+}

--- a/crates/standard-version/src/lib.rs
+++ b/crates/standard-version/src/lib.rs
@@ -112,7 +112,7 @@ fn commit_bump(commit: &ConventionalCommit) -> Option<BumpLevel> {
 
     match commit.r#type.as_str() {
         "feat" => Some(BumpLevel::Minor),
-        "fix" | "perf" => Some(BumpLevel::Patch),
+        "fix" | "perf" | "revert" => Some(BumpLevel::Patch),
         _ => None,
     }
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -238,6 +238,9 @@ Validate one or more commit messages against the conventional commit specificati
 4. Body, if present, is separated from subject by a blank line.
 5. Footer tokens (`BREAKING CHANGE:`, `Refs:`, etc.)
    follow the conventional commit footer spec.
+6. In `--range` mode: process commits (merges, reverts,
+   fixups, squashes, initial commits) are automatically
+   skipped and excluded from the valid/total count.
 
 **Input modes:**
 
@@ -270,14 +273,18 @@ $ git std check "added new feature"
 
 **Output with `--range`:**
 
+Process commits (merges, reverts, fixups) are automatically skipped
+and not counted as failures.
+
 ```text
 $ git std check --range main..HEAD
   ✓ feat(auth): add OAuth2 PKCE flow
   ✓ fix(auth): handle expired refresh tokens
+  ~ abc1234 Merge pull request #42 from owner/branch
   ✗ updated readme
     → missing type prefix
 
-2/3 valid
+2/3 valid  (1 skipped)
 ```
 
 ### 2.3 `git std bump`
@@ -796,18 +803,18 @@ regex = '<version>(.*)</version>'
 
 **Defaults when `.git-std.toml` is absent:**
 
-| Field                       | Default                                                                            |
-| --------------------------- | ---------------------------------------------------------------------------------- |
-| `scheme`                    | `semver`                                                                           |
-| `types`                     | `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build` |
-| `scopes`                    | None (no scope validation)                                                         |
-| `strict`                    | `false`                                                                            |
-| `versioning.tag_prefix`     | `v`                                                                                |
-| `versioning.prerelease_tag` | `rc`                                                                               |
-| `versioning.calver_format`  | `YYYY.MM.PATCH`                                                                    |
-| `changelog.hidden`          | `chore`, `ci`, `build`, `style`, `test`                                            |
-| `changelog.sections`        | Sensible defaults for each type                                                    |
-| `version_files`             | `[]` (empty — built-in files are always auto-detected)                             |
+| Field                       | Default                                                                                      |
+| --------------------------- | -------------------------------------------------------------------------------------------- |
+| `scheme`                    | `semver`                                                                                     |
+| `types`                     | `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert` |
+| `scopes`                    | None (no scope validation)                                                                   |
+| `strict`                    | `false`                                                                                      |
+| `versioning.tag_prefix`     | `v`                                                                                          |
+| `versioning.prerelease_tag` | `rc`                                                                                         |
+| `versioning.calver_format`  | `YYYY.MM.PATCH`                                                                              |
+| `changelog.hidden`          | `chore`, `ci`, `build`, `style`, `test`                                                      |
+| `changelog.sections`        | Sensible defaults for each type                                                              |
+| `version_files`             | `[]` (empty — built-in files are always auto-detected)                                       |
 
 **Inferred (not configurable):**
 


### PR DESCRIPTION
Closes #160

## Summary

Two related additions from issue #160:

1. **Process commit detection** — `standard_commit::is_process_commit()` classifies automatically generated commits (GitHub/GitLab/Gerrit merges, `git revert`, `fixup!`, `squash!`, `Initial commit`) so they can be skipped during validation.

2. **`revert` as a first-class type** — `revert` is added to defaults across the stack: allowed types, bump rules (patch), and changelog sections (Reverts).

## Changes

### `standard-commit` — new `process.rs` module

New `is_process_commit(message: &str) -> bool` function, exported from `lib.rs`. Matches the 10 patterns from the issue by inspecting the first line only. 20 unit tests covering all patterns plus negative cases.

### `git std check --range` — auto-skip process commits

- Process commits are printed with `~` and counted as skipped (not failures).
- Summary line shows `N/M valid  (K skipped)` when any are skipped.
- JSON output: skipped entries get `"skipped": true` (field omitted when false).

### `revert` type — default types, bump rule, changelog

| Touch point | Change |
|---|---|
| `git-std` config defaults | `revert` added to `DEFAULT_TYPES` (10 → 11) |
| `standard-version` bump | `revert` → `BumpLevel::Patch` |
| `standard-changelog` sections | `("revert", "Reverts")` added between `perf` and `refactor` |

### `docs/SPEC.md`

- §2.2: added rule 6 (process commit auto-skip in `--range` mode)
- §2.2: updated `--range` output example to show `~` skip line and `(1 skipped)` summary
- §3 defaults table: `revert` added to `types` default list

## Testing

- 20 new unit tests in `standard-commit::process`
- All 38+ existing tests pass with no regressions
- `just lint` clean (clippy, fmt, dprint, markdownlint)