### PR TITLE
fix(git-std): write config get JSON null to stdout

### DIFF
--- a/crates/git-std/src/cli/config.rs
+++ b/crates/git-std/src/cli/config.rs
@@ -279,10 +279,7 @@ pub fn get(dir: &Path, key: &str, format: OutputFormat) -> i32 {
             0
         }
         "changelog.bug_url" => {
-            match &cfg.changelog.bug_url {
-                Some(u) => print_value(u, format),
-                None => eprintln!("null"),
-            }
+            print_optional_value(cfg.changelog.bug_url.as_deref(), format);
             0
         }
         unknown => {
@@ -352,6 +349,20 @@ fn print_value(value: &str, format: OutputFormat) {
         println!("{}", serde_json::to_string(value).unwrap());
     } else {
         eprintln!("{value}");
+    }
+}
+
+/// Print an optional value: JSON `null` to stdout, text `"null"` to stderr.
+fn print_optional_value(value: Option<&str>, format: OutputFormat) {
+    match value {
+        Some(v) => print_value(v, format),
+        None => {
+            if format == OutputFormat::Json {
+                println!("null");
+            } else {
+                eprintln!("null");
+            }
+        }
     }
 }
 

--- a/crates/git-std/tests/config.rs
+++ b/crates/git-std/tests/config.rs
@@ -227,6 +227,42 @@ fn config_get_reflects_toml_value() {
         .stderr(contains("true"));
 }
 
+// ── config get nullable keys (#315) ──────────────────────────────
+
+#[test]
+fn config_get_json_bug_url_null_goes_to_stdout() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = git_std()
+        .args(["config", "get", "changelog.bug_url", "--format", "json"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "null");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("null"), "null should not appear on stderr");
+}
+
+#[test]
+fn config_get_text_bug_url_null_goes_to_stderr() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = git_std()
+        .args(["config", "get", "changelog.bug_url"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("null"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.is_empty(), "text mode should not write to stdout");
+}
+
 // ── config subcommand requires subcommand ────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- Fix `config get changelog.bug_url --format json` writing `null` to stderr instead of stdout
- Add `print_optional_value` helper that routes JSON null to stdout and text null to stderr
- Add integration tests for both JSON and text output modes

Closes #315

## Test plan
- [x] `cargo test --test config` — all 20 tests pass
- [x] `cargo clippy -p git-std -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)