### PR TITLE
docs: add monorepo versioning documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ footprint, zero runtime dependencies. Works out of the box
 with sensible defaults, which can be overridden with a
 `.git-std.toml`.
 
+Supports per-package monorepo versioning with automatic
+dependency cascades, per-package changelogs, and polyglot
+workspace discovery (Cargo, npm, Deno).
+
 Invoked as `git std` via git's subcommand discovery.
 
 ## Install

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -220,13 +220,14 @@ Entries with missing `name` or `path` are silently skipped.
 
 These are not configurable — git-std resolves them automatically:
 
-| Concern          | Resolution                                |
-| ---------------- | ----------------------------------------- |
-| Bump rules       | Inferred from `scheme`                    |
-| Version files    | Auto-detected (Cargo.toml)                |
-| URLs             | Inferred from `git remote get-url origin` |
-| Changelog output | Always `CHANGELOG.md`                     |
-| Release commit   | Always `chore(release): <version>`        |
+| Concern              | Resolution                                                |
+| -------------------- | --------------------------------------------------------- |
+| Bump rules           | Inferred from `scheme`                                    |
+| Version files        | Auto-detected (Cargo.toml)                                |
+| URLs                 | Inferred from `git remote get-url origin`                 |
+| Changelog output     | `CHANGELOG.md` at root; `{path}/CHANGELOG.md` per package |
+| Release commit       | `chore(release): <version>` (includes packages)           |
+| Package dependencies | Resolved from workspace manifests (runtime only)          |
 
 ## Minimal examples
 
@@ -278,4 +279,38 @@ path = "crates/core"
 [[packages]]
 name = "cli"
 path = "crates/cli"
