### PR TITLE
feat(cli): add background update check (#383)

### DIFF
--- a/crates/git-std/src/cli/mod.rs
+++ b/crates/git-std/src/cli/mod.rs
@@ -7,4 +7,5 @@ pub mod doctor;
 pub mod hook;
 pub mod init;
 pub mod lint;
+pub mod update_check;
 pub mod version;

--- a/crates/git-std/src/cli/update_check.rs
+++ b/crates/git-std/src/cli/update_check.rs
@@ -1,0 +1,259 @@
+//! Non-blocking update check — gh-style background fetch with local cache.
+//!
+//! On every CLI invocation the cache file is read. When stale (>24 h) or
+//! missing, a detached child process is spawned that queries the GitHub
+//! releases API via `curl`, writes the result to the cache, and exits.
+//! When the cache is fresh and contains a newer version the caller prints
+//! a one-line hint *after* command output.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::ui;
+
+const STALE_SECS: u64 = 24 * 60 * 60;
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+const RELEASES_URL: &str = "https://api.github.com/repos/driftsys/git-std/releases/latest";
+
+// ── cache data ──────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+struct UpdateCache {
+    latest_version: String,
+    checked_at: u64,
+}
+
+// ── public API ──────────────────────────────────────────────────────
+
+/// Spawn a background update check when the cache is missing or stale.
+///
+/// No-op when `GIT_STD_NO_UPDATE_CHECK=1`, stderr is not a TTY, or the
+/// cache is still fresh.
+pub fn maybe_spawn_background_check() {
+    if is_disabled() || !ui::is_tty() {
+        return;
+    }
+    let Some(path) = cache_path() else { return };
+    if let Some(cache) = read_cache_from(&path)
+        && !is_stale(cache.checked_at)
+    {
+        return; // fresh — hint will be printed later
+    }
+    // Cache missing, corrupt, or stale → spawn background worker.
+    let Some(exe) = std::env::current_exe().ok() else {
+        return;
+    };
+    let _ = std::process::Command::new(exe)
+        .arg("--update-check-bg")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn(); // fire-and-forget
+}
+
+/// Run the actual update check (called as a detached child process).
+pub fn run_background_check() {
+    let Some(path) = cache_path() else { return };
+    let Some(version) = fetch_latest_version() else {
+        return;
+    };
+    let cache = UpdateCache {
+        latest_version: version,
+        checked_at: now_epoch_secs(),
+    };
+    let _ = write_cache_to(&path, &cache);
+}
+
+/// Print an update hint if the cache is fresh and a newer version exists.
+pub fn print_update_hint() {
+    if is_disabled() {
+        return;
+    }
+    let Some(path) = cache_path() else { return };
+    let Some(cache) = read_cache_from(&path) else {
+        return;
+    };
+    if is_stale(cache.checked_at) {
+        return; // stale cache = silence
+    }
+    if let Some(msg) = build_hint_message(CURRENT_VERSION, &cache.latest_version) {
+        ui::blank();
+        for line in msg.lines() {
+            ui::hint(line);
+        }
+    }
+}
+
+// ── private helpers ─────────────────────────────────────────────────
+
+fn is_disabled() -> bool {
+    std::env::var("GIT_STD_NO_UPDATE_CHECK")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
+fn now_epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn is_stale(checked_at: u64) -> bool {
+    now_epoch_secs().saturating_sub(checked_at) >= STALE_SECS
+}
+
+fn cache_path() -> Option<PathBuf> {
+    let base = std::env::var("XDG_CONFIG_HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| std::env::var("HOME").ok().map(|h| format!("{h}/.config")))?;
+    Some(PathBuf::from(base).join("git-std/update-check.json"))
+}
+
+fn read_cache_from(path: &Path) -> Option<UpdateCache> {
+    let data = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+fn write_cache_to(path: &Path, cache: &UpdateCache) -> Result<(), std::io::Error> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string(cache).map_err(std::io::Error::other)?;
+    std::fs::write(path, json)
+}
+
+fn fetch_latest_version() -> Option<String> {
+    let output = std::process::Command::new("curl")
+        .args(["-sSf", "--max-time", "10", RELEASES_URL])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let body: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let tag = body.get("tag_name")?.as_str()?;
+    let version = tag.strip_prefix('v').unwrap_or(tag);
+    semver::Version::parse(version).ok()?;
+    Some(version.to_string())
+}
+
+fn build_hint_message(current: &str, latest: &str) -> Option<String> {
+    let cur = semver::Version::parse(current).ok()?;
+    let lat = semver::Version::parse(latest).ok()?;
+    if lat <= cur {
+        return None;
+    }
+    let cmd = detect_install_method();
+    Some(format!(
+        "a new release of git-std is available: {current} \u{2192} {latest}\nto update, run: {cmd}"
+    ))
+}
+
+fn detect_install_method() -> String {
+    let path = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.to_str().map(String::from))
+        .unwrap_or_default();
+    install_method_for_path(&path)
+}
+
+fn install_method_for_path(path: &str) -> String {
+    if path.contains("/.cargo/bin/") {
+        "cargo install git-std".to_string()
+    } else if path.contains("/.local/bin/") {
+        "curl -fsSL https://raw.githubusercontent.com/driftsys/git-std/main/install.sh | sh"
+            .to_string()
+    } else if path.contains("/nix/store/") {
+        "nix profile upgrade git-std".to_string()
+    } else {
+        "visit https://github.com/driftsys/git-std/releases".to_string()
+    }
+}
+
+// ── tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_after_24h() {
+        let old = now_epoch_secs() - 25 * 3600;
+        assert!(is_stale(old));
+    }
+
+    #[test]
+    fn fresh_within_24h() {
+        let recent = now_epoch_secs() - 3600;
+        assert!(!is_stale(recent));
+    }
+
+    #[test]
+    fn cache_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("update-check.json");
+        let cache = UpdateCache {
+            latest_version: "1.2.3".to_string(),
+            checked_at: now_epoch_secs(),
+        };
+        write_cache_to(&path, &cache).unwrap();
+        let loaded = read_cache_from(&path).unwrap();
+        assert_eq!(loaded.latest_version, "1.2.3");
+    }
+
+    #[test]
+    fn read_cache_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(read_cache_from(&dir.path().join("nope.json")).is_none());
+    }
+
+    #[test]
+    fn read_cache_corrupt_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.json");
+        std::fs::write(&path, "not json!!!").unwrap();
+        assert!(read_cache_from(&path).is_none());
+    }
+
+    #[test]
+    fn hint_when_newer() {
+        assert!(build_hint_message("0.9.0", "1.0.0").is_some());
+    }
+
+    #[test]
+    fn no_hint_when_current() {
+        assert!(build_hint_message("1.0.0", "1.0.0").is_none());
+    }
+
+    #[test]
+    fn no_hint_when_ahead() {
+        assert!(build_hint_message("2.0.0", "1.0.0").is_none());
+    }
+
+    #[test]
+    fn method_cargo() {
+        let m = install_method_for_path("/home/user/.cargo/bin/git-std");
+        assert!(m.contains("cargo install"));
+    }
+
+    #[test]
+    fn method_local_bin() {
+        let m = install_method_for_path("/home/user/.local/bin/git-std");
+        assert!(m.contains("curl"));
+    }
+
+    #[test]
+    fn method_nix() {
+        let m = install_method_for_path("/nix/store/abc/bin/git-std");
+        assert!(m.contains("nix profile"));
+    }
+
+    #[test]
+    fn method_other() {
+        let m = install_method_for_path("/usr/local/bin/git-std");
+        assert!(m.contains("github.com"));
+    }
+}

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -12,6 +12,12 @@ pub mod ui;
 use app::*;
 
 fn main() {
+    // Handle hidden background update-check mode before clap parsing.
+    if std::env::args().any(|a| a == "--update-check-bg") {
+        cli::update_check::run_background_check();
+        return;
+    }
+
     let cli = Cli::parse();
 
     // Configure yansi colour output based on --color flag.
@@ -44,7 +50,9 @@ fn main() {
         }
     };
 
