### PR TITLE
feat(cli): add monorepo CLI polish and changelog command

### DIFF
--- a/crates/git-std/src/app.rs
+++ b/crates/git-std/src/app.rs
@@ -136,6 +136,9 @@ pub enum Command {
         /// Git revision range (e.g. `v1.0.0..v2.0.0`).
         #[arg(long)]
         range: Option<String>,
+        /// Generate changelog for a specific package (monorepo only).
+        #[arg(short = 'p', long = "package")]
+        package: Option<String>,
     },
     /// Post-clone environment setup.
     Bootstrap {

--- a/crates/git-std/src/cli/changelog.rs
+++ b/crates/git-std/src/cli/changelog.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use standard_changelog::{ChangelogConfig, RepoHost, VersionRelease};
 
+use crate::config::ProjectConfig;
 use crate::git;
 use crate::ui;
 
@@ -14,13 +15,38 @@ pub struct ChangelogOptions {
     pub output: String,
     /// Optional git revision range (e.g. `v1.0.0..v2.0.0`).
     pub range: Option<String>,
+    /// Generate changelog for a specific package (monorepo only).
+    pub package: Option<String>,
+    /// Whether monorepo mode is enabled.
+    pub monorepo: bool,
+    /// Tag template for per-package tags.
+    pub tag_template: String,
+    /// Tag prefix for root tags.
+    pub tag_prefix: String,
 }
 
 /// Run the changelog subcommand. Returns the exit code.
-pub fn run(config: &ChangelogConfig, opts: &ChangelogOptions) -> i32 {
+pub fn run(
+    project_config: &ProjectConfig,
+    config: &ChangelogConfig,
+    opts: &ChangelogOptions,
+) -> i32 {
     let dir = std::path::Path::new(".");
-
     let host = git::detect_host(dir);
+
+    // Per-package changelog mode.
+    if let Some(ref pkg_name) = opts.package {
+        if !opts.monorepo {
+            ui::error("--package requires monorepo = true");
+            return 1;
+        }
+        return run_package_changelog(dir, project_config, config, &host, opts, pkg_name);
+    }
+
+    // Full mode in monorepo generates root + all per-package changelogs.
+    if opts.full && opts.monorepo {
+        return run_full_monorepo(dir, project_config, config, &host, opts);
+    }
 
     if let Some(ref range) = opts.range {
         run_range(dir, config, &host, opts, range)
@@ -250,4 +276,154 @@ fn build_releases(dir: &std::path::Path, config: &ChangelogConfig) -> Result<Vec
     }
 
     Ok(releases)
+}
+
+// ── Per-package changelog ──────────────────────────────────────────
+
+/// Generate changelog for a single package using path-filtered commits.
+fn run_package_changelog(
+    dir: &std::path::Path,
+    project_config: &ProjectConfig,
+    config: &ChangelogConfig,
+    host: &RepoHost,
+    opts: &ChangelogOptions,
+    pkg_name: &str,
+) -> i32 {
+    let workdir = match git::workdir(dir) {
+        Ok(w) => w,
+        Err(_) => {
+            ui::error("bare repository not supported");
+            return 1;
+        }
+    };
+
+    let packages = project_config.resolved_packages(&workdir);
+    let pkg = match packages.iter().find(|p| p.name == pkg_name) {
+        Some(p) => p,
+        None => {
+            ui::error(&format!("unknown package: {pkg_name}"));
+            return 1;
+        }
+    };
+
+    let head_oid = match git::head_oid(dir) {
+        Ok(oid) => oid,
+        Err(e) => {
+            ui::error(&format!("cannot resolve HEAD: {e}"));
+            return 1;
+        }
+    };
+
+    // Find latest per-package tag.
+    let tag_template = &opts.tag_template;
+    let prefix = tag_template
+        .replace("{name}", pkg_name)
+        .replace("{version}", "");
+
+    let tags = match git::collect_tags(dir) {
+        Ok(t) => t,
+        Err(e) => {
+            ui::error(&e.to_string());
+            return 1;
+        }
+    };
+
+    let latest_tag: Option<(String, String)> = tags
+        .iter()
+        .filter(|(_, name)| name.starts_with(&prefix))
+        .max_by_key(|(_, name)| {
+            name.strip_prefix(&prefix)
+                .and_then(|v| semver::Version::parse(v).ok())
+        })
+        .map(|(oid, name)| (oid.clone(), name.clone()));
+
+    let tag_oid = latest_tag.as_ref().map(|(oid, _)| oid.as_str());
+    let commits = match git::walk_commits_for_path(dir, &head_oid, tag_oid, &[&pkg.path]) {
+        Ok(c) => c,
+        Err(e) => {
+            ui::error(&format!("cannot walk commits: {e}"));
+            return 1;
+        }
+    };
+
+    if commits.is_empty() {
+        ui::print(&format!("no unreleased changes found for {pkg_name}"));
+        return 0;
+    }
+
+    let prev_tag_name = latest_tag.as_ref().map(|(_, name)| name.as_str());
+    let release = match build_release_from_commits(&commits, "Unreleased", prev_tag_name, config) {
+        Some(mut r) => {
+            if let Ok(date) = git::commit_date(dir, &head_oid) {
+                r.date = date;
+            }
+            r
+        }
+        None => {
+            ui::print(&format!("no conventional commits found for {pkg_name}"));
+            return 0;
+        }
+    };
+
+    if opts.stdout {
+        let section = standard_changelog::render_version(&release, config, host);
+        print!("{section}");
+        return 0;
+    }
+
+    let output_path = workdir.join(&pkg.path).join(&opts.output);
+    let existing = std::fs::read_to_string(&output_path).unwrap_or_default();
+    let output = standard_changelog::prepend_release(&existing, &release, config, host);
+
+    if let Err(e) = std::fs::write(&output_path, &output) {
+        ui::error(&format!("cannot write {}: {e}", output_path.display()));
+        return 1;
+    }
+    ui::info(&format!("wrote {}", output_path.display()));
+    0
+}
+
+/// Full monorepo changelog: regenerate root + all per-package changelogs.
+fn run_full_monorepo(
+    dir: &std::path::Path,
+    project_config: &ProjectConfig,
+    config: &ChangelogConfig,
+    host: &RepoHost,
+    opts: &ChangelogOptions,
+) -> i32 {
+    // Root changelog (all commits).
+    let code = run_full(dir, config, host, opts);
+    if code != 0 {
+        return code;
+    }
+
+    let workdir = match git::workdir(dir) {
+        Ok(w) => w,
+        Err(_) => {
+            ui::error("bare repository not supported");
+            return 1;
+        }
+    };
+
+    let packages = project_config.resolved_packages(&workdir);
+    for pkg in &packages {
+        let mut pkg_opts = ChangelogOptions {
+            full: false,
+            stdout: opts.stdout,
+            output: opts.output.clone(),
+            range: None,
+            package: Some(pkg.name.clone()),
+            monorepo: true,
+            tag_template: opts.tag_template.clone(),
+            tag_prefix: opts.tag_prefix.clone(),
+        };
+        // Use package-relative output path.
+        pkg_opts.output = "CHANGELOG.md".to_string();
+        let code = run_package_changelog(dir, project_config, config, host, &pkg_opts, &pkg.name);
+        if code != 0 {
+            return code;
+        }
+    }
+
+    0
 }

--- a/crates/git-std/src/config/mod.rs
+++ b/crates/git-std/src/config/mod.rs
@@ -167,12 +167,28 @@ impl ProjectConfig {
     /// Resolve the effective scope list.
     ///
     /// Returns the explicit list, auto-discovered names, or an empty vec.
+    /// When `monorepo = true`, package names and the project name are always
+    /// appended to the scope list.
     pub fn resolved_scopes(&self, repo_root: &Path) -> Vec<String> {
-        match &self.scopes {
-            ScopesConfig::None => Vec::new(),
+        let mut scopes = match &self.scopes {
+            ScopesConfig::None if self.monorepo => discover_scopes(repo_root),
+            ScopesConfig::None => return Vec::new(),
             ScopesConfig::Auto => discover_scopes(repo_root),
             ScopesConfig::List(list) => list.clone(),
+        };
+
+        if self.monorepo {
+            let packages = self.resolved_packages(repo_root);
+            for pkg in &packages {
+                if !scopes.contains(&pkg.name) {
+                    scopes.push(pkg.name.clone());
+                }
+            }
+            scopes.sort();
+            scopes.dedup();
         }
+
+        scopes
     }
 
     /// Resolve the effective package list.
@@ -196,20 +212,30 @@ impl ProjectConfig {
     /// or `strict = true` is set in `.git-std.toml`.
     ///
     /// When `scopes = "auto"`, scopes are discovered from the workspace
-    /// directory layout under `repo_root`.
+    /// directory layout under `repo_root`. When `monorepo = true`, package
+    /// names are always included regardless of scope mode.
     pub fn to_lint_config(&self, strict: bool, repo_root: &Path) -> standard_commit::LintConfig {
         if self.strict || strict {
-            let (scopes, require_scope) = match &self.scopes {
-                ScopesConfig::None => (None, false),
-                ScopesConfig::Auto => {
-                    let discovered = discover_scopes(repo_root);
-                    if discovered.is_empty() {
-                        (None, false)
-                    } else {
-                        (Some(discovered), true)
-                    }
+            let (scopes, require_scope) = if self.monorepo {
+                let resolved = self.resolved_scopes(repo_root);
+                if resolved.is_empty() {
+                    (None, false)
+                } else {
+                    (Some(resolved), true)
                 }
-                ScopesConfig::List(list) => (Some(list.clone()), true),
+            } else {
+                match &self.scopes {
+                    ScopesConfig::None => (None, false),
+                    ScopesConfig::Auto => {
+                        let discovered = discover_scopes(repo_root);
+                        if discovered.is_empty() {
+                            (None, false)
+                        } else {
+                            (Some(discovered), true)
+                        }
+                    }
+                    ScopesConfig::List(list) => (Some(list.clone()), true),
+                }
             };
             // `chore(release)` is the standard commit message produced by
             // `git std bump`. Always allow it so the tool's own commits

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -87,6 +87,7 @@ fn main() {
             stdout,
             output,
             range,
+            package,
         } => {
             let project_config = config::load(&std::env::current_dir().unwrap_or_default());
             let changelog_config = project_config.to_changelog_config();
@@ -95,8 +96,12 @@ fn main() {
                 stdout,
                 output,
                 range,
+                package,
+                monorepo: project_config.monorepo,
+                tag_template: project_config.versioning.tag_template.clone(),
+                tag_prefix: project_config.versioning.tag_prefix.clone(),
             };
-            let code = cli::changelog::run(&changelog_config, &opts);
+            let code = cli::changelog::run(&project_config, &changelog_config, &opts);
             std::process::exit(code);
         }
         Command::Bump {


### PR DESCRIPTION
Epic: #360 — Story 7. Depends on #366 (merged).

Add per-package changelog generation and monorepo scope integration for CLI polish.

## Changes

### Modified: `app.rs`
- Added `-p/--package` flag to `Changelog` subcommand

### Modified: `main.rs`
- Thread `package`, `monorepo`, `tag_template`, `tag_prefix` to `ChangelogOptions`

### Modified: `cli/changelog.rs`
- `ChangelogOptions` gains `package`, `monorepo`, `tag_template`, `tag_prefix`
- `run()` signature now takes `&ProjectConfig` for package resolution
- `run_package_changelog()` — per-package changelog using path-filtered commits
- `run_full_monorepo()` — regenerates root + all per-package changelogs
- Clear error for unknown package name

### Modified: `config/mod.rs`
- `resolved_scopes()` — when `monorepo = true`, package names always appended
  to scope list regardless of `ScopesConfig` mode
- `to_lint_config()` — uses `resolved_scopes()` when monorepo enabled so
  strict mode validates against package names

## Acceptance criteria
- ✅ `git std changelog -p <name>` generates per-package changelog
- ✅ `git std changelog --full` in monorepo regenerates root + all packages
- ✅ Clear error for unknown package name
- ✅ Scope suggestions include package names in monorepo mode
- ✅ Zero warnings, all tests pass

Closes #367