+```
+
+When `monorepo = true`, each package is bumped independently
+based on commits touching its path. Packages are
+auto-discovered from workspace manifests if `[[packages]]`
+is omitted.
+
+**Dependency cascade:** if package A bumps and package B
+depends on A (runtime dependency in Cargo.toml or
+package.json), B receives at least a patch bump. Use
+`-p` to skip cascade.
+
+**Per-package changelogs:** each bumped package gets a
+`CHANGELOG.md` in its root directory. The root
+`CHANGELOG.md` includes all commits.
+
+**Mixed versioning schemes:**
+
+```toml
+monorepo = true
+scheme = "semver"
+
+[versioning]
+tag_template = "{name}@{version}"
+calver_format = "YYYY.0M.PATCH"
+
+[[packages]]
+name = "core"
+path = "crates/core"
+
+[[packages]]
+name = "api"
+path = "crates/api"
+scheme = "calver"              # override: date-based versioning
 ```

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -495,6 +495,90 @@ Rules:
 - If the regex doesn't match, warn and skip.
 - Multiple `[[version_files]]` entries are supported.
 
+#### 2.3.3 Monorepo Mode
+
+When `monorepo = true` in `.git-std.toml`, `git std bump`
+performs per-package versioning in addition to the root
+version bump.
+
+**Package discovery:**
+
+1. Explicit `[[packages]]` entries in config (highest
+   priority).
+2. Auto-discovery from workspace manifests:
+   - `Cargo.toml` `[workspace] members`
+   - `package.json` `workspaces`
+   - `deno.json` `workspace`
+3. Fallback: subdirectories containing version files.
+
+**Per-package bump algorithm:**
+
+1. Collect all tags once.
+2. For each package:
+   a. Find the latest tag matching `tag_template` for
+   that package name.
+   b. Walk commits between that tag and HEAD, filtered
+   by the package path (`git log --first-parent -- {path}`).
+   c. Parse conventional commits and determine bump
+   level (same rules as root bump).
+   d. Compute new version string.
+3. If `scheme = "calver"` for a package (via per-package
+   `scheme` override or global), use date-based versioning:
+   any commit touching the package path triggers a new
+   version. Same date period increments the patch counter.
+
+**Dependency cascade:**
+
+After computing direct bumps, git-std resolves runtime
+dependencies from workspace manifests (Cargo, npm). If
+package A bumps and package B depends on A, B receives
+at least a patch bump. Dev-dependencies are excluded.
+The cascade iterates until stable (no new bumps).
+
+The `-p` / `--package` flag skips cascade — only the
+named packages are bumped.
+
+**Apply phase:**
+
+1. Write version files for each bumped package (respecting
+   per-package `[[packages.version_files]]` overrides).
+2. Write per-package `CHANGELOG.md` in each package root
+   (respecting per-package `[packages.changelog]` overrides).
+3. Write root `CHANGELOG.md` from all commits.
+4. Sync lock files once.
+5. Single commit: `chore(release): v{root}, {pkg}@{ver}, ...`
+6. Multiple tags: root `v{version}` + per-package tags
+   from `tag_template` (default `{name}@{version}`).
+
+**Flags:**
+
+| Flag               | Description                                   |
+| ------------------ | --------------------------------------------- |
+| `--package <name>` | Filter bump to specific packages (repeatable) |
+
+All existing bump flags (`--dry-run`, `--no-tag`,
+`--no-commit`, `--skip-changelog`, `--format json`, etc.)
+work in monorepo mode.
+
+**Output (monorepo dry-run):**
+
+```text
+$ git std bump --dry-run
+
+  core    0.2.0 → 0.3.0   minor — new feature
+  cli     0.1.4 → 0.1.5   patch — dependency cascade (core)
+  root    0.8.0 → 0.9.0   minor — new feature
+
+  Tags:
+    v0.9.0
+    core@0.3.0
+    cli@0.1.5
+```
+
+**First release:** when no tag and no version file exist
+for a package, the first semver release defaults to
+`0.1.0`. Calver packages use the current date.
+
 ### 2.4 `git std changelog`
 
 Generate or update the changelog from git commit history
@@ -777,12 +861,14 @@ types = ["feat", "fix", "docs", "style",
 scopes = ["auth", "api", "ci", "deps"]         # "auto" | string[] | omit
 # "auto" discovers directory names from crates/*/, packages/*/, modules/*/
 strict = true                                  # enforce types/scopes without --strict flag
+monorepo = false                               # per-package versioning
 
 # ── Versioning ────────────────────────────────────────────────────
 [versioning]
 tag_prefix = "v"                               # git tag prefix
 prerelease_tag = "rc"                          # default pre-release id
 calver_format = "YYYY.MM.PATCH"                # only used when scheme = "calver"
+tag_template = "{name}@{version}"              # per-package tag format (monorepo)
 
 # ── Changelog ─────────────────────────────────────────────────────
 [changelog]
@@ -799,6 +885,12 @@ docs = "Documentation"
 [[version_files]]
 path = "pom.xml"
 regex = '<version>(.*)</version>'
+
+# ── Packages (monorepo) ──────────────────────────────────
+# [[packages]]
+# name = "core"
+# path = "crates/core"
+# scheme = "patch"                             # optional override
 ```
 
 **Defaults when `.git-std.toml` is absent:**
@@ -809,22 +901,26 @@ regex = '<version>(.*)</version>'
 | `types`                     | `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert` |
 | `scopes`                    | None (no scope validation)                                                                   |
 | `strict`                    | `false`                                                                                      |
+| `monorepo`                  | `false`                                                                                      |
 | `versioning.tag_prefix`     | `v`                                                                                          |
 | `versioning.prerelease_tag` | `rc`                                                                                         |
 | `versioning.calver_format`  | `YYYY.MM.PATCH`                                                                              |
+| `versioning.tag_template`   | `{name}@{version}`                                                                           |
 | `changelog.hidden`          | `chore`, `ci`, `build`, `style`, `test`                                                      |
 | `changelog.sections`        | Sensible defaults for each type                                                              |
 | `version_files`             | `[]` (empty — built-in files are always auto-detected)                                       |
+| `packages`                  | `[]` (auto-discovered from workspace manifests when `monorepo = true`)                       |
 
 **Inferred (not configurable):**
 
-| Concern          | How it's resolved                                              |
-| ---------------- | -------------------------------------------------------------- |
-| Bump rules       | Inferred from `scheme` (semver/calver/patch)                   |
-| Version files    | Auto-detected (see §2.3.1); extensible via `[[version_files]]` |
-| URLs             | Inferred from `git remote get-url origin`                      |
-| Changelog output | Always `CHANGELOG.md`                                          |
-| Release commit   | Always `chore(release): <version>`                             |
+| Concern              | How it's resolved                                              |
+| -------------------- | -------------------------------------------------------------- |
+| Bump rules           | Inferred from `scheme` (semver/calver/patch)                   |
+| Version files        | Auto-detected (see §2.3.1); extensible via `[[version_files]]` |
+| URLs                 | Inferred from `git remote get-url origin`                      |
+| Changelog output     | `CHANGELOG.md` at root; `{path}/CHANGELOG.md` per package      |
+| Release commit       | `chore(release): <version>` (includes all packages)            |
+| Package dependencies | Resolved from workspace manifests (runtime only)               |
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -98,6 +98,30 @@ update version files, generate changelog, commit, and tag.
 
 **Exit codes:** `0` = success, `1` = error.
 
