### PR TITLE
feat(bump): add dependency cascade for monorepo versioning

### DIFF
--- a/crates/git-std/src/cli/bump/monorepo.rs
+++ b/crates/git-std/src/cli/bump/monorepo.rs
@@ -1,11 +1,13 @@
 //! Per-package version planning for monorepo workspaces.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use serde::Serialize;
 use yansi::Paint;
 
 use crate::app::OutputFormat;
+use crate::config::deps::{self, DependencyGraph};
 use crate::config::{PackageConfig, ProjectConfig};
 use crate::git;
 use crate::ui;
@@ -28,6 +30,9 @@ pub(crate) struct PackageBumpPlan {
     pub raw_commits: Vec<(String, String)>,
     /// Full tag name for the new version.
     pub tag_name: String,
+    /// If this bump was caused (or elevated) by a dependency cascade, the
+    /// source package name is recorded here.
+    pub cascade_from: Option<String>,
 }
 
 /// JSON schema for a per-package bump plan entry.
@@ -41,6 +46,8 @@ struct PackagePlanJson {
     bump_level: String,
     tag: String,
     commit_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cascade_from: Option<String>,
 }
 
 /// JSON schema for the full monorepo bump plan.
@@ -162,6 +169,7 @@ fn plan_package(
         bump_level,
         raw_commits,
         tag_name,
+        cascade_from: None,
     })
 }
 
@@ -224,6 +232,20 @@ pub(super) fn plan_monorepo_bump(
         }
     }
 
+    // Apply dependency cascade when not filtering to specific packages.
+    if packages_filter.is_empty() {
+        let dep_graph = deps::resolve_dependency_graph(&workdir, &all_packages);
+        if !dep_graph.is_empty() {
+            apply_cascade(
+                &mut package_plans,
+                &all_packages,
+                &dep_graph,
+                &workdir,
+                tag_template,
+            );
+        }
+    }
+
     // Plan root version bump via existing dispatch logic.
     let root_plan = plan_root(config, dir);
 
@@ -242,6 +264,86 @@ pub(super) fn plan_monorepo_bump(
     }
 
     0
+}
+
+/// Apply dependency cascade: when a package bumps, its dependents get at
+/// least a patch bump. Iterates until stable (transitive cascade).
+fn apply_cascade(
+    plans: &mut Vec<PackageBumpPlan>,
+    all_packages: &[PackageConfig],
+    dep_graph: &DependencyGraph,
+    workdir: &Path,
+    tag_template: &str,
+) {
+    let pkg_by_name: std::collections::HashMap<&str, &PackageConfig> =
+        all_packages.iter().map(|p| (p.name.as_str(), p)).collect();
+
+    // Iterate until no new cascade bumps are added.
+    loop {
+        let bumped: HashSet<String> = plans.iter().map(|p| p.name.clone()).collect();
+        let mut new_cascades: Vec<PackageBumpPlan> = Vec::new();
+
+        for plan in plans.iter() {
+            for dependent_name in dep_graph.dependents_of(&plan.name) {
+                if bumped.contains(dependent_name.as_str()) {
+                    continue;
+                }
+                let Some(pkg) = pkg_by_name.get(dependent_name.as_str()) else {
+                    continue;
+                };
+
+                let cascade_plan = create_cascade_plan(workdir, pkg, tag_template, &plan.name);
+                if let Some(cp) = cascade_plan {
+                    new_cascades.push(cp);
+                }
+            }
+        }
+
+        if new_cascades.is_empty() {
+            break;
+        }
+
+        // Deduplicate (a package may be reachable from multiple bumped deps).
+        let mut seen = HashSet::new();
+        new_cascades.retain(|p| seen.insert(p.name.clone()));
+
+        plans.extend(new_cascades);
+    }
+}
+
+/// Create a cascade patch bump for a dependent package.
+fn create_cascade_plan(
+    dir: &Path,
+    pkg: &PackageConfig,
+    tag_template: &str,
+    cascade_source: &str,
+) -> Option<PackageBumpPlan> {
+    let latest_tag = find_latest_package_tag(dir, tag_template, &pkg.name).ok()?;
+
+    let cur_ver = latest_tag
+        .as_ref()
+        .map(|(_, v)| v.clone())
+        .unwrap_or_else(|| semver::Version::new(0, 1, 0));
+
+    let new_version = if latest_tag.is_none() {
+        semver::Version::new(0, 1, 0)
+    } else {
+        standard_version::apply_bump(&cur_ver, standard_version::BumpLevel::Patch)
+    };
+
+    let prev_version = latest_tag.as_ref().map(|(_, v)| v.to_string());
+    let tag_name = build_tag_name(tag_template, &pkg.name, &new_version.to_string());
+
+    Some(PackageBumpPlan {
+        name: pkg.name.clone(),
+        path: pkg.path.clone(),
+        prev_version,
+        new_version: new_version.to_string(),
+        bump_level: standard_version::BumpLevel::Patch,
+        raw_commits: Vec::new(),
+        tag_name,
+        cascade_from: Some(cascade_source.to_string()),
+    })
 }
 
 /// Minimal root version info for the plan output.
