### PR TITLE
feat(config): add monorepo flag, packages schema, and tag_template

### DIFF
--- a/crates/git-std/src/cli/config.rs
+++ b/crates/git-std/src/cli/config.rs
@@ -99,6 +99,13 @@ pub fn list(dir: &Path, format: OutputFormat) -> i32 {
         }
     }
 
+    let monorepo_src = if has_key("monorepo") {
+        Source::File
+    } else {
+        Source::Default
+    };
+    print_kv("monorepo", &cfg.monorepo.to_string(), monorepo_src);
+
     // ── [versioning] ────────────────────────────────────────────
     ui::blank();
     ui::info("[versioning]");
@@ -134,6 +141,17 @@ pub fn list(dir: &Path, format: OutputFormat) -> i32 {
         "calver_format",
         &format!("{:?}", cfg.versioning.calver_format),
         calver_src,
+    );
+
+    let tag_template_src = if has_versioning_key("tag_template") {
+        Source::File
+    } else {
+        Source::Default
+    };
+    print_kv(
+        "tag_template",
+        &format!("{:?}", cfg.versioning.tag_template),
+        tag_template_src,
     );
 
     // ── [changelog] ─────────────────────────────────────────────
@@ -191,6 +209,27 @@ pub fn list(dir: &Path, format: OutputFormat) -> i32 {
         }
     }
 
+    // ── [[packages]] ────────────────────────────────────────────
+    if !cfg.packages.is_empty() {
+        ui::blank();
+        ui::info("[[packages]]");
+        for pkg in &cfg.packages {
+            let mut parts = vec![
+                format!("name = {:?}", pkg.name),
+                format!("path = {:?}", pkg.path),
+            ];
+            if let Some(ref scheme) = pkg.scheme {
+                let label = match scheme {
+                    config::Scheme::Semver => "semver",
+                    config::Scheme::Calver => "calver",
+                    config::Scheme::Patch => "patch",
+                };
+                parts.push(format!("scheme = {label:?}"));
+            }
+            ui::detail(&parts.join(", "));
+        }
+    }
+
     0
 }
 
@@ -211,6 +250,10 @@ pub fn get(dir: &Path, key: &str, format: OutputFormat) -> i32 {
         }
         "strict" => {
             print_value(&cfg.strict.to_string(), format);
+            0
+        }
+        "monorepo" => {
+            print_value(&cfg.monorepo.to_string(), format);
             0
         }
         "types" => {
@@ -244,6 +287,10 @@ pub fn get(dir: &Path, key: &str, format: OutputFormat) -> i32 {
         }
         "versioning.calver_format" => {
             print_value(&cfg.versioning.calver_format, format);
+            0
+        }
+        "versioning.tag_template" => {
+            print_value(&cfg.versioning.tag_template, format);
             0
         }
         "changelog.title" => {
@@ -284,9 +331,11 @@ pub fn get(dir: &Path, key: &str, format: OutputFormat) -> i32 {
         }
         unknown => {
             ui::error(&format!("unknown config key: {unknown:?}"));
-            ui::info("supported keys: scheme, strict, types, scopes, versioning.tag_prefix,");
-            ui::info("  versioning.prerelease_tag, versioning.calver_format, changelog.title,");
-            ui::info("  changelog.hidden, changelog.sections, changelog.bug_url");
+            ui::info("supported keys: scheme, strict, monorepo, types, scopes,");
+            ui::info("  versioning.tag_prefix, versioning.prerelease_tag,");
+            ui::info("  versioning.calver_format, versioning.tag_template,");
+            ui::info("  changelog.title, changelog.hidden, changelog.sections,");
+            ui::info("  changelog.bug_url");
             1
         }
     }
@@ -324,12 +373,14 @@ fn list_json(cfg: &config::ProjectConfig) -> i32 {
     let obj = serde_json::json!({
         "scheme": scheme,
         "strict": cfg.strict,
+        "monorepo": cfg.monorepo,
         "types": cfg.types,
         "scopes": scopes_json,
         "versioning": {
             "tag_prefix": cfg.versioning.tag_prefix,
             "prerelease_tag": cfg.versioning.prerelease_tag,
             "calver_format": cfg.versioning.calver_format,
+            "tag_template": cfg.versioning.tag_template,
         },
         "changelog": {
             "title": title,
@@ -337,6 +388,21 @@ fn list_json(cfg: &config::ProjectConfig) -> i32 {
             "sections": sections_map,
             "bug_url": cfg.changelog.bug_url,
         },
+        "packages": cfg.packages.iter().map(|p| {
+            let mut obj = serde_json::json!({
+                "name": p.name,
+                "path": p.path,
+            });
+            if let Some(ref scheme) = p.scheme {
+                let label = match scheme {
+                    config::Scheme::Semver => "semver",
+                    config::Scheme::Calver => "calver",
+                    config::Scheme::Patch => "patch",
+                };
+                obj["scheme"] = serde_json::Value::String(label.to_string());
+            }
+            obj
+        }).collect::<Vec<_>>(),
     });
 
     println!("{}", serde_json::to_string_pretty(&obj).unwrap());

--- a/crates/git-std/src/config/load.rs
+++ b/crates/git-std/src/config/load.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 
 use super::{
-    ChangelogConfig, ProjectConfig, Scheme, ScopesConfig, VersionFileConfig, VersioningConfig,
+    ChangelogConfig, PackageConfig, ProjectConfig, Scheme, ScopesConfig, VersionFileConfig,
+    VersioningConfig,
 };
 
 /// Config filename.
@@ -29,6 +30,8 @@ pub fn load(dir: &Path) -> ProjectConfig {
             changelog: ChangelogConfig::default(),
             versioning: VersioningConfig::default(),
             version_files: Vec::new(),
+            monorepo: false,
+            packages: Vec::new(),
         },
     }
 }
@@ -74,6 +77,8 @@ fn default_config() -> ProjectConfig {
         changelog: ChangelogConfig::default(),
         versioning: VersioningConfig::default(),
         version_files: Vec::new(),
+        monorepo: false,
+        packages: Vec::new(),
     }
 }
 
