### PR TITLE
fix(ecosystem): emit warnings for silent error handling (#353)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "git-std"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -976,14 +976,14 @@ dependencies = [
 
 [[package]]
 name = "standard-changelog"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "standard-commit",
 ]
 
 [[package]]
 name = "standard-commit"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "git-conventional",
  "thiserror",
@@ -991,14 +991,14 @@ dependencies = [
 
 [[package]]
 name = "standard-githooks"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "globset",
 ]
 
 [[package]]
 name = "standard-version"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "regex",
  "semver",

--- a/crates/git-std/src/ecosystem/mod.rs
+++ b/crates/git-std/src/ecosystem/mod.rs
@@ -104,7 +104,10 @@ pub fn native_write(root: &Path, engine: &dyn VersionFile, new_version: &str) ->
 
         let content = match fs::read_to_string(&path) {
             Ok(c) => c,
-            Err(_) => continue,
+            Err(e) => {
+                ui::warning(&format!("{}: {e}", path.display()));
+                continue;
+            }
         };
 
         if !engine.detect(&content) {
@@ -118,7 +121,10 @@ pub fn native_write(root: &Path, engine: &dyn VersionFile, new_version: &str) ->
 
         let updated = match engine.write_version(&content, new_version) {
             Ok(u) => u,
-            Err(_) => continue,
+            Err(e) => {
+                ui::warning(&format!("{}: {e}", path.display()));
+                continue;
+            }
         };
 
         let extra = engine.extra_info(&content, &updated);
@@ -127,6 +133,7 @@ pub fn native_write(root: &Path, engine: &dyn VersionFile, new_version: &str) ->
             .unwrap_or_else(|| new_version.to_string());
 
         if fs::write(&path, &updated).is_err() {
+            ui::warning(&format!("{}: failed to write file", path.display()));
             continue;
         }
 
@@ -310,26 +317,43 @@ fn process_custom_files(
 
         let path = root.join(engine.path());
         if !path.exists() {
+            ui::warning(&format!("{}: file not found", path.display()));
             continue;
         }
 
         let content = match fs::read_to_string(&path) {
             Ok(c) => c,
-            Err(_) => continue,
+            Err(e) => {
+                ui::warning(&format!("{}: {e}", path.display()));
+                continue;
+            }
         };
 
         if !engine.detect(&content) {
+            ui::warning(&format!(
+                "{}: pattern did not match file content",
+                path.display()
+            ));
             continue;
         }
 
         let old_version = match engine.read_version(&content) {
             Some(v) => v,
-            None => continue,
+            None => {
+                ui::warning(&format!(
+                    "{}: could not extract version from matched content",
+                    path.display()
+                ));
+                continue;
+            }
         };
 
         let updated = match engine.write_version(&content, new_version) {
             Ok(u) => u,
-            Err(_) => continue,
+            Err(e) => {
+                ui::warning(&format!("{}: {e}", path.display()));
+                continue;
+            }
         };
 
         let actual_new_version = engine
@@ -337,6 +361,7 @@ fn process_custom_files(
             .unwrap_or_else(|| new_version.to_string());
 
         if fs::write(&path, &updated).is_err() {
+            ui::warning(&format!("{}: failed to write file", path.display()));
             continue;
         }
 

--- a/crates/git-std/tests/bump_custom.rs
+++ b/crates/git-std/tests/bump_custom.rs
@@ -161,14 +161,16 @@ regex = 'version = "(\d+\.\d+\.\d+)"'
 
     add_commit(dir.path(), "a.txt", "feat: add feature");
 
-    // Should still succeed — missing custom files are skipped silently.
+    // Should still succeed — missing custom files are skipped, but a warning is emitted.
     Command::cargo_bin("git-std")
         .unwrap()
         .args(["bump", "--skip-changelog"])
         .current_dir(dir.path())
         .assert()
         .success()
-        .stderr(predicate::str::contains("1.0.0 → 1.1.0"));
+        .stderr(predicate::str::contains("1.0.0 → 1.1.0"))
+        .stderr(predicate::str::contains("warning:"))
+        .stderr(predicate::str::contains("file not found"));
 
     // Cargo.toml should still be updated.
     let cargo = std::fs::read_to_string(dir.path().join("Cargo.toml")).unwrap();


### PR DESCRIPTION
## Summary

Replaces silent error handling with user-visible warnings at 8 critical failure points in the ecosystem module (`native_write` and `process_custom_files`). The most dangerous case: disk write failures were previously silently ignored, causing version bumps to appear successful while files remained unchanged.

## Changes

- **File I/O failures**: Added warnings for `fs::read_to_string` and `fs::write` errors  
- **Pattern matching**: Added warnings when regex pattern doesn't match file content  
- **Version extraction**: Added warnings when capture group fails to extract version  
- **Custom files**: Added explicit "file not found" warning for missing configured files

## Test Coverage

Updated `bump_custom_file_missing` test to verify warnings are emitted. All existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
