### PR TITLE
fix(ci): use sha256sum instead of shasum in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           tar czf git-std-${{ matrix.target }}.tar.gz -C staging .
       - name: Generate SHA256 checksum
         shell: bash
-        run: shasum -a 256 git-std-${{ matrix.target }}.tar.gz > git-std-${{ matrix.target }}.tar.gz.sha256
+        run: sha256sum git-std-${{ matrix.target }}.tar.gz > git-std-${{ matrix.target }}.tar.gz.sha256
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary

- Replaces `shasum -a 256` with `sha256sum` in the release workflow
- `shasum` is not available on Windows Git Bash runners, causing the Windows build to fail
- `sha256sum` is available on all three platforms (Linux, macOS, Windows)

Fixes the v0.7.0 release build failure: https://github.com/driftsys/git-std/actions/runs/23687787810

## Test plan

- [ ] Re-run release workflow after merge to verify Windows build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)