### PR TITLE
fix(changelog): warn when --range arguments are reversed

### DIFF
--- a/crates/git-std/src/cli/changelog.rs
+++ b/crates/git-std/src/cli/changelog.rs
@@ -209,6 +209,20 @@ fn run_range(
         }
     };
 
+    // If the range produced no commits, check if the user reversed the arguments.
+    // Probe the inverse direction — if that yields commits, the range is backwards.
+    if commits.is_empty() {
+        let inverse_has_commits = git::walk_commits(dir, &from_oid, Some(&to_oid))
+            .map(|c| !c.is_empty())
+            .unwrap_or(false);
+        if inverse_has_commits {
+            ui::warning(&format!(
+                "range '{range}' is empty — did you mean '{to_spec}..{from_spec}'?"
+            ));
+            return 1;
+        }
+    }
+
     // Use the "to" ref as the version label, stripping a leading 'v' if present.
     let version = to_spec.strip_prefix('v').unwrap_or(to_spec);
 

--- a/crates/git-std/tests/changelog.rs
+++ b/crates/git-std/tests/changelog.rs
@@ -116,6 +116,33 @@ fn changelog_range_invalid_ref() {
 }
 
 #[test]
+fn changelog_range_warns_on_reversed_range() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+
+    add_commit(dir.path(), "a.txt", "feat: add feature A");
+    create_tag(dir.path(), "v1.1.0");
+
+    let assert = Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["changelog", "--range", "v1.1.0..v1.0.0", "--stdout"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1);
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("warning:"),
+        "should print a warning, got stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("did you mean 'v1.0.0..v1.1.0'"),
+        "should suggest the corrected range, got stderr: {stderr}"
+    );
+}
+
+#[test]
 fn changelog_range_no_conventional_commits() {
     let dir = tempfile::tempdir().unwrap();
     init_bump_repo(dir.path());


### PR DESCRIPTION
## Summary

- `git std changelog --range v2.0.0..v1.0.0` now prints a `warning:` and exits 1 instead of silently succeeding with "no conventional commits found"
- After an empty walk, probes the inverse direction — if that yields commits, the range is backwards and the warning suggests the corrected form

## Example

```
$ git std changelog --range v2.0.0..v1.0.0 --stdout
warning: range 'v2.0.0..v1.0.0' is empty — did you mean 'v1.0.0..v2.0.0'?
```

Fixes #127