### PR TITLE
feat: support calver scheme in monorepo mode

### DIFF
--- a/crates/git-std/src/cli/bump/monorepo.rs
+++ b/crates/git-std/src/cli/bump/monorepo.rs
@@ -8,7 +8,7 @@ use yansi::Paint;
 
 use crate::app::OutputFormat;
 use crate::config::deps::{self, DependencyGraph};
-use crate::config::{PackageConfig, ProjectConfig};
+use crate::config::{PackageConfig, ProjectConfig, Scheme};
 use crate::git;
 use crate::ui;
 
@@ -95,6 +95,36 @@ fn find_latest_package_tag(
     best
 }
 
+/// Find the latest calver tag matching a per-package tag template.
+///
+/// Calver tags are matched by date-sorted order (newest creator date first).
+/// Returns `(commit_oid, version_string)`.
+fn find_latest_calver_package_tag(
+    tags: &[(String, String)],
+    template: &str,
+    pkg_name: &str,
+) -> Option<(String, String)> {
+    let prefix = template
+        .replace("{name}", pkg_name)
+        .replace("{version}", "");
+
+    for (oid, name) in tags {
+        let ver_str = match name.strip_prefix(&prefix) {
+            Some(s) => s,
+            None => continue,
+        };
+        if ver_str.starts_with(|c: char| c.is_ascii_digit()) {
+            return Some((oid.clone(), ver_str.to_string()));
+        }
+    }
+    None
+}
+
+/// Resolve the effective versioning scheme for a package.
+fn resolve_scheme(pkg: &PackageConfig, global: &Scheme) -> Scheme {
+    pkg.scheme.clone().unwrap_or_else(|| global.clone())
+}
+
 /// Build a tag name from the template, package name, and version string.
 fn build_tag_name(template: &str, pkg_name: &str, version: &str) -> String {
     template
@@ -118,7 +148,13 @@ fn plan_package(
     head_oid: &str,
     tag_template: &str,
     tags: &[(String, String)],
+    config: &ProjectConfig,
 ) -> Option<PackageBumpPlan> {
+    let scheme = resolve_scheme(pkg, &config.scheme);
+    if scheme == Scheme::Calver {
+        return plan_package_calver(dir, pkg, head_oid, tag_template, tags, config);
+    }
+
     let latest_tag = find_latest_package_tag(tags, tag_template, &pkg.name);
 
     let tag_oid = latest_tag.as_ref().map(|(oid, _)| oid.as_str());
@@ -162,6 +198,61 @@ fn plan_package(
         prev_version,
         new_version: new_version.to_string(),
         bump_level,
+        raw_commits,
+        tag_name,
+        cascade_from: None,
+    })
+}
+
+/// Plan a single package bump using calver versioning.
+///
+/// Any conventional commit touching the package triggers a bump. The date
+/// determines the version; if the date period is the same as the previous
+/// version, the patch (build) counter increments.
+fn plan_package_calver(
+    dir: &Path,
+    pkg: &PackageConfig,
+    head_oid: &str,
+    tag_template: &str,
+    tags: &[(String, String)],
+    config: &ProjectConfig,
+) -> Option<PackageBumpPlan> {
+    let latest_tag = find_latest_calver_package_tag(tags, tag_template, &pkg.name);
+
+    let tag_oid = latest_tag.as_ref().map(|(oid, _)| oid.as_str());
+    let raw_commits = match git::walk_commits_for_path(dir, head_oid, tag_oid, &[&pkg.path]) {
+        Ok(c) => c,
+        Err(e) => {
+            ui::warning(&format!("{}: cannot walk commits: {e}", pkg.name));
+            return None;
+        }
+    };
+
+    if raw_commits.is_empty() {
+        return None;
+    }
+
+    let calver_format = &config.versioning.calver_format;
+    let date = super::detect::today_calver_date();
+    let prev_ver = latest_tag.as_ref().map(|(_, v)| v.as_str());
+
+    let new_version = match standard_version::calver::next_version(calver_format, date, prev_ver) {
+        Ok(v) => v,
+        Err(e) => {
+            ui::warning(&format!("{}: calver error: {e}", pkg.name));
+            return None;
+        }
+    };
+
+    let prev_version = latest_tag.map(|(_, v)| v);
+    let tag_name = build_tag_name(tag_template, &pkg.name, &new_version);
+
+    Some(PackageBumpPlan {
+        name: pkg.name.clone(),
+        path: pkg.path.clone(),
+        prev_version,
+        new_version,
+        bump_level: standard_version::BumpLevel::Patch,
         raw_commits,
         tag_name,
         cascade_from: None,
@@ -231,7 +322,8 @@ pub(super) fn plan_monorepo_bump(
     // Plan per-package bumps.
     let mut package_plans: Vec<PackageBumpPlan> = Vec::new();
     for pkg in &packages {
-        if let Some(plan) = plan_package(&workdir, pkg, &head_oid, tag_template, &all_tags) {
+        if let Some(plan) = plan_package(&workdir, pkg, &head_oid, tag_template, &all_tags, config)
+        {
             package_plans.push(plan);
         }
     }
@@ -246,6 +338,7 @@ pub(super) fn plan_monorepo_bump(
                 &dep_graph,
                 tag_template,
                 &all_tags,
+                config,
             );
         }
     }
@@ -280,6 +373,7 @@ fn apply_cascade(
     dep_graph: &DependencyGraph,
     tag_template: &str,
     tags: &[(String, String)],
+    config: &ProjectConfig,
 ) {
     let pkg_by_name: std::collections::HashMap<&str, &PackageConfig> =
         all_packages.iter().map(|p| (p.name.as_str(), p)).collect();
@@ -298,7 +392,7 @@ fn apply_cascade(
                     continue;
                 };
 
-                let cascade_plan = create_cascade_plan(pkg, tag_template, &plan.name, tags);
+                let cascade_plan = create_cascade_plan(pkg, tag_template, &plan.name, tags, config);
                 if let Some(cp) = cascade_plan {
                     new_cascades.push(cp);
                 }
@@ -323,7 +417,14 @@ fn create_cascade_plan(
     tag_template: &str,
     cascade_source: &str,
     tags: &[(String, String)],
+    config: &ProjectConfig,
 ) -> Option<PackageBumpPlan> {
+    let scheme = resolve_scheme(pkg, &config.scheme);
+
+    if scheme == Scheme::Calver {
+        return create_cascade_plan_calver(pkg, tag_template, cascade_source, tags, config);
+    }
+
     let latest_tag = find_latest_package_tag(tags, tag_template, &pkg.name);
 
     let cur_ver = latest_tag
@@ -345,6 +446,37 @@ fn create_cascade_plan(
         path: pkg.path.clone(),
         prev_version,
         new_version: new_version.to_string(),
+        bump_level: standard_version::BumpLevel::Patch,
+        raw_commits: Vec::new(),
+        tag_name,
+        cascade_from: Some(cascade_source.to_string()),
+    })
+}
+
+/// Create a cascade calver bump for a dependent package.
+fn create_cascade_plan_calver(
+    pkg: &PackageConfig,
+    tag_template: &str,
+    cascade_source: &str,
+    tags: &[(String, String)],
+    config: &ProjectConfig,
+) -> Option<PackageBumpPlan> {
+    let latest_tag = find_latest_calver_package_tag(tags, tag_template, &pkg.name);
+
+    let calver_format = &config.versioning.calver_format;
+    let date = super::detect::today_calver_date();
+    let prev_ver = latest_tag.as_ref().map(|(_, v)| v.as_str());
+
+    let new_version = standard_version::calver::next_version(calver_format, date, prev_ver).ok()?;
+
+    let prev_version = latest_tag.map(|(_, v)| v);
+    let tag_name = build_tag_name(tag_template, &pkg.name, &new_version);
+
+    Some(PackageBumpPlan {
+        name: pkg.name.clone(),
+        path: pkg.path.clone(),
+        prev_version,
+        new_version,
         bump_level: standard_version::BumpLevel::Patch,
         raw_commits: Vec::new(),
         tag_name,

--- a/crates/git-std/tests/monorepo.rs
+++ b/crates/git-std/tests/monorepo.rs
@@ -461,3 +461,146 @@ fn changelog_package_requires_monorepo() {
         .failure()
         .stderr(predicate::str::contains("monorepo"));
 }
+
+// ── Calver monorepo tests ──────────────────────────────────────────
+
+/// Set up a calver monorepo with two packages.
+fn init_calver_monorepo(dir: &Path) {
+    git(dir, &["init"]);
+    git(dir, &["config", "user.name", "Test"]);
+    git(dir, &["config", "user.email", "test@test.com"]);
+
+    write_file(
+        dir,
+        "Cargo.toml",
+        r#"[workspace]
+members = ["crates/core", "crates/cli"]
+"#,
+    );
+
+    write_file(
+        dir,
+        "crates/core/Cargo.toml",
+        r#"[package]
+name = "core"
+version = "0.1.0"
+edition = "2021"
+"#,
+    );
+    write_file(dir, "crates/core/src/lib.rs", "");
+
+    write_file(
+        dir,
+        "crates/cli/Cargo.toml",
+        r#"[package]
+name = "cli"
+version = "0.1.0"
+edition = "2021"
+"#,
+    );
+    write_file(dir, "crates/cli/src/main.rs", "fn main() {}");
+
+    write_file(
+        dir,
+        ".git-std.toml",
+        r#"monorepo = true
+scheme = "calver"
+"#,
+    );
+
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "-m", "chore: init calver monorepo"]);
+}
+
+#[test]
+fn calver_monorepo_dry_run_shows_date_version() {
+    let dir = tempfile::tempdir().unwrap();
+    init_calver_monorepo(dir.path());
+
+    add_commit(
+        dir.path(),
+        "crates/core/src/lib.rs",
+        "feat: add core feature",
+    );
+
+    // Should produce a date-based version (YYYY.M.0 format).
+    let output = Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Version should contain current year.
+    let year = chrono_free_current_year();
+    assert!(
+        stderr.contains(&year),
+        "expected calver year {year} in output: {stderr}"
+    );
+}
+
+#[test]
+fn calver_monorepo_patch_increments_same_period() {
+    let dir = tempfile::tempdir().unwrap();
+    init_calver_monorepo(dir.path());
+
+    let year = chrono_free_current_year();
+    let month = chrono_free_current_month();
+    let first_tag = format!("core@{year}.{month}.0");
+    let root_tag = format!("v{year}.{month}.0");
+
+    add_commit(dir.path(), "crates/core/src/lib.rs", "feat: first feature");
+    create_tag(dir.path(), &first_tag);
+    create_tag(dir.path(), &root_tag);
+
+    add_commit(dir.path(), "crates/core/src/lib.rs", "feat: second feature");
+
+    let output = Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let expected_version = format!("{year}.{month}.1");
+    assert!(
+        stderr.contains(&expected_version),
+        "expected {expected_version} in output: {stderr}"
+    );
+}
+
+/// Get current year as string without chrono dependency.
+fn chrono_free_current_year() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let days = secs / 86400;
+    // Howard Hinnant algorithm (simplified).
+    let z = days + 719468;
+    let era = z.div_euclid(146097);
+    let doe = z.rem_euclid(146097);
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    y.to_string()
+}
+
+/// Get current month (1–12) as string without chrono dependency.
+fn chrono_free_current_month() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let days = secs / 86400;
+    let z = days + 719468;
+    let doe = z.rem_euclid(146097);
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    m.to_string()
+}


### PR DESCRIPTION
Fixes #377 item 3.

Previously `plan_package()` always used `semver::Version::parse()` for tag lookup — calver tags silently failed and packages got no plan.

Now dispatches based on effective scheme (per-package override or global):
- **Calver**: date-sorted tag lookup → `calver::next_version()` — any commit triggers a bump, date drives the version
- **Semver** (unchanged): semver tag comparison → `determine_bump()` from commit types

Same date period → increment PATCH counter. New period → reset to 0.
Cascade bumps also respect calver.

Two integration tests added: first calver release and patch increment.