@@ -123,6 +128,11 @@ fn build_config(table: &toml::Table) -> ProjectConfig {
     let changelog = parse_changelog_config(table);
     let versioning = parse_versioning_config(table);
     let version_files = parse_version_files(table);
+    let monorepo = table
+        .get("monorepo")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let packages = parse_packages(table);
 
     // Validate calver_format when scheme is calver.
     let versioning = if scheme == Scheme::Calver {
@@ -150,6 +160,8 @@ fn build_config(table: &toml::Table) -> ProjectConfig {
         changelog,
         versioning,
         version_files,
+        monorepo,
+        packages,
     }
 }
 
@@ -179,10 +191,17 @@ fn parse_versioning_config(table: &toml::Table) -> VersioningConfig {
         .map(String::from)
         .unwrap_or(defaults.calver_format);
 
+    let tag_template = versioning_table
+        .get("tag_template")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or(defaults.tag_template);
+
     VersioningConfig {
         tag_prefix,
         prerelease_tag,
         calver_format,
+        tag_template,
     }
 }
 
@@ -201,44 +220,84 @@ fn parse_version_files(table: &toml::Table) -> Vec<VersionFileConfig> {
         .collect()
 }
 
-fn parse_changelog_config(table: &toml::Table) -> ChangelogConfig {
-    let changelog_table = match table.get("changelog").and_then(|v| v.as_table()) {
-        Some(t) => t,
-        None => return ChangelogConfig::default(),
+fn parse_packages(table: &toml::Table) -> Vec<PackageConfig> {
+    let Some(arr) = table.get("packages").and_then(|v| v.as_array()) else {
+        return Vec::new();
     };
 
-    let title = changelog_table
+    arr.iter()
+        .filter_map(|entry| {
+            let t = entry.as_table()?;
+            let name = t.get("name")?.as_str()?.to_string();
+            let path = t.get("path")?.as_str()?.to_string();
+
+            let scheme = t.get("scheme").and_then(|v| v.as_str()).map(|s| match s {
+                "calver" => Scheme::Calver,
+                "patch" => Scheme::Patch,
+                _ => Scheme::Semver,
+            });
+
+            let version_files = t.get("version_files").and_then(|v| v.as_array()).map(|a| {
+                a.iter()
+                    .filter_map(|entry| {
+                        let t = entry.as_table()?;
+                        let path = t.get("path")?.as_str()?.to_string();
+                        let regex = t.get("regex")?.as_str()?.to_string();
+                        Some(VersionFileConfig { path, regex })
+                    })
+                    .collect()
+            });
+
+            let changelog = t
+                .get("changelog")
+                .and_then(|v| v.as_table())
+                .map(parse_changelog_from_table);
+
+            Some(PackageConfig {
+                name,
+                path,
+                scheme,
+                version_files,
+                changelog,
+            })
+        })
+        .collect()
+}
+
+fn parse_changelog_from_table(table: &toml::Table) -> ChangelogConfig {
+    let title = table
         .get("title")
         .and_then(|v| v.as_str())
         .map(String::from);
 
-    let hidden = changelog_table
-        .get("hidden")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        });
+    let hidden = table.get("hidden").and_then(|v| v.as_array()).map(|arr| {
+        arr.iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect()
+    });
 
-    let bug_url = changelog_table
+    let bug_url = table
         .get("bug_url")
         .and_then(|v| v.as_str())
         .map(String::from);
 
-    let sections = changelog_table
-        .get("sections")
-        .and_then(|v| v.as_table())
-        .map(|t| {
-            t.iter()
-                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                .collect()
-        });
+    let sections = table.get("sections").and_then(|v| v.as_table()).map(|t| {
+        t.iter()
+            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+            .collect()
+    });
 
     ChangelogConfig {
         title,
         sections,
         hidden,
         bug_url,
+    }
+}
+
+fn parse_changelog_config(table: &toml::Table) -> ChangelogConfig {
+    match table.get("changelog").and_then(|v| v.as_table()) {
+        Some(t) => parse_changelog_from_table(t),
+        None => ChangelogConfig::default(),
     }
 }

--- a/crates/git-std/src/config/mod.rs
+++ b/crates/git-std/src/config/mod.rs
@@ -71,6 +71,9 @@ impl Serialize for ScopesConfig {
     }
 }
 