-    match command {
+    cli::update_check::maybe_spawn_background_check();
+
+    let code = match command {
         Command::Lint {
             message,
             file,
@@ -62,7 +70,7 @@ fn main() {
                 None
             };
 
-            let code = if let Some(path) = file {
+            if let Some(path) = file {
                 cli::lint::run_file(&path, lint_ref, format)
             } else if let Some(range) = range {
                 cli::lint::run_range(&range, lint_ref, format)
@@ -74,8 +82,7 @@ fn main() {
                 ui::info("       git std lint --file <path>");
                 ui::info("       git std lint --range <from..to>");
                 2
-            };
-            std::process::exit(code);
+            }
         }
         Command::Commit {
             commit_type,
@@ -102,8 +109,7 @@ fn main() {
                 footer,
                 signoff,
             };
-            let code = cli::commit::run_interactive(&project_config, &opts);
-            std::process::exit(code);
+            cli::commit::run_interactive(&project_config, &opts)
         }
         Command::Changelog {
             full,
@@ -122,8 +128,7 @@ fn main() {
                 tag_template: project_config.versioning.tag_template.clone(),
                 tag_prefix: project_config.versioning.tag_prefix.clone(),
             };
-            let code = cli::changelog::run(&project_config, &changelog_config, &opts);
-            std::process::exit(code);
+            cli::changelog::run(&project_config, &changelog_config, &opts)
         }
         Command::Bump {
             dry_run,
@@ -159,28 +164,19 @@ fn main() {
                 packages,
                 push,
             };
-            let code = cli::bump::run(&project_config, &opts);
-            std::process::exit(code);
+            cli::bump::run(&project_config, &opts)
         }
-        Command::Init { force } => {
-            std::process::exit(cli::init::run(force));
-        }
-        Command::Bootstrap { dry_run } => {
-            let code = cli::bootstrap::run(dry_run);
-            std::process::exit(code);
-        }
-        Command::Hook { subcommand } => {
-            let code = match subcommand {
-                HookCommand::Run { hook, args, format } => cli::hook::run(&hook, &args, format),
-                HookCommand::List { format } => cli::hook::list(format),
-                HookCommand::Enable { hook } => cli::hook::enable(&hook),
-                HookCommand::Disable { hook } => cli::hook::disable(&hook),
-            };
-            std::process::exit(code);
-        }
+        Command::Init { force } => cli::init::run(force),
+        Command::Bootstrap { dry_run } => cli::bootstrap::run(dry_run),
+        Command::Hook { subcommand } => match subcommand {
+            HookCommand::Run { hook, args, format } => cli::hook::run(&hook, &args, format),
+            HookCommand::List { format } => cli::hook::list(format),
+            HookCommand::Enable { hook } => cli::hook::enable(&hook),
+            HookCommand::Disable { hook } => cli::hook::disable(&hook),
+        },
         Command::Doctor { format } => {
             let cwd = std::env::current_dir().unwrap_or_default();
-            std::process::exit(cli::doctor::run(&cwd, format));
+            cli::doctor::run(&cwd, format)
         }
         Command::Version {
             describe,
@@ -197,7 +193,10 @@ fn main() {
                 code,
                 format,
             };
-            std::process::exit(cli::version::run(&project_config, &opts));
+            cli::version::run(&project_config, &opts)
         }
-    }
+    };
+
+    cli::update_check::print_update_hint();
+    std::process::exit(code);
 }

