### PR TITLE
feat(git-std): install man pages and shell completions on install

### DIFF
--- a/crates/git-std/src/cli/bootstrap.rs
+++ b/crates/git-std/src/cli/bootstrap.rs
@@ -430,6 +430,16 @@ ensure_git_std() {{
   chmod +x "$INSTALL_DIR/git-std"
 
   printf 'installed git-std %s to %s/git-std\n' "$version" "$INSTALL_DIR"
+
+  # Install man pages if present in the tarball.
+  local man_dir="${{GIT_STD_MAN_DIR:-$INSTALL_DIR/../share/man/man1}}"
+  if ls "$tmp_dir"/git-std*.1 >/dev/null 2>&1; then
+    mkdir -p "$man_dir"
+    cp "$tmp_dir"/git-std*.1 "$man_dir/"
+    printf 'installed man pages to %s\n' "$man_dir"
+    printf "hint: if 'man git-std' doesn't work, add to your shell profile:\n"
+    printf "      export MANPATH=\"\$HOME/.local/share/man:\${{MANPATH:-}}\"\n"
+  fi
 }}
 
 ensure_git_std

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,48 @@ tmp_dir=""
 
 die() { printf 'error: %s\n' "$1" >&2; exit 1; }
 
+detect_shell() {
+  case "$(basename "${SHELL:-}")" in
+    bash) echo "bash" ;;
+    zsh)  echo "zsh"  ;;
+    fish) echo "fish" ;;
+    *)    echo ""     ;;
+  esac
+}
+
+install_completions() {
+  local shell rc_file snippet
+  shell="$(detect_shell)"
+  case "$shell" in
+    bash) rc_file="$HOME/.bashrc"; snippet="eval \"\$(git-std completions bash)\"" ;;
+    zsh)  rc_file="$HOME/.zshrc";  snippet="eval \"\$(git-std completions zsh)\""  ;;
+    fish)
+      mkdir -p "$HOME/.config/fish/conf.d"
+      rc_file="$HOME/.config/fish/conf.d/git-std.fish"
+      snippet='git-std completions fish | source'
+      ;;
+    *)
+      printf 'note: unknown shell %s — add completions manually\n' "${SHELL:-}" >&2
+      return
+      ;;
+  esac
+
+  # Don't create a missing RC file (fish conf.d/ dir already created above).
+  if [ "$shell" != "fish" ] && [ ! -f "$rc_file" ]; then
+    printf 'note: %s not found — add completions manually\n' "$rc_file" >&2
+    return
+  fi
+
+  if grep -q 'git-std completions' "$rc_file" 2>/dev/null; then
+    printf 'completions already configured in %s\n' "$rc_file"
+    return
+  fi
+
+  printf '\n# git-std completions\n%s\n' "$snippet" >> "$rc_file"
+  printf 'completions installed to %s\n' "$rc_file"
+  printf 'note: restart your shell or run: source %s\n' "$rc_file"
+}
+
 sha256_check() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum -c "$1"
@@ -83,7 +125,12 @@ main() {
     mkdir -p "$man_dir"
     cp "$tmp_dir"/git-std*.1 "$man_dir/"
     printf 'installed man pages to %s\n' "$man_dir"
+    printf "hint: if 'man git-std' doesn't work, add to your shell profile:\n"
+    printf "      export MANPATH=\"\$HOME/.local/share/man:\${MANPATH:-}\"\n"
   fi
+
+  # Install shell completions.
+  install_completions
 
   # Verify
   if command -v git-std >/dev/null 2>&1; then

--- a/justfile
+++ b/justfile
@@ -70,10 +70,43 @@ publish: check
     @echo ""
     @echo "==> All crates published."
 
-# Build release binary and install to ~/.local/bin
+# Build release binary, man pages, and shell completions, then install to ~/.local/bin
 install:
+    #!/usr/bin/env bash
+    set -euo pipefail
     cargo build --release
     cp target/release/git-std ~/.local/bin/
+
+    just man
+    mkdir -p ~/.local/share/man/man1
+    cp target/man/*.1 ~/.local/share/man/man1/
+    printf "hint: if 'man git-std' doesn't work, add to your shell profile:\n"
+    printf "      export MANPATH=\"\$HOME/.local/share/man:\${MANPATH:-}\"\n"
+
+    shell="$(basename "${SHELL:-}")"
+    case "$shell" in
+      bash) rc="$HOME/.bashrc"; s="eval \"\$(git-std completions bash)\"" ;;
+      zsh)  rc="$HOME/.zshrc";  s="eval \"\$(git-std completions zsh)\""  ;;
+      fish)
+        mkdir -p "$HOME/.config/fish/conf.d"
+        rc="$HOME/.config/fish/conf.d/git-std.fish"
+        s='git-std completions fish | source'
+        ;;
+      *)
+        printf 'note: add completions manually for %s\n' "${SHELL:-}" >&2
+        exit 0
+        ;;
+    esac
+    if [ "$shell" != "fish" ] && [ ! -f "$rc" ]; then
+      printf 'note: %s not found — add completions manually\n' "$rc" >&2
+      exit 0
+    fi
+    if grep -q 'git-std completions' "$rc" 2>/dev/null; then
+      printf 'completions already configured in %s\n' "$rc"
+    else
+      printf '\n# git-std completions\n%s\n' "$s" >> "$rc"
+      printf 'completions installed to %s\n' "$rc"
+    fi
 
 # Remove build artifacts
 clean:


### PR DESCRIPTION
## Summary

- `install.sh`: detect `$SHELL` and append the sourcing snippet to `~/.bashrc`, `~/.zshrc`, or `~/.config/fish/conf.d/git-std.fish`; skip if already present; never create a missing RC file; print a MANPATH hint after man pages are installed
- `justfile install`: build and copy man pages to `~/.local/share/man/man1`, then run the same shell completion setup
- `bootstrap.rs`: add man page installation to the generated `ensure_git_std()` function so the bootstrapped script also installs man pages

## Safety

- Append-only (`>>`), never overwrites existing RC files
- Idempotent: skips if `git-std completions` is already in the target file
- Does not create a missing `~/.bashrc` or `~/.zshrc`
- Unknown shells get a warning, not a failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)