### PR TITLE
fix(completions): add git subcommand wrappers

### DIFF
--- a/crates/git-std/src/cli/completions.rs
+++ b/crates/git-std/src/cli/completions.rs
@@ -1,0 +1,63 @@
+use clap_complete::Shell;
+
+/// Shell snippet that enables `git std …` tab-completion.
+///
+/// `clap_complete::generate` registers completions for the standalone
+/// `git-std` binary.  Each shell's git-completion framework uses a
+/// different mechanism for custom sub-commands; we append the right
+/// wrapper so that `git std <TAB>` works too.
+pub fn git_subcommand_wrapper(shell: Shell) -> &'static str {
+    match shell {
+        Shell::Bash => GIT_SUBCMD_BASH,
+        Shell::Zsh => GIT_SUBCMD_ZSH,
+        Shell::Fish => GIT_SUBCMD_FISH,
+        _ => "",
+    }
+}
+
+/// Bash: git's completion framework calls `_git_<subcmd>` for custom
+/// sub-commands.  We translate `COMP_WORDS` from `("git" "std" …)` to
+/// `("git-std" …)` and delegate to the clap-generated `_git-std`.
+const GIT_SUBCMD_BASH: &str = r#"
+# --- git subcommand wrapper -------------------------------------------
+# Enable completion for "git std" (git subcommand invocation).
+# Git's bash completion calls _git_<subcmd> for custom subcommands.
+_git_std() {
+    local _save_words=("${COMP_WORDS[@]}")
+    local _save_cword=$COMP_CWORD
+    # Merge "git std" into "git-std" so _git-std sees the expected layout.
+    COMP_WORDS=("git-std" "${COMP_WORDS[@]:2}")
+    (( COMP_CWORD -= 1 ))
+    local _cur="${COMP_WORDS[$COMP_CWORD]}"
+    local _prev="${COMP_WORDS[$((COMP_CWORD > 0 ? COMP_CWORD - 1 : 0))]}"
+    _git-std "git-std" "$_cur" "$_prev"
+    COMP_WORDS=("${_save_words[@]}")
+    COMP_CWORD=$_save_cword
+}
+"#;
+
+/// Zsh: register `std` as a git user-command so `_git` delegates to the
+/// already-defined `_git-std` completion function.
+const GIT_SUBCMD_ZSH: &str = r#"
+# --- git subcommand wrapper -------------------------------------------
+# Register "std" as a git user-command so "git std <TAB>" triggers _git-std.
+zstyle ':completion:*:*:git:*' user-commands std:'Conventional commit standards'
+"#;
+
+/// Fish: register `std` as a git subcommand and list top-level
+/// sub-commands.  Deeper option completion is handled by the standalone
+/// `git-std` completions above.
+const GIT_SUBCMD_FISH: &str = r#"
+# --- git subcommand wrapper -------------------------------------------
+# Register "std" as a git subcommand for "git std <TAB>" completion.
+complete -f -c git -n __fish_git_needs_command -a std -d 'Conventional commit standards'
+complete -f -c git -n '__fish_git_using_command std' -a commit -d 'Interactive conventional commit builder'
+complete -f -c git -n '__fish_git_using_command std' -a check -d 'Validate commit messages'
+complete -f -c git -n '__fish_git_using_command std' -a bump -d 'Version bump, changelog, commit, and tag'
+complete -f -c git -n '__fish_git_using_command std' -a changelog -d 'Generate a changelog'
+complete -f -c git -n '__fish_git_using_command std' -a bootstrap -d 'Post-clone environment setup'
+complete -f -c git -n '__fish_git_using_command std' -a hooks -d 'Git hooks management'
+complete -f -c git -n '__fish_git_using_command std' -a config -d 'Inspect git-std configuration'
+complete -f -c git -n '__fish_git_using_command std' -a doctor -d 'Run health checks'
+complete -f -c git -n '__fish_git_using_command std' -a completions -d 'Generate shell completions'
+"#;

--- a/crates/git-std/src/cli/mod.rs
+++ b/crates/git-std/src/cli/mod.rs
@@ -3,6 +3,7 @@ pub mod bump;
 pub mod changelog;
 pub mod check;
 pub mod commit;
+pub mod completions;
 pub mod config;
 pub mod doctor;
 pub mod hooks;

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -182,6 +182,7 @@ fn main() {
         Command::Completions { shell } => {
             let mut cmd = Cli::command();
             clap_complete::generate(shell, &mut cmd, "git-std", &mut std::io::stdout());
+            print!("{}", cli::completions::git_subcommand_wrapper(shell));
         }
     }
 }

--- a/crates/git-std/tests/completions.rs
+++ b/crates/git-std/tests/completions.rs
@@ -11,6 +11,16 @@ fn completions_bash_outputs_script() {
 }
 
 #[test]
+fn completions_bash_includes_git_subcommand_wrapper() {
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("_git_std"));
+}
+
+#[test]
 fn completions_zsh_outputs_script() {
     Command::cargo_bin("git-std")
         .unwrap()
@@ -21,6 +31,16 @@ fn completions_zsh_outputs_script() {
 }
 
 #[test]
+fn completions_zsh_includes_git_subcommand_wrapper() {
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("user-commands std:"));
+}
+
+#[test]
 fn completions_fish_outputs_script() {
     Command::cargo_bin("git-std")
         .unwrap()
@@ -28,4 +48,14 @@ fn completions_fish_outputs_script() {
         .assert()
         .success()
         .stdout(predicates::str::contains("complete"));
+}
+
+#[test]
+fn completions_fish_includes_git_subcommand_wrapper() {
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("complete -f -c git"));
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -823,17 +823,20 @@ git std completions zsh    # Zsh completions
 git std completions fish   # Fish completions
 ```
 
+The generated scripts include wrappers that enable completion for
+both `git-std` (standalone) and `git std` (git subcommand) invocations.
+
 **Example — add to shell profile:**
 
 ```bash
 # Bash (~/.bashrc)
-eval "$(git std completions bash)"
+eval "$(git-std completions bash)"
 
 # Zsh (~/.zshrc)
-eval "$(git std completions zsh)"
+eval "$(git-std completions zsh)"
 
 # Fish (~/.config/fish/config.fish)
-git std completions fish | source
+git-std completions fish | source
 ```
 
 ### 2.9 Global Flags

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -225,7 +225,8 @@ git std doctor --format json  # machine-readable JSON on stdout
 
 ## `git std completions`
 
-Generate shell completion scripts.
+Generate shell completion scripts. The output includes wrappers that
+enable completion for both `git-std` and `git std` invocations.
 
 ```bash
 git std completions bash   # Bash


### PR DESCRIPTION
## Summary

- `clap_complete::generate` only registers completions for the standalone `git-std` binary — `git std <TAB>` was silently broken
- Append shell-specific wrappers so tab-completion works for both `git-std` and `git std` invocations
- Bash: define `_git_std()` that delegates to `_git-std`; Zsh: register `std` via `zstyle user-commands`; Fish: register `std` as a git subcommand with top-level sub-commands

## Test plan

- [x] `just check` passes (tests, clippy, fmt, lint, audit)
- [x] Three new integration tests verify each shell wrapper is present in the output
- [ ] Manual: source completions then verify `git std <TAB>` completes subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)