### PR TITLE
fix(ecosystem): use ecosystem layer in dry-run path

### DIFF
--- a/crates/git-std/src/cli/bump/apply.rs
+++ b/crates/git-std/src/cli/bump/apply.rs
@@ -87,13 +87,8 @@ pub(super) fn finalize_bump(
 
     // --- Dry run: print plan and exit ---
     if opts.dry_run {
-        let detected = match standard_version::detect_version_files(workdir, &custom_files) {
-            Ok(d) => d,
-            Err(e) => {
-                ui::warning(&format!("cannot detect version files: {e}"));
-                Vec::new()
-            }
-        };
+        let detected = crate::ecosystem::dry_run_version_files(workdir, &custom_files);
+        let lock_files = crate::ecosystem::dry_run_lock_file_names(workdir);
 
         if opts.format == OutputFormat::Json {
             let result = BumpResultJson {
@@ -117,7 +112,7 @@ pub(super) fn finalize_bump(
                         new_version: new_version.clone(),
                     })
                     .collect(),
-                synced_locks: Vec::new(),
+                synced_locks: lock_files,
                 changelog: !opts.skip_changelog,
                 commit: if !opts.no_commit {
                     Some(format!("chore(release): {new_version}"))

--- a/crates/git-std/src/ecosystem/deno.rs
+++ b/crates/git-std/src/ecosystem/deno.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 
-use standard_version::DenoVersionFile;
+use standard_version::{DenoVersionFile, VersionFile};
 
 use super::{Ecosystem, SyncOutcome, WriteOutcome, native_write, try_sync};
 
@@ -38,5 +38,9 @@ impl Ecosystem for Deno {
 
     fn lock_files(&self) -> &[&str] {
         &["deno.lock"]
+    }
+
+    fn version_file_engine(&self) -> Option<Box<dyn VersionFile>> {
+        Some(Box::new(DenoVersionFile))
     }
 }

--- a/crates/git-std/src/ecosystem/flutter.rs
+++ b/crates/git-std/src/ecosystem/flutter.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use standard_version::PubspecVersionFile;
+use standard_version::{PubspecVersionFile, VersionFile};
 
 use super::{Ecosystem, SyncOutcome, WriteOutcome, native_write};
 
@@ -30,5 +30,9 @@ impl Ecosystem for Flutter {
 
     fn sync_lock(&self, _root: &Path) -> Vec<SyncOutcome> {
         vec![SyncOutcome::NoLockFile]
+    }
+
+    fn version_file_engine(&self) -> Option<Box<dyn VersionFile>> {
+        Some(Box::new(PubspecVersionFile))
     }
 }

--- a/crates/git-std/src/ecosystem/gradle.rs
+++ b/crates/git-std/src/ecosystem/gradle.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use standard_version::GradleVersionFile;
+use standard_version::{GradleVersionFile, VersionFile};
 
 use super::{Ecosystem, SyncOutcome, WriteOutcome, native_write};
 
@@ -30,5 +30,9 @@ impl Ecosystem for Gradle {
 
     fn sync_lock(&self, _root: &Path) -> Vec<SyncOutcome> {
         vec![SyncOutcome::NoLockFile]
+    }
+
+    fn version_file_engine(&self) -> Option<Box<dyn VersionFile>> {
+        Some(Box::new(GradleVersionFile))
     }
 }

--- a/crates/git-std/src/ecosystem/mod.rs
+++ b/crates/git-std/src/ecosystem/mod.rs
@@ -16,7 +16,9 @@ mod rust;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use standard_version::{CustomVersionFile, RegexVersionFile, UpdateResult, VersionFile};
+use standard_version::{
+    CustomVersionFile, DetectedFile, RegexVersionFile, UpdateResult, VersionFile,
+};
 
 use crate::ui;
 
@@ -47,6 +49,15 @@ pub trait Ecosystem {
     /// Lock file name(s) this ecosystem manages (for dry-run display).
     fn lock_files(&self) -> &[&str] {
         &[]
+    }
+
+    /// Return the version-file engine used for read-only detection.
+    ///
+    /// Used by [`dry_run_version_files`] to detect existing versions without
+    /// writing. Ecosystems that own a `standard_version::VersionFile` engine
+    /// should return it here.
+    fn version_file_engine(&self) -> Option<Box<dyn VersionFile>> {
+        None
     }
 }
 
@@ -293,6 +304,95 @@ pub fn dry_run_lock_sync(root: &Path) {
             }
         }
     }
+}
+
+/// Detect version files through the ecosystem layer (read-only).
+///
+/// Uses each ecosystem's `detect()` gate and `version_file_engine()` to
+/// find version files, mirroring the detection that [`run_bump`] would
+/// perform. Custom `[[version_files]]` are appended via the regex engine.
+pub fn dry_run_version_files(root: &Path, custom_files: &[CustomVersionFile]) -> Vec<DetectedFile> {
+    let ecosystems = all_ecosystems();
+    let mut results: Vec<DetectedFile> = Vec::new();
+
+    for eco in &ecosystems {
+        if !eco.detect(root) {
+            continue;
+        }
+        let Some(engine) = eco.version_file_engine() else {
+            continue;
+        };
+        for filename in engine.filenames() {
+            let path = root.join(filename);
+            if !path.exists() {
+                continue;
+            }
+            let content = match fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            if !engine.detect(&content) {
+                continue;
+            }
+            let Some(old_version) = engine.read_version(&content) else {
+                continue;
+            };
+            results.push(DetectedFile {
+                path,
+                name: engine.name().to_string(),
+                old_version,
+            });
+        }
+    }
+
+    // Append custom [[version_files]] via regex engine.
+    for cf in custom_files {
+        let engine = match RegexVersionFile::new(cf) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let path = root.join(engine.path());
+        if !path.exists() {
+            continue;
+        }
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if !engine.detect(&content) {
+            continue;
+        }
+        let Some(old_version) = engine.read_version(&content) else {
+            continue;
+        };
+        results.push(DetectedFile {
+            path,
+            name: engine.name(),
+            old_version,
+        });
+    }
+
+    results
+}
+
+/// Return lock file names that would be synced during a real bump.
+///
+/// Only returns names for lock files that exist on disk, filtered through
+/// the ecosystem detection layer.
+pub fn dry_run_lock_file_names(root: &Path) -> Vec<String> {
+    let ecosystems = all_ecosystems();
+    let mut names = Vec::new();
+    for eco in &ecosystems {
+        if !eco.detect(root) {
+            continue;
+        }
+        for lock_file in eco.lock_files() {
+            if root.join(lock_file).exists() {
+                names.push(lock_file.to_string());
+            }
+        }
+    }
+    names
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/git-std/src/ecosystem/node.rs
+++ b/crates/git-std/src/ecosystem/node.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 
-use standard_version::JsonVersionFile;
+use standard_version::{JsonVersionFile, VersionFile};
 
 use super::{Ecosystem, SyncOutcome, WriteOutcome, cmd, native_write, try_sync};
 use crate::ui;
@@ -77,6 +77,10 @@ impl Ecosystem for Node {
 
     fn lock_files(&self) -> &[&str] {
         &["package-lock.json", "yarn.lock", "pnpm-lock.yaml"]
+    }
+
+    fn version_file_engine(&self) -> Option<Box<dyn VersionFile>> {
+        Some(Box::new(JsonVersionFile))
     }
 }
 

--- a/crates/git-std/src/ecosystem/plain.rs
+++ b/crates/git-std/src/ecosystem/plain.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use standard_version::PlainVersionFile;
+use standard_version::{PlainVersionFile, VersionFile};
 
 use super::{Ecosystem, SyncOutcome, WriteOutcome, native_write};
 
@@ -30,5 +30,9 @@ impl Ecosystem for Plain {
 
     fn sync_lock(&self, _root: &Path) -> Vec<SyncOutcome> {
         vec![SyncOutcome::NoLockFile]
+    }
+
+    fn version_file_engine(&self) -> Option<Box<dyn VersionFile>> {
+        Some(Box::new(PlainVersionFile))
     }
 }

--- a/crates/git-std/src/ecosystem/python.rs
+++ b/crates/git-std/src/ecosystem/python.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 
-use standard_version::PyprojectVersionFile;
+use standard_version::{PyprojectVersionFile, VersionFile};
 
 use super::{Ecosystem, SyncOutcome, WriteOutcome, cmd, native_write, try_sync};
 use crate::ui;
@@ -63,6 +63,10 @@ impl Ecosystem for Python {
 
     fn lock_files(&self) -> &[&str] {
         &["uv.lock", "poetry.lock"]
+    }
+
+    fn version_file_engine(&self) -> Option<Box<dyn VersionFile>> {
+        Some(Box::new(PyprojectVersionFile))
     }
 }
 

--- a/crates/git-std/src/ecosystem/rust.rs
+++ b/crates/git-std/src/ecosystem/rust.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use standard_version::CargoVersionFile;
+use standard_version::{CargoVersionFile, VersionFile};
 
 use super::{Ecosystem, SyncOutcome, WriteOutcome, cmd, native_write, try_sync};
 use crate::ui;
@@ -70,5 +70,9 @@ impl Ecosystem for Rust {
 
     fn lock_files(&self) -> &[&str] {
         &["Cargo.lock"]
+    }
+
+    fn version_file_engine(&self) -> Option<Box<dyn VersionFile>> {
+        Some(Box::new(CargoVersionFile))
     }
 }


### PR DESCRIPTION
## Summary
- Dry-run path now uses ecosystem orchestration for version file detection instead of calling `standard_version::detect_version_files()` directly (#352)
- `synced_locks` in dry-run JSON output populated via ecosystem detection instead of hardcoded empty array
- Added `version_file_engine()` trait method to all 7 ecosystem implementations

Closes #352

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy -p git-std` — zero warnings
- [x] Dry-run version detection now mirrors actual bump detection path

🤖 Generated with [Claude Code](https://claude.com/claude-code)