### PR TITLE
refactor(git-std): remove result_line, unify with info

### DIFF
--- a/crates/git-std/src/cli/bootstrap.rs
+++ b/crates/git-std/src/cli/bootstrap.rs
@@ -42,7 +42,7 @@ pub fn run(dry_run: bool) -> i32 {
     // Tier 2 — custom bootstrap.hooks
     if Path::new(BOOTSTRAP_HOOKS_FILE).exists() {
         if dry_run {
-            ui::result_line(&format!("{}  custom bootstrap hooks executed", ui::pass()));
+            ui::info(&format!("{}  custom bootstrap hooks executed", ui::pass()));
         } else {
             let code = super::hooks::run("bootstrap", &[]);
             if code != 0 {
@@ -62,7 +62,7 @@ fn check_hooks_path(dry_run: bool) -> bool {
     }
 
     if dry_run {
-        ui::result_line(&format!("{}  git hooks configured", ui::pass()));
+        ui::info(&format!("{}  git hooks configured", ui::pass()));
         return true;
     }
 
@@ -72,7 +72,7 @@ fn check_hooks_path(dry_run: bool) -> bool {
 
     match status {
         Ok(s) if s.success() => {
-            ui::result_line(&format!("{}  git hooks configured", ui::pass()));
+            ui::info(&format!("{}  git hooks configured", ui::pass()));
             true
         }
         _ => {
@@ -118,7 +118,7 @@ fn check_lfs(dry_run: bool) -> bool {
     }
 
     if dry_run {
-        ui::result_line(&format!("{}  LFS objects downloaded", ui::pass()));
+        ui::info(&format!("{}  LFS objects downloaded", ui::pass()));
         return true;
     }
 
@@ -146,7 +146,7 @@ fn check_lfs(dry_run: bool) -> bool {
         return false;
     }
 
-    ui::result_line(&format!("{}  LFS objects downloaded", ui::pass()));
+    ui::info(&format!("{}  LFS objects downloaded", ui::pass()));
     true
 }
 
@@ -158,7 +158,7 @@ fn check_blame_ignore_revs(dry_run: bool) -> bool {
     }
 
     if dry_run {
-        ui::result_line(&format!("{}  blame ignore revs configured", ui::pass()));
+        ui::info(&format!("{}  blame ignore revs configured", ui::pass()));
         return true;
     }
 
@@ -168,7 +168,7 @@ fn check_blame_ignore_revs(dry_run: bool) -> bool {
 
     match status {
         Ok(s) if s.success() => {
-            ui::result_line(&format!("{}  blame ignore revs configured", ui::pass()));
+            ui::info(&format!("{}  blame ignore revs configured", ui::pass()));
             true
         }
         _ => {
@@ -238,10 +238,10 @@ pub fn install(force: bool) -> i32 {
     // Print summary
     ui::blank();
     for path in &created {
-        ui::result_line(&format!("{}  {path} created", ui::pass()));
+        ui::info(&format!("{}  {path} created", ui::pass()));
     }
     for path in &skipped {
-        ui::result_line(&format!(
+        ui::info(&format!(
             "{}  {path} already exists (use --force to overwrite)",
             ui::warn()
         ));

--- a/crates/git-std/src/cli/check.rs
+++ b/crates/git-std/src/cli/check.rs
@@ -158,7 +158,7 @@ pub fn run_range(range: &str, lint_config: Option<&LintConfig>, format: OutputFo
         let short = &oid[..7];
 
         if standard_commit::is_process_commit(message) {
-            ui::result_line(&format!("~ {} {}", short, first_line(message).dim(),));
+            ui::info(&format!("~ {} {}", short, first_line(message).dim(),));
             skipped += 1;
             continue;
         }
@@ -168,7 +168,7 @@ pub fn run_range(range: &str, lint_config: Option<&LintConfig>, format: OutputFo
             if errors.is_empty() {
                 true
             } else {
-                ui::result_line(&format!(
+                ui::info(&format!(
                     "{} {} {}",
                     ui::fail(),
                     short,
@@ -183,7 +183,7 @@ pub fn run_range(range: &str, lint_config: Option<&LintConfig>, format: OutputFo
             match standard_commit::parse(message) {
                 Ok(_) => true,
                 Err(e) => {
-                    ui::result_line(&format!(
+                    ui::info(&format!(
                         "{} {} {}",
                         ui::fail(),
                         short,
@@ -196,7 +196,7 @@ pub fn run_range(range: &str, lint_config: Option<&LintConfig>, format: OutputFo
         };
 
         if valid {
-            ui::result_line(&format!(
+            ui::info(&format!(
                 "{} {} {}",
                 ui::pass(),
                 short,

--- a/crates/git-std/src/cli/hooks/enable.rs
+++ b/crates/git-std/src/cli/hooks/enable.rs
@@ -17,7 +17,7 @@ pub fn enable(hook_name: &str) -> i32 {
     let off_path = hooks_dir.join(format!("{hook_name}.off"));
 
     if active_path.exists() {
-        ui::result_line(&format!("{} {hook_name} is already enabled", ui::warn()));
+        ui::info(&format!("{} {hook_name} is already enabled", ui::warn()));
         return 0;
     }
 
@@ -40,7 +40,7 @@ pub fn enable(hook_name: &str) -> i32 {
         let _ = std::fs::set_permissions(&active_path, perms);
     }
 
-    ui::result_line(&format!("{}  {hook_name} enabled", ui::pass()));
+    ui::info(&format!("{}  {hook_name} enabled", ui::pass()));
     0
 }
 
@@ -59,7 +59,7 @@ pub fn disable(hook_name: &str) -> i32 {
     let off_path = hooks_dir.join(format!("{hook_name}.off"));
 
     if off_path.exists() {
-        ui::result_line(&format!("{} {hook_name} is already disabled", ui::warn()));
+        ui::info(&format!("{} {hook_name} is already disabled", ui::warn()));
         return 0;
     }
 
@@ -75,6 +75,6 @@ pub fn disable(hook_name: &str) -> i32 {
         return 1;
     }
 
-    ui::result_line(&format!("{}  {hook_name} disabled", ui::pass()));
+    ui::info(&format!("{}  {hook_name} disabled", ui::pass()));
     0
 }

--- a/crates/git-std/src/cli/hooks/install.rs
+++ b/crates/git-std/src/cli/hooks/install.rs
@@ -22,7 +22,7 @@ pub fn install() -> i32 {
 
     match status {
         Ok(s) if s.success() => {
-            ui::result_line(&format!("{}  git hooks configured", ui::pass()));
+            ui::info(&format!("{}  git hooks configured", ui::pass()));
         }
         _ => {
             ui::error("failed to set core.hooksPath");
@@ -133,7 +133,7 @@ pub fn install() -> i32 {
             "disabled".dim().to_string()
         };
 
-        ui::result_line(&format!("{}  {hook_name:<22} {status_label}", ui::pass()));
+        ui::info(&format!("{}  {hook_name:<22} {status_label}", ui::pass()));
     }
 
     0

--- a/crates/git-std/src/cli/hooks/run.rs
+++ b/crates/git-std/src/cli/hooks/run.rs
@@ -277,19 +277,19 @@ fn execute_and_print(
 
     // Print the result line
     if success {
-        ui::result_line(&format!("{} {}", ui::pass(), display));
+        ui::info(&format!("{} {}", ui::pass(), display));
     } else if is_advisory {
         let info = match exit_code {
             Some(code) => format!("(advisory, exit {code})"),
             None => "(advisory, killed)".to_string(),
         };
-        ui::result_line(&format!("{} {} {}", ui::warn(), display, info.yellow()));
+        ui::info(&format!("{} {} {}", ui::warn(), display, info.yellow()));
     } else {
         let info = match exit_code {
             Some(code) => format!("(exit {code})"),
             None => "(killed)".to_string(),
         };
-        ui::result_line(&format!("{} {} {}", ui::fail(), display, info.red()));
+        ui::info(&format!("{} {} {}", ui::fail(), display, info.red()));
     }
 
     let failed = !success && !is_advisory;
@@ -313,7 +313,7 @@ pub fn run(hook: &str, args: &[String]) -> i32 {
     if let Ok(val) = std::env::var("GIT_STD_SKIP_HOOKS")
         && (val == "1" || val.eq_ignore_ascii_case("true"))
     {
-        ui::result_line(&format!(
+        ui::info(&format!(
             "{} hooks skipped (GIT_STD_SKIP_HOOKS)",
             ui::warn()
         ));

--- a/crates/git-std/src/ui.rs
+++ b/crates/git-std/src/ui.rs
@@ -87,13 +87,6 @@ pub fn print(msg: &str) {
     eprintln!("{msg}");
 }
 
-/// Print a plain indented line to stderr (two-space indent) with a leading symbol.
-///
-/// Suitable for check/hook result lines: `  ✓ <text>` or `  ✗ <text>`.
-pub fn result_line(msg: &str) {
-    eprintln!("{INDENT}{msg}");
-}
-
 /// Return `true` when stderr is connected to a terminal.
 pub fn is_tty() -> bool {
     std::io::stderr().is_terminal()


### PR DESCRIPTION
## Summary

`result_line` and `info` were byte-for-byte identical — both print a two-space indented line to stderr. This PR removes `result_line` and replaces all 23 call sites with `info`.

## Changes

- **Removed** `ui::result_line()` from `ui.rs`
- **Replaced** all 23 call sites across 5 files:
  - `cli/bootstrap.rs` (9 calls)
  - `cli/check.rs` (4 calls)
  - `cli/hooks/enable.rs` (4 calls)
  - `cli/hooks/install.rs` (2 calls)
  - `cli/hooks/run.rs` (4 calls)

No behaviour change — output is identical.

Closes #243