+### Monorepo bump
+
+When `monorepo = true`, each package is versioned
+independently based on commits touching its path.
+
+```bash
+# Bump all packages with changes
+git std bump
+
+# Preview monorepo bump
+git std bump --dry-run
+
+# Bump specific package(s)
+git std bump -p core
+git std bump -p core -p cli
+
+# JSON output for CI
+git std bump --dry-run --format json
+```
+
+Dependency cascade: when package A bumps and package B
+depends on A, B gets at least a patch bump. Use `-p` to
+skip cascade and bump only the named packages.
+
 ## `git std changelog`
 
 Generate or update the changelog from git history.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -156,6 +156,83 @@ These are updated alongside auto-detected files during
 `git std bump`. Use `--dry-run` to preview which files
 would be updated.
 
+## Monorepo workflow
+
+Enable per-package versioning for multi-package repositories:
+
+```toml
+monorepo = true
+scheme = "semver"
+scopes = "auto"
+
+[versioning]
+tag_template = "{name}@{version}"
+
+# Optional — auto-discovered from workspace manifests if omitted
+# [[packages]]
+# name = "core"
+# path = "crates/core"
+```
+
+Packages are auto-discovered from `Cargo.toml` workspace
+members, `package.json` workspaces, or `deno.json` workspace.
+
+### Bump all packages
+
+```bash
+git std bump                   # bumps all packages with changes
+git std bump --dry-run         # preview what would change
+```
+
+### Bump specific packages
+
+```bash
+git std bump -p core           # bump only core
+git std bump -p core -p cli    # bump core and cli
+```
+
+The `-p` flag skips dependency cascade — only the named
+packages are bumped.
+
+### Per-package scheme override
+
+Mix versioning schemes in the same monorepo:
+
+```toml
+monorepo = true
+scheme = "semver"              # default for all packages
+
+[versioning]
+tag_template = "{name}@{version}"
+calver_format = "YYYY.0M.PATCH"
+
+[[packages]]
+name = "core"
+path = "crates/core"
+
+[[packages]]
+name = "api"
+path = "crates/api"
+scheme = "calver"              # this package uses calver
+```
+
+### Per-package changelog config
+
+Override changelog settings per package:
+
+```toml
+[[packages]]
+name = "core"
+path = "crates/core"
+
+[packages.changelog]
+hidden = ["chore"]             # show more commit types for core
+```
+
+Each package gets its own `CHANGELOG.md` in its root
+directory (e.g. `crates/core/CHANGELOG.md`). The root
+`CHANGELOG.md` includes all commits from all packages.
+
 ## Git hooks
 
 ### Setting up hooks


### PR DESCRIPTION
## Summary

Add per-package monorepo versioning documentation across all docs, ensuring consistency with the implementation from epic #360 and debt fixes from #377.

## Changes

### SPEC.md
- New **§2.3.3 Monorepo Mode**: package discovery, per-package bump algorithm, dependency cascade, apply phase (version writes, changelogs, commit, tags), calver behavior, output example
- Updated Part 3 config reference with `monorepo`, `tag_template`, `packages` defaults
- Updated inferred settings table with per-package changelog paths and dependency resolution

### USAGE.md
- Added **Monorepo bump** section with `-p` flag examples (single/multiple packages, dry-run, JSON)
- Documented dependency cascade behavior

### recipes.md
- New **Monorepo workflow** recipe: setup, per-package bump, per-package scheme override (mixed semver/calver), per-package changelog config

### CONFIG.md
- Expanded monorepo example with dependency cascade explanation, per-package changelogs, mixed versioning schemes example
- Updated inferred settings table

### README.md
- Added monorepo support mention in intro paragraph

Epic: #360
Refs: #377