### PR TITLE
fix(changelog): split reversed-range warning and add same-commit test

### DIFF
--- a/crates/git-std/src/cli/changelog.rs
+++ b/crates/git-std/src/cli/changelog.rs
@@ -216,9 +216,8 @@ fn run_range(
             .map(|c| !c.is_empty())
             .unwrap_or(false);
         if inverse_has_commits {
-            ui::warning(&format!(
-                "range '{range}' is empty — did you mean '{to_spec}..{from_spec}'?"
-            ));
+            ui::warning(&format!("range '{range}' is empty"));
+            ui::hint(&format!("did you mean '{to_spec}..{from_spec}'?"));
             return 1;
         }
     }

--- a/crates/git-std/tests/changelog.rs
+++ b/crates/git-std/tests/changelog.rs
@@ -133,12 +133,12 @@ fn changelog_range_warns_on_reversed_range() {
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("warning:"),
-        "should print a warning, got stderr: {stderr}"
+        stderr.contains("warning:") && stderr.contains("is empty"),
+        "should print a warning about empty range, got stderr: {stderr}"
     );
     assert!(
-        stderr.contains("did you mean 'v1.0.0..v1.1.0'"),
-        "should suggest the corrected range, got stderr: {stderr}"
+        stderr.contains("hint:") && stderr.contains("did you mean 'v1.0.0..v1.1.0'"),
+        "should print a hint with the corrected range, got stderr: {stderr}"
     );
 }
 
@@ -160,6 +160,33 @@ fn changelog_range_no_conventional_commits() {
         .success();
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("no conventional commits found"),
+        "should report no conventional commits, got stderr: {stderr}"
+    );
+}
+
+#[test]
+fn changelog_range_no_warning_for_same_commit_tags() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+
+    // Create a second tag on the same commit.
+    git(dir.path(), &["tag", "-a", "v1.0.1", "-m", "v1.0.1"]);
+
+    let assert = Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["changelog", "--range", "v1.0.0..v1.0.1", "--stdout"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        !stderr.contains("warning:"),
+        "should not print a warning for same-commit tags, got stderr: {stderr}"
+    );
     assert!(
         stderr.contains("no conventional commits found"),
         "should report no conventional commits, got stderr: {stderr}"


### PR DESCRIPTION
## Summary
- Split reversed-range warning into `ui::warning()` + `ui::hint()` per project convention (#391)
- Add test for same-commit range edge case — two tags on same SHA produce no warning (#392)

Closes #391, closes #392

## Test plan
- [x] `changelog_range_warns_on_reversed_range` updated to check warning + hint separately
- [x] `changelog_range_no_warning_for_same_commit_tags` added
- [x] All 6 changelog tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)