### PR TITLE
fix: use per-package changelog config in monorepo bump

### DIFF
--- a/crates/git-std/src/cli/bump/monorepo.rs
+++ b/crates/git-std/src/cli/bump/monorepo.rs
@@ -515,20 +515,21 @@ fn finalize_monorepo_bump(
         for plan in package_plans {
             let pkg_changelog_path = workdir.join(&plan.path).join("CHANGELOG.md");
 
+            let pkg_cl_override = pkg_configs
+                .get(plan.name.as_str())
+                .and_then(|pc| pc.changelog.as_ref());
+            let pkg_cl_config = config.to_package_changelog_config(pkg_cl_override);
+
             let release = super::apply::build_version_release(
                 &plan.raw_commits,
                 &plan.new_version,
                 plan.prev_version.as_deref(),
-                &changelog_config,
+                &pkg_cl_config,
             );
             if let Some(release) = release {
                 let existing = std::fs::read_to_string(&pkg_changelog_path).unwrap_or_default();
-                let output = standard_changelog::prepend_release(
-                    &existing,
-                    &release,
-                    &changelog_config,
-                    &host,
-                );
+                let output =
+                    standard_changelog::prepend_release(&existing, &release, &pkg_cl_config, &host);
                 if let Err(e) = std::fs::write(&pkg_changelog_path, &output) {
                     ui::warning(&format!("{}: cannot write CHANGELOG.md: {e}", plan.name));
                 } else {

--- a/crates/git-std/src/config/mod.rs
+++ b/crates/git-std/src/config/mod.rs
@@ -164,6 +164,26 @@ impl ProjectConfig {
         }
     }
 
+    /// Build a changelog config for a specific package, falling back to global.
+    ///
+    /// Per-package overrides (sections, hidden, title, bug_url) take precedence
+    /// over global settings when present.
+    pub fn to_package_changelog_config(
+        &self,
+        pkg_changelog: Option<&ChangelogConfig>,
+    ) -> standard_changelog::ChangelogConfig {
+        let global = self.to_changelog_config();
+        let Some(pkg) = pkg_changelog else {
+            return global;
+        };
+        standard_changelog::ChangelogConfig {
+            title: pkg.title.clone().unwrap_or(global.title),
+            sections: pkg.sections.clone().unwrap_or(global.sections),
+            hidden: pkg.hidden.clone().unwrap_or(global.hidden),
+            bug_url: pkg.bug_url.clone().or(global.bug_url),
+        }
+    }
+
     /// Resolve the effective scope list.
     ///
     /// Returns the explicit list, auto-discovered names, or an empty vec.


### PR DESCRIPTION
Fixes #377 item 2.

`PackageConfig.changelog` was parsed from TOML but never used — the global changelog config was always applied. Now per-package overrides (sections, hidden, title, bug_url) are merged with the global config via `to_package_changelog_config()`.