@@ -320,11 +422,15 @@ fn print_plan_text(
         ui::heading("Packages:", "");
         for plan in package_plans {
             let prev = plan.prev_version.as_deref().unwrap_or("none");
+            let reason = match &plan.cascade_from {
+                Some(source) => format!("patch — dependency cascade from {source}"),
+                None => bump_reason(plan.bump_level).to_string(),
+            };
             ui::info(&format!(
                 "{}: {} ({})",
                 plan.name.bold(),
                 format!("{prev} \u{2192} {}", plan.new_version).bold(),
-                bump_reason(plan.bump_level),
+                reason,
             ));
             ui::detail(&format!(
                 "tag: {}  ({} commit{})",
@@ -354,6 +460,7 @@ fn print_plan_json(root_plan: &Option<RootPlan>, package_plans: &[PackageBumpPla
                 bump_level: format!("{:?}", p.bump_level).to_lowercase(),
                 tag: p.tag_name.clone(),
                 commit_count: p.raw_commits.len(),
+                cascade_from: p.cascade_from.clone(),
             })
             .collect(),
         dry_run: true,

--- a/crates/git-std/src/config/deps.rs
+++ b/crates/git-std/src/config/deps.rs
@@ -1,0 +1,498 @@
+//! Dependency graph resolution for monorepo workspaces.
+//!
+//! Parses workspace manifests (Cargo.toml, package.json, deno.json) to build
+//! a graph of runtime dependencies between packages. Dev-dependencies are
+//! excluded to avoid circular cascade and unnecessary patch bumps.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use super::PackageConfig;
+
+/// A dependency graph mapping each package name to its runtime dependents.
+///
+/// `dependents["core"] = ["cli", "api"]` means both `cli` and `api` depend
+/// on `core` — so when `core` bumps, `cli` and `api` get at least a patch.
+#[derive(Debug, Default)]
+pub struct DependencyGraph {
+    /// Maps package name → list of packages that depend on it.
+    dependents: HashMap<String, Vec<String>>,
+}
+
+impl DependencyGraph {
+    /// Packages that directly depend on `name`.
+    pub fn dependents_of(&self, name: &str) -> &[String] {
+        self.dependents
+            .get(name)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    /// Returns `true` when the graph has no edges.
+    pub fn is_empty(&self) -> bool {
+        self.dependents.values().all(|v| v.is_empty())
+    }
+}
+
+/// Build a dependency graph from workspace manifests.
+///
+/// For each package, parse its manifest and collect runtime (non-dev)
+/// dependencies that reference other workspace packages. The result is
+/// inverted: instead of "A depends on B", we store "B has dependent A"
+/// so cascade lookups are O(1).
+pub fn resolve_dependency_graph(root: &Path, packages: &[PackageConfig]) -> DependencyGraph {
+    let pkg_names: Vec<&str> = packages.iter().map(|p| p.name.as_str()).collect();
+    let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
+
+    for pkg in packages {
+        let pkg_dir = root.join(&pkg.path);
+        let deps = parse_runtime_deps(&pkg_dir, &pkg_names);
+        for dep in deps {
+            dependents.entry(dep).or_default().push(pkg.name.clone());
+        }
+    }
+
+    // Sort dependent lists for deterministic output.
+    for v in dependents.values_mut() {
+        v.sort();
+        v.dedup();
+    }
+
+    DependencyGraph { dependents }
+}
+
+/// Parse runtime dependencies from a package directory.
+///
+/// Tries Cargo.toml first, then package.json, then deno.json/deno.jsonc.
+/// Returns only workspace-internal dependencies (names present in `workspace_names`).
+fn parse_runtime_deps(pkg_dir: &Path, workspace_names: &[&str]) -> Vec<String> {
+    if let Some(deps) = parse_cargo_deps(pkg_dir, workspace_names) {
+        return deps;
+    }
+    if let Some(deps) = parse_node_deps(pkg_dir, workspace_names) {
+        return deps;
+    }
+    if let Some(deps) = parse_deno_deps(pkg_dir, workspace_names) {
+        return deps;
+    }
+    Vec::new()
+}
+
+/// Parse `[dependencies]` from `Cargo.toml`, excluding `[dev-dependencies]`.
+fn parse_cargo_deps(pkg_dir: &Path, workspace_names: &[&str]) -> Option<Vec<String>> {
+    let cargo_toml = pkg_dir.join("Cargo.toml");
+    let content = std::fs::read_to_string(&cargo_toml).ok()?;
+    let table: toml::Table = content.parse().ok()?;
+
+    let mut deps = Vec::new();
+
+    // [dependencies]
+    if let Some(dep_table) = table.get("dependencies").and_then(|v| v.as_table()) {
+        collect_cargo_workspace_deps(dep_table, workspace_names, &mut deps);
+    }
+
+    // [build-dependencies] — included in cascade (needed at build time)
+    if let Some(dep_table) = table.get("build-dependencies").and_then(|v| v.as_table()) {
+        collect_cargo_workspace_deps(dep_table, workspace_names, &mut deps);
+    }
+
+    // [target.'cfg(...)'.dependencies] — scan for workspace deps
+    if let Some(target_table) = table.get("target").and_then(|v| v.as_table()) {
+        for (_target_spec, target_val) in target_table {
+            if let Some(t) = target_val.as_table()
+                && let Some(d) = t.get("dependencies").and_then(|v| v.as_table())
+            {
+                collect_cargo_workspace_deps(d, workspace_names, &mut deps);
+            }
+        }
+    }
+
+    // Explicitly skip [dev-dependencies]
+
+    deps.sort();
+    deps.dedup();
+    Some(deps)
+}
+
+/// Collect workspace-internal dependency names from a Cargo dependency table.
+///
+/// Handles both simple (`foo = "1.0"`) and table (`foo = { path = "..." }`)
+/// dependency specs. Only includes names matching workspace packages.
+fn collect_cargo_workspace_deps(
+    dep_table: &toml::Table,
+    workspace_names: &[&str],
+    out: &mut Vec<String>,
+) {
+    for (dep_name, _dep_spec) in dep_table {
+        if workspace_names.contains(&dep_name.as_str()) {
+            out.push(dep_name.clone());
+        }
+    }
+}
+
+/// Parse `"dependencies"` from `package.json`, excluding `"devDependencies"`.
+fn parse_node_deps(pkg_dir: &Path, workspace_names: &[&str]) -> Option<Vec<String>> {
+    let pkg_json = pkg_dir.join("package.json");
+    let content = std::fs::read_to_string(&pkg_json).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+    let mut deps = Vec::new();
+
+    // "dependencies" only — skip "devDependencies"
+    if let Some(dep_obj) = json.get("dependencies").and_then(|v| v.as_object()) {
+        for dep_name in dep_obj.keys() {
+            if workspace_names.contains(&dep_name.as_str()) {
+                deps.push(dep_name.clone());
+            }
+        }
+    }
+
+    // "peerDependencies" — include in cascade (runtime requirement)
+    if let Some(dep_obj) = json.get("peerDependencies").and_then(|v| v.as_object()) {
+        for dep_name in dep_obj.keys() {
+            if workspace_names.contains(&dep_name.as_str()) {
+                deps.push(dep_name.clone());
+            }
+        }
+    }
+
+    deps.sort();
+    deps.dedup();
+    Some(deps)
+}
+
+/// Parse `"imports"` from `deno.json` / `deno.jsonc`, excluding
+/// entries that look like dev or test imports.
+fn parse_deno_deps(pkg_dir: &Path, workspace_names: &[&str]) -> Option<Vec<String>> {
+    let deno_path = ["deno.json", "deno.jsonc"]
+        .iter()
+        .map(|f| pkg_dir.join(f))
+        .find(|p| p.exists())?;
+
+    let content = std::fs::read_to_string(&deno_path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+    let mut deps = Vec::new();
+
+    if let Some(imports) = json.get("imports").and_then(|v| v.as_object()) {
+        for dep_name in imports.keys() {
+            if workspace_names.contains(&dep_name.as_str()) {
+                deps.push(dep_name.clone());
+            }
+        }
+    }
+
+    deps.sort();
+    deps.dedup();
+    Some(deps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_file(root: &Path, path: &str, content: &str) {
+        let full = root.join(path);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(full, content).unwrap();
+    }
+
+    fn make_packages(specs: &[(&str, &str)]) -> Vec<PackageConfig> {
+        specs
+            .iter()
+            .map(|(name, path)| PackageConfig {
+                name: name.to_string(),
+                path: path.to_string(),
+                ..Default::default()
+            })
+            .collect()
+    }
+
+    // ── Cargo dependency parsing ───────────────────────────
+
+    #[test]
+    fn cargo_runtime_deps_included() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(
+            dir.path(),
+            "crates/cli/Cargo.toml",
+            r#"
+[package]
+name = "my-cli"
+version = "0.1.0"
+
+[dependencies]
+core = { path = "../core" }
+serde = "1"
+"#,
+        );
+        write_file(
+            dir.path(),
+            "crates/core/Cargo.toml",
+            r#"
+[package]
+name = "core"
+version = "0.1.0"
+"#,
+        );
+        let packages = make_packages(&[("core", "crates/core"), ("my-cli", "crates/cli")]);
+        let graph = resolve_dependency_graph(dir.path(), &packages);
+
+        assert_eq!(graph.dependents_of("core"), &["my-cli"]);
+        assert!(graph.dependents_of("my-cli").is_empty());
+    }
+
+    #[test]
+    fn cargo_dev_deps_excluded() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(
+            dir.path(),
+            "crates/cli/Cargo.toml",
+            r#"
+[package]
+name = "my-cli"
+version = "0.1.0"
+
+[dev-dependencies]
+core = { path = "../core" }
+"#,
+        );
+        write_file(
+            dir.path(),
+            "crates/core/Cargo.toml",
+            r#"
+[package]
+name = "core"
+version = "0.1.0"
+"#,
+        );
+        let packages = make_packages(&[("core", "crates/core"), ("my-cli", "crates/cli")]);
+        let graph = resolve_dependency_graph(dir.path(), &packages);
+
+        assert!(graph.dependents_of("core").is_empty());
+    }
+
+    #[test]
+    fn cargo_build_deps_included() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(
+            dir.path(),
+            "crates/cli/Cargo.toml",
+            r#"
+[package]
+name = "my-cli"
+version = "0.1.0"
+
+[build-dependencies]
+core = { path = "../core" }
+"#,
+        );
+        write_file(
+            dir.path(),
+            "crates/core/Cargo.toml",
+            r#"
+[package]
+name = "core"
+version = "0.1.0"
+"#,
+        );
+        let packages = make_packages(&[("core", "crates/core"), ("my-cli", "crates/cli")]);
+        let graph = resolve_dependency_graph(dir.path(), &packages);
+
+        assert_eq!(graph.dependents_of("core"), &["my-cli"]);
+    }
+
+    // ── npm dependency parsing ─────────────────────────────
+
+    #[test]
+    fn node_runtime_deps_included() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(
+            dir.path(),
+            "packages/web/package.json",
+            r#"{"name": "web", "dependencies": {"core": "workspace:*", "react": "^18"}}"#,
+        );
+        write_file(
+            dir.path(),
+            "packages/core/package.json",
+            r#"{"name": "core"}"#,
+        );
+        let packages = make_packages(&[("core", "packages/core"), ("web", "packages/web")]);
+        let graph = resolve_dependency_graph(dir.path(), &packages);
+
+        assert_eq!(graph.dependents_of("core"), &["web"]);
+    }
+
+    #[test]
+    fn node_dev_deps_excluded() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(
+            dir.path(),
+            "packages/web/package.json",
+            r#"{"name": "web", "devDependencies": {"core": "workspace:*"}}"#,
+        );
+        write_file(
+            dir.path(),
+            "packages/core/package.json",
+            r#"{"name": "core"}"#,
+        );
+        let packages = make_packages(&[("core", "packages/core"), ("web", "packages/web")]);
+        let graph = resolve_dependency_graph(dir.path(), &packages);
+
+        assert!(graph.dependents_of("core").is_empty());
+    }
+
+    #[test]
+    fn node_peer_deps_included() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(
+            dir.path(),
+            "packages/plugin/package.json",
+            r#"{"name": "plugin", "peerDependencies": {"core": "^1.0"}}"#,
+        );
+        write_file(
+            dir.path(),
+            "packages/core/package.json",
+            r#"{"name": "core"}"#,
+        );
+        let packages = make_packages(&[("core", "packages/core"), ("plugin", "packages/plugin")]);
+        let graph = resolve_dependency_graph(dir.path(), &packages);
+
+        assert_eq!(graph.dependents_of("core"), &["plugin"]);
+    }
+
+    // ── Transitive / multi-edge ────────────────────────────
+
+    #[test]
+    fn transitive_dependencies() {
+        let dir = tempfile::tempdir().unwrap();
+        // C depends on B, B depends on A
+        write_file(
+            dir.path(),
+            "crates/a/Cargo.toml",
+            r#"
+[package]
+name = "a"
+version = "0.1.0"
+"#,
+        );
+        write_file(
+            dir.path(),
+            "crates/b/Cargo.toml",
+            r#"
+[package]
+name = "b"
+version = "0.1.0"
+
+[dependencies]
+a = { path = "../a" }
+"#,
+        );
+        write_file(
+            dir.path(),
+            "crates/c/Cargo.toml",
+            r#"
+[package]
+name = "c"
+version = "0.1.0"
+
+[dependencies]
+b = { path = "../b" }
+"#,
+        );
+        let packages = make_packages(&[("a", "crates/a"), ("b", "crates/b"), ("c", "crates/c")]);
+        let graph = resolve_dependency_graph(dir.path(), &packages);
+
+        // A's direct dependents: B
+        assert_eq!(graph.dependents_of("a"), &["b"]);
+        // B's direct dependents: C
+        assert_eq!(graph.dependents_of("b"), &["c"]);
+    }
+
+    #[test]
+    fn multiple_dependents() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(
+            dir.path(),
+            "crates/core/Cargo.toml",
+            r#"
+[package]
+name = "core"
+version = "0.1.0"
+"#,
+        );
+        write_file(
+            dir.path(),
+            "crates/cli/Cargo.toml",
+            r#"
+[package]
+name = "cli"
+version = "0.1.0"
+
+[dependencies]
+core = { path = "../core" }
+"#,
+        );
+        write_file(
+            dir.path(),
+            "crates/api/Cargo.toml",
+            r#"
+[package]
+name = "api"
+version = "0.1.0"
+
+[dependencies]
+core = { path = "../core" }
+"#,
+        );
+        let packages = make_packages(&[
+            ("api", "crates/api"),
+            ("cli", "crates/cli"),
+            ("core", "crates/core"),
+        ]);
+        let graph = resolve_dependency_graph(dir.path(), &packages);
+
+        assert_eq!(graph.dependents_of("core"), &["api", "cli"]);
+    }
+
+    // ── Edge cases ─────────────────────────────────────────
+
+    #[test]
+    fn empty_packages_produces_empty_graph() {
+        let dir = tempfile::tempdir().unwrap();
+        let graph = resolve_dependency_graph(dir.path(), &[]);
+        assert!(graph.is_empty());
+    }
+
+    #[test]
+    fn external_deps_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(
+            dir.path(),
+            "crates/app/Cargo.toml",
+            r#"
+[package]
+name = "app"
+version = "0.1.0"
+
+[dependencies]
+serde = "1"
+tokio = { version = "1", features = ["full"] }
+"#,
+        );
+        let packages = make_packages(&[("app", "crates/app")]);
+        let graph = resolve_dependency_graph(dir.path(), &packages);
+
+        assert!(graph.is_empty());
+    }
+
+    #[test]
+    fn no_manifest_produces_no_deps() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("crates/orphan")).unwrap();
+        let packages = make_packages(&[("orphan", "crates/orphan")]);
+        let graph = resolve_dependency_graph(dir.path(), &packages);
+
+        assert!(graph.is_empty());
+    }
+}

