### PR TITLE
fix(docs): add missing revert to default types in schema and CONFIG

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -30,7 +30,7 @@ Or use a [taplo](https://taplo.tamasfe.dev) inline directive
 scheme = "semver"                              # semver | calver | patch
 types = ["feat", "fix", "docs", "style",
          "refactor", "perf", "test",
-         "chore", "ci", "build"]
+         "chore", "ci", "build", "revert"]
 scopes = ["auth", "api", "ci", "deps"]         # "auto" | string[] | omit
 strict = true                         # enforce types/scopes
 
@@ -66,12 +66,12 @@ regex = '<version>([^<]+)</version>'
 | Field    | Type                 | Default           | Description                                             |
 | -------- | -------------------- | ----------------- | ------------------------------------------------------- |
 | `scheme` | string               | `"semver"`        | Versioning scheme (see below)                           |
-| `types`  | string[]             | 10 standard types | Allowed conventional commit types                       |
+| `types`  | string[]             | 11 standard types | Allowed conventional commit types                       |
 | `scopes` | `"auto"` or string[] | None              | Scope discovery or explicit allowlist                   |
 | `strict` | bool                 | `false`           | Enforce types/scopes validation without `--strict` flag |
 
 Default types: `feat`, `fix`, `docs`, `style`, `refactor`,
-`perf`, `test`, `chore`, `ci`, `build`.
+`perf`, `test`, `chore`, `ci`, `build`, `revert`.
 
 **Versioning schemes:**
 

--- a/docs/schema/v1/git-std.toml.json
+++ b/docs/schema/v1/git-std.toml.json
@@ -24,7 +24,7 @@
       },
       "default": [
         "feat", "fix", "docs", "style", "refactor",
-        "perf", "test", "chore", "ci", "build"
+        "perf", "test", "chore", "ci", "build", "revert"
       ],
       "description": "Allowed conventional commit types. Used for validation in strict mode and for the interactive commit prompt."
     },


### PR DESCRIPTION
## Summary

- Adds `revert` to the default types list in `docs/schema/v1/git-std.toml.json` and `docs/CONFIG.md`
- The codebase (`config/load.rs`) includes 11 default types with `revert`, but the published schema and docs only listed 10

## Test plan

- [x] JSON schema matches codebase defaults
- [x] CONFIG.md matches codebase defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)