+/// Default tag template for per-package tags.
+pub const DEFAULT_TAG_TEMPLATE: &str = "{name}@{version}";
+
 /// Versioning configuration.
 #[derive(Debug, Clone, Serialize)]
 pub struct VersioningConfig {
@@ -80,6 +83,10 @@ pub struct VersioningConfig {
     pub prerelease_tag: String,
     /// Calver format string (e.g. `"YYYY.MM.PATCH"`).
     pub calver_format: String,
+    /// Tag template for per-package tags (default `"{name}@{version}"`).
+    ///
+    /// Supports `{name}` and `{version}` placeholders.
+    pub tag_template: String,
 }
 
 impl Default for VersioningConfig {
@@ -88,6 +95,7 @@ impl Default for VersioningConfig {
             tag_prefix: "v".to_string(),
             prerelease_tag: "rc".to_string(),
             calver_format: standard_version::calver::DEFAULT_FORMAT.to_string(),
+            tag_template: DEFAULT_TAG_TEMPLATE.to_string(),
         }
     }
 }
@@ -110,6 +118,21 @@ pub struct VersionFileConfig {
     pub regex: String,
 }
 
+/// Per-package configuration for monorepo workspaces.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct PackageConfig {
+    /// Package name (used in tags and changelog headings).
+    pub name: String,
+    /// Path to the package root, relative to the repository root.
+    pub path: String,
+    /// Override the global versioning scheme for this package.
+    pub scheme: Option<Scheme>,
+    /// Override version files for this package.
+    pub version_files: Option<Vec<VersionFileConfig>>,
+    /// Override changelog configuration for this package.
+    pub changelog: Option<ChangelogConfig>,
+}
+
 /// Project configuration loaded from `.git-std.toml`.
 #[derive(Debug, Default, Serialize)]
 pub struct ProjectConfig {
@@ -120,6 +143,10 @@ pub struct ProjectConfig {
     pub changelog: ChangelogConfig,
     pub versioning: VersioningConfig,
     pub version_files: Vec<VersionFileConfig>,
+    /// Enable per-package monorepo versioning.
+    pub monorepo: bool,
+    /// Explicit package definitions (auto-discovered when empty and `monorepo = true`).
+    pub packages: Vec<PackageConfig>,
 }
 
 impl ProjectConfig {

--- a/crates/git-std/src/config/tests.rs
+++ b/crates/git-std/src/config/tests.rs
@@ -1,5 +1,5 @@
 use super::load::{DEFAULT_TYPES, default_types, load, parse_config};
-use super::{ProjectConfig, Scheme, ScopesConfig, discover_scopes};
+use super::{DEFAULT_TAG_TEMPLATE, ProjectConfig, Scheme, ScopesConfig, discover_scopes};
 
 #[test]
 fn default_types_when_no_config() {
@@ -494,4 +494,215 @@ fn default_types_function_returns_all_types() {
     for t in DEFAULT_TYPES {
         assert!(types.contains(&t.to_string()));
     }
+}
+
+// ── monorepo ────────────────────────────────────────────────
+
+#[test]
+fn monorepo_default_false() {
+    let config = parse_config(r#"types = ["feat"]"#);
+    assert!(!config.monorepo);
+}
+
+#[test]
+fn monorepo_true_parsed() {
+    let config = parse_config("monorepo = true\n");
+    assert!(config.monorepo);
+}
+
+#[test]
+fn monorepo_false_explicit() {
+    let config = parse_config("monorepo = false\n");
+    assert!(!config.monorepo);
+}
+
+#[test]
+fn monorepo_missing_defaults_false() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = load(dir.path());
+    assert!(!config.monorepo);
+}
+
+// ── packages ────────────────────────────────────────────────
+
+#[test]
+fn packages_default_empty() {
+    let config = parse_config(r#"types = ["feat"]"#);
+    assert!(config.packages.is_empty());
+}
+
+#[test]
+fn packages_parsed_with_name_and_path() {
+    let config = parse_config(
+        r#"
+[[packages]]
+name = "core"
+path = "crates/core"
+
+[[packages]]
+name = "cli"
+path = "crates/cli"
+"#,
+    );
+    assert_eq!(config.packages.len(), 2);
+    assert_eq!(config.packages[0].name, "core");
+    assert_eq!(config.packages[0].path, "crates/core");
+    assert_eq!(config.packages[1].name, "cli");
+    assert_eq!(config.packages[1].path, "crates/cli");
+}
+
+#[test]
+fn packages_with_scheme_override() {
+    let config = parse_config(
+        r#"
+[[packages]]
+name = "core"
+path = "crates/core"
+scheme = "patch"
+"#,
+    );
+    assert_eq!(config.packages.len(), 1);
+    assert_eq!(config.packages[0].scheme, Some(Scheme::Patch));
+}
+
+#[test]
+fn packages_with_version_files_override() {
+    let config = parse_config(
+        r#"
+[[packages]]
+name = "core"
+path = "crates/core"
+
+[[packages.version_files]]
+path = "version.txt"
+regex = '(\d+\.\d+\.\d+)'
+"#,
+    );
+    assert_eq!(config.packages.len(), 1);
+    let vf = config.packages[0].version_files.as_ref().unwrap();
+    assert_eq!(vf.len(), 1);
+    assert_eq!(vf[0].path, "version.txt");
+}
+
+#[test]
+fn packages_with_changelog_override() {
+    let config = parse_config(
+        r#"
+[[packages]]
+name = "core"
+path = "crates/core"
+
+[packages.changelog]
+title = "Core Changelog"
+hidden = ["chore"]
+"#,
+    );
+    assert_eq!(config.packages.len(), 1);
+    let cl = config.packages[0].changelog.as_ref().unwrap();
+    assert_eq!(cl.title, Some("Core Changelog".to_string()));
+    assert_eq!(cl.hidden, Some(vec!["chore".to_string()]));
+}
+
+#[test]
+fn packages_missing_name_skipped() {
+    let config = parse_config(
+        r#"
+[[packages]]
+path = "crates/core"
+"#,
+    );
+    assert!(config.packages.is_empty());
+}
+
+#[test]
+fn packages_missing_path_skipped() {
+    let config = parse_config(
+        r#"
+[[packages]]
+name = "core"
+"#,
+    );
+    assert!(config.packages.is_empty());
+}
+
+#[test]
+fn packages_no_overrides_uses_none() {
+    let config = parse_config(
+        r#"
+[[packages]]
+name = "core"
+path = "crates/core"
+"#,
+    );
+    assert_eq!(config.packages[0].scheme, None);
+    assert!(config.packages[0].version_files.is_none());
+    assert!(config.packages[0].changelog.is_none());
+}
+
+// ── tag_template ────────────────────────────────────────────
+
+#[test]
+fn tag_template_default() {
+    let config = parse_config(r#"types = ["feat"]"#);
+    assert_eq!(config.versioning.tag_template, DEFAULT_TAG_TEMPLATE);
+}
+
+#[test]
+fn tag_template_custom() {
+    let config = parse_config(
+        r#"
+[versioning]
+tag_template = "{name}/v{version}"
+"#,
+    );
+    assert_eq!(config.versioning.tag_template, "{name}/v{version}");
+}
+
+#[test]
+fn tag_template_with_other_versioning_fields() {
+    let config = parse_config(
+        r#"
+[versioning]
+tag_prefix = "v"
+tag_template = "@{name}@{version}"
+"#,
+    );
+    assert_eq!(config.versioning.tag_prefix, "v");
+    assert_eq!(config.versioning.tag_template, "@{name}@{version}");
+}
+
+// ── full monorepo config ────────────────────────────────────
+
+#[test]
+fn full_monorepo_config() {
+    let config = parse_config(
+        r#"
+monorepo = true
+scheme = "semver"
+strict = true
+scopes = "auto"
+
+[versioning]
+tag_template = "{name}@{version}"
+
+[[packages]]
+name = "standard-commit"
+path = "crates/standard-commit"
+
+[[packages]]
+name = "standard-version"
+path = "crates/standard-version"
+scheme = "patch"
+"#,
+    );
+    assert!(config.monorepo);
+    assert_eq!(config.scheme, Scheme::Semver);
+    assert!(config.strict);
+    assert_eq!(config.scopes, ScopesConfig::Auto);
+    assert_eq!(config.versioning.tag_template, "{name}@{version}");
+    assert_eq!(config.packages.len(), 2);
+    assert_eq!(config.packages[0].name, "standard-commit");
+    assert_eq!(config.packages[0].scheme, None);
+    assert_eq!(config.packages[1].name, "standard-version");
+    assert_eq!(config.packages[1].scheme, Some(Scheme::Patch));
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -33,12 +33,14 @@ types = ["feat", "fix", "docs", "style",
          "chore", "ci", "build", "revert"]
 scopes = ["auth", "api", "ci", "deps"]         # "auto" | string[] | omit
 strict = true                         # enforce types/scopes
+monorepo = false                      # per-package versioning
 
 # ── Versioning ────────────────────────────────────────────────────
 [versioning]
 tag_prefix = "v"                               # git tag prefix
 prerelease_tag = "rc"                          # default pre-release id
 calver_format = "YYYY.MM.PATCH"                # only when scheme = "calver"
+tag_template = "{name}@{version}"              # per-package tag format
 
 # ── Changelog ─────────────────────────────────────────────────────
 [changelog]
@@ -57,18 +59,25 @@ docs = "Documentation"
 [[version_files]]
 path = "pom.xml"
 regex = '<version>([^<]+)</version>'
+
+# ── Packages (monorepo) ─────────────────────────────────────
+[[packages]]
+name = "core"
+path = "crates/core"
+# scheme = "patch"                             # optional override
 ```
 
 ## Fields
 
 ### Top-level
 
-| Field    | Type                 | Default           | Description                                             |
-| -------- | -------------------- | ----------------- | ------------------------------------------------------- |
-| `scheme` | string               | `"semver"`        | Versioning scheme (see below)                           |
-| `types`  | string[]             | 11 standard types | Allowed conventional commit types                       |
-| `scopes` | `"auto"` or string[] | None              | Scope discovery or explicit allowlist                   |
-| `strict` | bool                 | `false`           | Enforce types/scopes validation without `--strict` flag |
+| Field      | Type                 | Default           | Description                                             |
+| ---------- | -------------------- | ----------------- | ------------------------------------------------------- |
+| `scheme`   | string               | `"semver"`        | Versioning scheme (see below)                           |
+| `types`    | string[]             | 11 standard types | Allowed conventional commit types                       |
+| `scopes`   | `"auto"` or string[] | None              | Scope discovery or explicit allowlist                   |
+| `strict`   | bool                 | `false`           | Enforce types/scopes validation without `--strict` flag |
+| `monorepo` | bool                 | `false`           | Enable per-package versioning                           |
 
 Default types: `feat`, `fix`, `docs`, `style`, `refactor`,
 `perf`, `test`, `chore`, `ci`, `build`, `revert`.
@@ -100,11 +109,12 @@ populate the interactive scope prompt.
 
 ### `[versioning]`
 
-| Field            | Type   | Default           | Description                                             |
-| ---------------- | ------ | ----------------- | ------------------------------------------------------- |
-| `tag_prefix`     | string | `"v"`             | Git tag prefix (e.g., `v1.0.0`)                         |
-| `prerelease_tag` | string | `"rc"`            | Default pre-release identifier                          |
-| `calver_format`  | string | `"YYYY.MM.PATCH"` | Calendar version format (only when `scheme = "calver"`) |
+| Field            | Type   | Default              | Description                                             |
+| ---------------- | ------ | -------------------- | ------------------------------------------------------- |
+| `tag_prefix`     | string | `"v"`                | Git tag prefix (e.g., `v1.0.0`)                         |
+| `prerelease_tag` | string | `"rc"`               | Default pre-release identifier                          |
+| `calver_format`  | string | `"YYYY.MM.PATCH"`    | Calendar version format (only when `scheme = "calver"`) |
+| `tag_template`   | string | `"{name}@{version}"` | Per-package tag format (only when `monorepo = true`)    |
 
 **Calendar version format tokens:**
 
@@ -174,6 +184,38 @@ Entries with missing `path` or `regex` are silently skipped.
 These are in addition to auto-detected version files
 (e.g. `Cargo.toml`).
 
+### `[[packages]]`
+
+Explicit package definitions for monorepo workspaces. When
+`monorepo = true` and no packages are listed, git-std
+auto-discovers packages from workspace manifests (Cargo,
+npm, Deno) or subdirectories with version files.
+
+```toml
+[[packages]]
+name = "core"
+path = "crates/core"
+scheme = "patch"                   # optional: override global scheme
+
+[[packages.version_files]]         # optional: override version files
+path = "version.txt"
+regex = '(\d+\.\d+\.\d+)'
+
+[packages.changelog]               # optional: override changelog config
+title = "Core Changelog"
+hidden = ["chore"]
+```
+
+| Field           | Type   | Description                                |
+| --------------- | ------ | ------------------------------------------ |
+| `name`          | string | Package name (used in tags and changelogs) |
+| `path`          | string | Package root relative to repo root         |
+| `scheme`        | string | Optional versioning scheme override        |
+| `version_files` | array  | Optional version files override            |
+| `changelog`     | table  | Optional changelog config override         |
+
+Entries with missing `name` or `path` are silently skipped.
+
 ## Inferred settings
 
 These are not configurable — git-std resolves them automatically:
@@ -217,4 +259,23 @@ hidden = ["chore", "ci"]
 feat = "New Features"
 fix = "Bug Fixes"
 perf = "Performance Improvements"
+```
+
+**Monorepo with per-package versioning:**
+
+```toml
+monorepo = true
+scheme = "semver"
+scopes = "auto"
+
+[versioning]
+tag_template = "{name}@{version}"
+
+[[packages]]
+name = "core"
+path = "crates/core"
+
+[[packages]]
+name = "cli"
+path = "crates/cli"
 ```

--- a/docs/schema/v1/git-std.toml.json
+++ b/docs/schema/v1/git-std.toml.json
@@ -50,6 +50,11 @@
       "default": false,
       "description": "Enforce types and scopes validation without requiring the --strict CLI flag."
     },
+    "monorepo": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable per-package versioning. When true, each package gets its own version, changelog, and tag based on which files changed."
+    },
     "versioning": {
       "type": "object",
       "description": "Version bump settings.",
@@ -69,6 +74,11 @@
           "type": "string",
           "default": "YYYY.MM.PATCH",
           "description": "Calendar version format. Tokens: YYYY (full year), YY (short year), 0M (zero-padded month), MM (month), WW (ISO week), DD (day), PATCH (auto-incrementing counter), DP (day-of-week + patch). Only used when scheme = \"calver\"."
+        },
+        "tag_template": {
+          "type": "string",
+          "default": "{name}@{version}",
+          "description": "Tag format for per-package tags. Supports {name} and {version} placeholders. Only used when monorepo = true."
         }
       }
     },
@@ -125,6 +135,77 @@
           "regex": {
             "type": "string",
             "description": "Regex whose first capture group contains the version string."
+          }
+        }
+      }
+    },
+    "packages": {
+      "type": "array",
+      "description": "Explicit package definitions for monorepo workspaces. When monorepo = true and no packages are listed, packages are auto-discovered from workspace manifests.",
+      "items": {
+        "type": "object",
+        "required": ["name", "path"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Package name, used in tags and changelog headings."
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Package root directory relative to the repository root."
+          },
+          "scheme": {
+            "type": "string",
+            "enum": ["semver", "calver", "patch"],
+            "description": "Override the global versioning scheme for this package."
+          },
+          "version_files": {
+            "type": "array",
+            "description": "Override version files for this package.",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["path", "regex"],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "description": "File path relative to the repository root."
+                },
+                "regex": {
+                  "type": "string",
+                  "description": "Regex whose first capture group contains the version string."
+                }
+              }
+            }
+          },
+          "changelog": {
+            "type": "object",
+            "description": "Override changelog configuration for this package.",
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Custom changelog title heading."
+              },
+              "hidden": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Commit types excluded from the package changelog."
+              },
+              "bug_url": {
+                "type": "string",
+                "format": "uri",
+                "description": "Base URL for bug/issue links."
+              },
+              "sections": {
+                "type": "object",
+                "additionalProperties": { "type": "string" },
+                "description": "Map commit types to changelog section headings."
+              }
+            }
           }
         }
       }

