### PR TITLE
refactor: avoid redundant package discovery in resolved_scopes

### DIFF
--- a/crates/git-std/src/cli/commit/prompt.rs
+++ b/crates/git-std/src/cli/commit/prompt.rs
@@ -46,7 +46,7 @@ pub(super) fn prompt_scope(config: &ProjectConfig) -> Result<Option<String>> {
         }
         ScopesConfig::Auto => {
             let cwd = std::env::current_dir().unwrap_or_default();
-            let discovered = config.resolved_scopes(&cwd);
+            let discovered = config.resolved_scopes(&cwd, None);
             if discovered.is_empty() {
                 let mut prompt = Text::new("scope:");
                 if config.strict {

--- a/crates/git-std/src/cli/config.rs
+++ b/crates/git-std/src/cli/config.rs
@@ -89,7 +89,7 @@ pub fn list(dir: &Path, format: OutputFormat) -> i32 {
         ScopesConfig::None => print_kv("scopes", "none", scopes_src),
         ScopesConfig::Auto => {
             print_kv("scopes", "auto", scopes_src);
-            let resolved = cfg.resolved_scopes(dir);
+            let resolved = cfg.resolved_scopes(dir, None);
             if !resolved.is_empty() {
                 ui::detail(&format!("resolved: {}", resolved.join(", ")));
             }

--- a/crates/git-std/src/config/mod.rs
+++ b/crates/git-std/src/config/mod.rs
@@ -169,7 +169,14 @@ impl ProjectConfig {
     /// Returns the explicit list, auto-discovered names, or an empty vec.
     /// When `monorepo = true`, package names and the project name are always
     /// appended to the scope list.
-    pub fn resolved_scopes(&self, repo_root: &Path) -> Vec<String> {
+    ///
+    /// When `packages` is `Some`, uses the provided list instead of
+    /// re-discovering from disk — avoids redundant filesystem scans.
+    pub fn resolved_scopes(
+        &self,
+        repo_root: &Path,
+        packages: Option<&[PackageConfig]>,
+    ) -> Vec<String> {
         let mut scopes = match &self.scopes {
             ScopesConfig::None if self.monorepo => discover_scopes(repo_root),
             ScopesConfig::None => return Vec::new(),
@@ -178,8 +185,15 @@ impl ProjectConfig {
         };
 
         if self.monorepo {
-            let packages = self.resolved_packages(repo_root);
-            for pkg in &packages {
+            let owned;
+            let pkgs = match packages {
+                Some(p) => p,
+                None => {
+                    owned = self.resolved_packages(repo_root);
+                    &owned
+                }
+            };
+            for pkg in pkgs {
                 if !scopes.contains(&pkg.name) {
                     scopes.push(pkg.name.clone());
                 }
@@ -217,7 +231,7 @@ impl ProjectConfig {
     pub fn to_lint_config(&self, strict: bool, repo_root: &Path) -> standard_commit::LintConfig {
         if self.strict || strict {
             let (scopes, require_scope) = if self.monorepo {
-                let resolved = self.resolved_scopes(repo_root);
+                let resolved = self.resolved_scopes(repo_root, None);
                 if resolved.is_empty() {
                     (None, false)
                 } else {

--- a/crates/git-std/src/config/tests.rs
+++ b/crates/git-std/src/config/tests.rs
@@ -252,7 +252,7 @@ fn resolved_scopes_auto() {
         scopes: ScopesConfig::Auto,
         ..Default::default()
     };
-    assert_eq!(config.resolved_scopes(dir.path()), vec!["web"]);
+    assert_eq!(config.resolved_scopes(dir.path(), None), vec!["web"]);
 }
 
 #[test]
@@ -262,7 +262,7 @@ fn resolved_scopes_list() {
         scopes: ScopesConfig::List(vec!["auth".into()]),
         ..Default::default()
     };
-    assert_eq!(config.resolved_scopes(dir.path()), vec!["auth"]);
+    assert_eq!(config.resolved_scopes(dir.path(), None), vec!["auth"]);
 }
 
 #[test]
@@ -272,7 +272,7 @@ fn resolved_scopes_none() {
         scopes: ScopesConfig::None,
         ..Default::default()
     };
-    assert!(config.resolved_scopes(dir.path()).is_empty());
+    assert!(config.resolved_scopes(dir.path(), None).is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #377 item 8.

`resolved_scopes()` called `resolved_packages()` internally, both hitting the filesystem for workspace auto-discovery. Now accepts an optional `packages` parameter so callers with pre-resolved packages can avoid the redundant scan. All existing callers pass `None` to preserve current behavior.