--- a/crates/git-std/tests/update_check.rs
+++ b/crates/git-std/tests/update_check.rs
@@ -1,0 +1,99 @@
+use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
+use tempfile::TempDir;
+
+#[test]
+fn update_check_bg_exits_cleanly() {
+    let config_dir = TempDir::new().unwrap();
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .arg("--update-check-bg")
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .timeout(std::time::Duration::from_secs(15))
+        .assert()
+        .success();
+}
+
+#[test]
+fn opt_out_suppresses_hint() {
+    let config_dir = TempDir::new().unwrap();
+    prepopulate_cache(config_dir.path(), "99.99.99");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["lint", "feat: test"])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .env("GIT_STD_NO_UPDATE_CHECK", "1")
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("hint:").not());
+}
+
+#[test]
+fn hint_printed_when_cache_has_newer_version() {
+    let config_dir = TempDir::new().unwrap();
+    prepopulate_cache(config_dir.path(), "99.99.99");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["lint", "feat: test"])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success()
+        .stderr(predicates::str::contains(
+            "a new release of git-std is available",
+        ));
+}
+
+#[test]
+fn no_hint_when_cache_is_stale() {
+    let config_dir = TempDir::new().unwrap();
+    prepopulate_cache_with_age(config_dir.path(), "99.99.99", 25 * 3600);
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["lint", "feat: test"])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("a new release").not());
+}
+
+#[test]
+fn no_hint_when_up_to_date() {
+    let config_dir = TempDir::new().unwrap();
+    let current = env!("CARGO_PKG_VERSION");
+    prepopulate_cache(config_dir.path(), current);
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["lint", "feat: test"])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("a new release").not());
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+fn prepopulate_cache(config_dir: &std::path::Path, version: &str) {
+    prepopulate_cache_with_age(config_dir, version, 0);
+}
+
+fn prepopulate_cache_with_age(config_dir: &std::path::Path, version: &str, age_secs: u64) {
+    let cache_dir = config_dir.join("git-std");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let cache = serde_json::json!({
+        "latest_version": version,
+        "checked_at": now - age_secs,
+    });
+    std::fs::write(
+        cache_dir.join("update-check.json"),
+        serde_json::to_string(&cache).unwrap(),
+    )
+    .unwrap();
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1000,7 +1000,32 @@ The stage range ensures every pre-release build is numerically less than the
 final stable release while remaining monotonically increasing within each
 pre-release track.
 
-### 2.9 Global Flags
+### 2.9 Update Check
+
+git-std periodically checks whether a newer release is available and
+prints a one-line hint after command output.
+
+**Behaviour (gh-style background check):**
+
+1. On every invocation, read the cache file
+   (`~/.config/git-std/update-check.json`, respects `$XDG_CONFIG_HOME`).
+2. If the cache is missing or stale (>24 h), spawn a detached background
+   process that queries the GitHub releases API and writes the cache.
+   No hint is printed on this run.
+3. On the next invocation (cache fresh, newer version exists), print a
+   hint after command output.
+4. The update command adapts to the detected install method
+   (`cargo install`, `install.sh`, `nix profile upgrade`, or a link to
+   the releases page).
+
+**Properties:**
+
+- Never blocks CLI startup — background subprocess is fire-and-forget.
+- 24 h throttle — at most one network request per day.
+- Stale or missing cache = silence.
+- Opt-out: set `GIT_STD_NO_UPDATE_CHECK=1`.
+
+### 2.10 Global Flags
 
 | Flag                    | Description                          |
 | ----------------------- | ------------------------------------ |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -389,4 +389,14 @@ $ git std config list
   ...
 ```
 
+## Update Check
+
+git-std periodically checks for newer releases in the background and
+prints a hint after command output when an update is available.
+
+- Non-blocking — a detached background process fetches the latest
+  release once every 24 hours.
+- Adapts to install method (cargo, install.sh, nix).
+- Opt-out: `GIT_STD_NO_UPDATE_CHECK=1`.
+
 [conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
## Summary

- Non-blocking gh-style update check: detached background subprocess queries GitHub releases API via `curl`, caches result for 24h
- Prints a hint after command output when a newer version exists, adapting the update command to the detected install method (cargo/install.sh/nix/generic)
- Opt-out with `GIT_STD_NO_UPDATE_CHECK=1`; skips spawning when stderr is not a TTY (CI)

Closes #383

## Test plan

- [x] `just check` passes (tests, clippy, fmt, markdownlint, audit)
- [x] 12 unit tests (staleness, cache round-trip, corrupt/missing file, version comparison, install method detection)
- [x] 5 integration tests (bg flag exits cleanly, opt-out, hint on newer version, no hint on stale cache, no hint when up to date)
- [ ] Manual: delete cache, run `git std check "feat: test"` twice, verify hint appears on second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)