--- a/spec/tests/cmd/config/get_unknown_key.stderr
+++ b/spec/tests/cmd/config/get_unknown_key.stderr
@@ -1,4 +1,6 @@
 error: unknown config key: "unknown.key"
-  supported keys: scheme, strict, types, scopes, versioning.tag_prefix,
-    versioning.prerelease_tag, versioning.calver_format, changelog.title,
-    changelog.hidden, changelog.sections, changelog.bug_url
+  supported keys: scheme, strict, monorepo, types, scopes,
+    versioning.tag_prefix, versioning.prerelease_tag,
+    versioning.calver_format, versioning.tag_template,
+    changelog.title, changelog.hidden, changelog.sections,
+    changelog.bug_url


### PR DESCRIPTION
Epic: #360 — Story 1

Add `monorepo: bool` (default false), `packages: Vec<PackageConfig>` with name, path, and optional overrides, and `versioning.tag_template` (default `{name}@{version}`) to `ProjectConfig`.

## Changes

### Config types (`config/mod.rs`)
- New `PackageConfig` struct with `name`, `path`, optional `scheme`, `version_files`, `changelog` overrides
- New `monorepo: bool` and `packages: Vec<PackageConfig>` fields on `ProjectConfig`
- New `tag_template: String` field on `VersioningConfig`
- `DEFAULT_TAG_TEMPLATE` constant (`{name}@{version}`)