--- a/crates/git-std/src/config/mod.rs
+++ b/crates/git-std/src/config/mod.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use serde::Serialize;
 
+pub(crate) mod deps;
 mod load;
 mod workspace;
 


### PR DESCRIPTION
Epic: #360 — Story 5. Depends on #364 (merged).

Add dependency graph resolution and cascade logic for monorepo versioning. When a package bumps, its runtime dependents automatically get at least a patch bump.

## Changes

### New: `config/deps.rs`
- `DependencyGraph` with inverted edges: maps each package to its dependents
- `resolve_dependency_graph(root, packages)` — parses manifests for all packages
- Cargo: `[dependencies]` + `[build-dependencies]` included, `[dev-dependencies]` excluded
- npm: `dependencies` + `peerDependencies` included, `devDependencies` excluded
- Deno: `imports` included
- 11 unit tests covering all ecosystems and edge cases

### Modified: `cli/bump/monorepo.rs`
- `PackageBumpPlan` gains `cascade_from: Option<String>` field
- `apply_cascade()` — iterates until stable (transitive cascade)
- `create_cascade_plan()` — creates patch bump for dependent packages
- `-p` flag skips cascade (intentional single-package mode)
- Text output shows "patch — dependency cascade from {source}"
- JSON output includes `cascade_from` field

### Modified: `config/mod.rs`
- Registered `deps` module

## Acceptance criteria
- ✅ A bumps → B (depends on A) gets patch
- ✅ Transitive works (C depends on B depends on A)
- ✅ Higher bumps from own commits not downgraded
- ✅ `-p` skips cascade
- ✅ Dev-dependencies excluded
- ✅ Zero warnings, all tests pass

Closes #365