### Config parsing (`config/load.rs`)
- Parse `monorepo` bool (default false)
- Parse `[[packages]]` array with all optional overrides
- Parse `versioning.tag_template` (default from constant)
- Refactored `parse_changelog_config` to reuse `parse_changelog_from_table` (shared with package changelog override parsing)

### Config display (`cli/config.rs`)
- `monorepo` shown in top-level section
- `tag_template` shown in `[versioning]` section
- `[[packages]]` section with name, path, and optional scheme
- JSON output includes all new fields
- `config get` supports `monorepo` and `versioning.tag_template` keys

### Tests (`config/tests.rs`)
17 new unit tests:
- `monorepo` default, explicit true/false, missing file
- `packages` parsing, overrides (scheme, version_files, changelog), missing name/path skipped
- `tag_template` default, custom, with other versioning fields
- Full monorepo config integration test

### Docs
- `CONFIG.md` updated with new fields, tables, and monorepo example
- `docs/schema/v1/git-std.toml.json` updated with `monorepo`, `tag_template`, and `packages` definitions
- Snapshot test updated for new help text

## Acceptance criteria
- ✅ `monorepo = false` by default
- ✅ `[[packages]]` parsed with name, path, optional overrides
- ✅ Existing tests unchanged (all 70 config tests pass)
- ✅ Zero warnings (clippy, fmt, audit all clean)

Closes #361