### PR TITLE
feat(cli): move completions to --completions global flag (#401)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,15 +45,20 @@ updates.
 
 **Seven subcommands**, each a separate concern:
 
-| Subcommand            | Purpose                                                |
-| --------------------- | ------------------------------------------------------ |
-| `git std commit`      | Interactive conventional commit builder                |
-| `git std lint`        | Commit message validation                              |
-| `git std bump`        | Version bump + changelog + commit + tag                |
-| `git std changelog`   | Changelog generation (incremental or full)             |
-| `git std bootstrap`   | Post-clone environment setup                           |
-| `git std hook`        | Git hooks management (install/run/list/enable/disable) |
-| `git std completions` | Generate shell completion scripts                      |
+| Subcommand          | Purpose                                                |
+| ------------------- | ------------------------------------------------------ |
+| `git std commit`    | Interactive conventional commit builder                |
+| `git std lint`      | Commit message validation                              |
+| `git std bump`      | Version bump + changelog + commit + tag                |
+| `git std changelog` | Changelog generation (incremental or full)             |
+| `git std bootstrap` | Post-clone environment setup                           |
+| `git std hook`      | Git hooks management (install/run/list/enable/disable) |
+
+**Global flag** (no subcommand required):
+
+| Flag                    | Purpose                           |
+| ----------------------- | --------------------------------- |
+| `--completions <shell>` | Generate shell completion scripts |
 
 **Key design decisions:**
 

--- a/crates/git-std/src/app.rs
+++ b/crates/git-std/src/app.rs
@@ -29,8 +29,12 @@ pub struct Cli {
     #[arg(long, global = true, default_value = "auto")]
     pub color: ColorWhen,
 
+    /// Generate shell completion scripts and print to stdout.
+    #[arg(long, value_name = "SHELL")]
+    pub completions: Option<Shell>,
+
     #[command(subcommand)]
-    pub command: Command,
+    pub command: Option<Command>,
 }
 
 /// Available subcommands.
@@ -166,11 +170,6 @@ pub enum Command {
         /// Output format.
         #[arg(long, default_value = "text")]
         format: OutputFormat,
-    },
-    /// Generate shell completion scripts.
-    Completions {
-        /// Target shell.
-        shell: Shell,
     },
 }
 

--- a/crates/git-std/src/cli/completions.rs
+++ b/crates/git-std/src/cli/completions.rs
@@ -52,12 +52,11 @@ const GIT_SUBCMD_FISH: &str = r#"
 # Register "std" as a git subcommand for "git std <TAB>" completion.
 complete -f -c git -n __fish_git_needs_command -a std -d 'Conventional commit standards'
 complete -f -c git -n '__fish_git_using_command std' -a commit -d 'Interactive conventional commit builder'
-complete -f -c git -n '__fish_git_using_command std' -a check -d 'Validate commit messages'
+complete -f -c git -n '__fish_git_using_command std' -a lint -d 'Validate commit messages'
 complete -f -c git -n '__fish_git_using_command std' -a bump -d 'Version bump, changelog, commit, and tag'
 complete -f -c git -n '__fish_git_using_command std' -a changelog -d 'Generate a changelog'
 complete -f -c git -n '__fish_git_using_command std' -a bootstrap -d 'Post-clone environment setup'
-complete -f -c git -n '__fish_git_using_command std' -a hooks -d 'Git hooks management'
+complete -f -c git -n '__fish_git_using_command std' -a hook -d 'Git hooks management'
 complete -f -c git -n '__fish_git_using_command std' -a config -d 'Inspect git-std configuration'
 complete -f -c git -n '__fish_git_using_command std' -a doctor -d 'Run health checks'
-complete -f -c git -n '__fish_git_using_command std' -a completions -d 'Generate shell completions'
 "#;

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -25,7 +25,26 @@ fn main() {
         }
     }
 
-    match cli.command {
+    // Handle --completions before subcommand dispatch so it works without a subcommand.
+    if let Some(shell) = cli.completions {
+        let mut cmd = Cli::command();
+        clap_complete::generate(shell, &mut cmd, "git-std", &mut std::io::stdout());
+        print!("{}", cli::completions::git_subcommand_wrapper(shell));
+        return;
+    }
+
+    let command = match cli.command {
+        Some(cmd) => cmd,
+        None => {
+            // No subcommand and no --completions: print help.
+            let mut cmd = Cli::command();
+            cmd.print_help().ok();
+            println!();
+            std::process::exit(2);
+        }
+    };
+
+    match command {
         Command::Lint {
             message,
             file,
@@ -180,11 +199,6 @@ fn main() {
         Command::Doctor { format } => {
             let cwd = std::env::current_dir().unwrap_or_default();
             std::process::exit(cli::doctor::run(&cwd, format));
-        }
-        Command::Completions { shell } => {
-            let mut cmd = Cli::command();
-            clap_complete::generate(shell, &mut cmd, "git-std", &mut std::io::stdout());
-            print!("{}", cli::completions::git_subcommand_wrapper(shell));
         }
     }
 }

--- a/crates/git-std/tests/cli.rs
+++ b/crates/git-std/tests/cli.rs
@@ -19,20 +19,16 @@ fn help_lists_subcommands() {
         .success();
 
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
-    for sub in [
-        "commit",
-        "lint",
-        "bump",
-        "changelog",
-        "hook",
-        "config",
-        "completions",
-    ] {
+    for sub in ["commit", "lint", "bump", "changelog", "hook", "config"] {
         assert!(
             stdout.contains(sub),
             "help output should list '{sub}' subcommand"
         );
     }
+    assert!(
+        stdout.contains("--completions"),
+        "help output should list '--completions' global flag"
+    );
 }
 
 #[test]

--- a/crates/git-std/tests/completions.rs
+++ b/crates/git-std/tests/completions.rs
@@ -4,7 +4,7 @@ use assert_cmd::Command;
 fn completions_bash_outputs_script() {
     Command::cargo_bin("git-std")
         .unwrap()
-        .args(["completions", "bash"])
+        .args(["--completions", "bash"])
         .assert()
         .success()
         .stdout(predicates::str::contains("complete"));
@@ -14,7 +14,7 @@ fn completions_bash_outputs_script() {
 fn completions_bash_includes_git_subcommand_wrapper() {
     Command::cargo_bin("git-std")
         .unwrap()
-        .args(["completions", "bash"])
+        .args(["--completions", "bash"])
         .assert()
         .success()
         .stdout(predicates::str::contains("_git_std"));
@@ -24,7 +24,7 @@ fn completions_bash_includes_git_subcommand_wrapper() {
 fn completions_zsh_outputs_script() {
     Command::cargo_bin("git-std")
         .unwrap()
-        .args(["completions", "zsh"])
+        .args(["--completions", "zsh"])
         .assert()
         .success()
         .stdout(predicates::str::contains("_git-std"));
@@ -34,7 +34,7 @@ fn completions_zsh_outputs_script() {
 fn completions_zsh_includes_git_subcommand_wrapper() {
     Command::cargo_bin("git-std")
         .unwrap()
-        .args(["completions", "zsh"])
+        .args(["--completions", "zsh"])
         .assert()
         .success()
         .stdout(predicates::str::contains("user-commands std:"));
@@ -44,7 +44,7 @@ fn completions_zsh_includes_git_subcommand_wrapper() {
 fn completions_fish_outputs_script() {
     Command::cargo_bin("git-std")
         .unwrap()
-        .args(["completions", "fish"])
+        .args(["--completions", "fish"])
         .assert()
         .success()
         .stdout(predicates::str::contains("complete"));
@@ -54,7 +54,7 @@ fn completions_fish_outputs_script() {
 fn completions_fish_includes_git_subcommand_wrapper() {
     Command::cargo_bin("git-std")
         .unwrap()
-        .args(["completions", "fish"])
+        .args(["--completions", "fish"])
         .assert()
         .success()
         .stdout(predicates::str::contains("complete -f -c git"));

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -72,7 +72,7 @@ git-std covers six concerns:
 | Version bump + changelog     | `git std bump`, `git std changelog`                             |
 | Git hooks management         | `git std hook install`, `git std hook run`, `git std hook list` |
 | Post-clone bootstrap         | `git std bootstrap`, `git std bootstrap install`                |
-| Shell completions            | `git std completions`                                           |
+| Shell completions            | `git std --completions <shell>`                                 |
 
 **Out of scope:** repo scaffolding, directory structure
 compliance, formatting, linting, CI pipeline generation,
@@ -838,14 +838,24 @@ commit:
 All steps are idempotent — running twice produces the
 same result.
 
-### 2.8 `git std completions`
+### 2.8 Global Flags
 
-Generate shell completion scripts for bash, zsh, or fish.
+| Flag                    | Description                          |
+| ----------------------- | ------------------------------------ |
+| `--help` / `-h`         | Print help                           |
+| `--version` / `-V`      | Print git-std version                |
+| `--color <when>`        | `auto` (default), `always`, `never`  |
+| `--completions <shell>` | Generate shell completions to stdout |
+
+#### `--completions <shell>`
+
+Generate shell completion scripts for bash, zsh, or fish. Works
+without a subcommand — usable regardless of install method.
 
 ```bash
-git std completions bash   # Bash completions
-git std completions zsh    # Zsh completions
-git std completions fish   # Fish completions
+git std --completions bash   # Bash completions
+git std --completions zsh    # Zsh completions
+git std --completions fish   # Fish completions
 ```
 
 The generated scripts include wrappers that enable completion for
@@ -855,22 +865,14 @@ both `git-std` (standalone) and `git std` (git subcommand) invocations.
 
 ```bash
 # Bash (~/.bashrc)
-eval "$(git-std completions bash)"
+eval "$(git-std --completions bash)"
 
 # Zsh (~/.zshrc)
-eval "$(git-std completions zsh)"
+eval "$(git-std --completions zsh)"
 
 # Fish (~/.config/fish/config.fish)
-git-std completions fish | source
+git-std --completions fish | source
 ```
-
-### 2.9 Global Flags
-
-| Flag               | Description                         |
-| ------------------ | ----------------------------------- |
-| `--help` / `-h`    | Print help                          |
-| `--version` / `-V` | Print git-std version               |
-| `--color <when>`   | `auto` (default), `always`, `never` |
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -6,11 +6,12 @@ git std <command> [options]
 
 ## Global Flags
 
-| Flag               | Description                         |
-| ------------------ | ----------------------------------- |
-| `--help` / `-h`    | Print help                          |
-| `--version` / `-V` | Print version                       |
-| `--color <when>`   | `auto` (default), `always`, `never` |
+| Flag                    | Description                          |
+| ----------------------- | ------------------------------------ |
+| `--help` / `-h`         | Print help                           |
+| `--version` / `-V`      | Print version                        |
+| `--color <when>`        | `auto` (default), `always`, `never`  |
+| `--completions <shell>` | Generate shell completions to stdout |
 
 ## `git std lint`
 
@@ -226,28 +227,29 @@ git std doctor --format json  # machine-readable JSON on stdout
 **Exit codes:** `0` = all checks pass, `1` = one or more checks failed,
 `2` = not a git repository.
 
-## `git std completions`
+## `--completions <shell>`
 
-Generate shell completion scripts. The output includes wrappers that
-enable completion for both `git-std` and `git std` invocations.
+Generate shell completion scripts to stdout. The output includes wrappers
+that enable completion for both `git-std` and `git std` invocations.
+Works without a subcommand — usable regardless of install method.
 
 ```bash
-git std completions bash   # Bash
-git std completions zsh    # Zsh
-git std completions fish   # Fish
+git std --completions bash   # Bash
+git std --completions zsh    # Zsh
+git std --completions fish   # Fish
 ```
 
 Add to your shell profile:
 
 ```bash
 # Bash (~/.bashrc)
-eval "$(git-std completions bash)"
+eval "$(git-std --completions bash)"
 
 # Zsh (~/.zshrc)
-eval "$(git-std completions zsh)"
+eval "$(git-std --completions zsh)"
 
 # Fish (~/.config/fish/config.fish)
-git-std completions fish | source
+git-std --completions fish | source
 ```
 
 ## `git std config`

--- a/spec/tests/cmd/general/completions_help.toml
+++ b/spec/tests/cmd/general/completions_help.toml
@@ -1,3 +1,3 @@
 bin.name = "git-std"
-args = ["completions", "--help"]
+args = ["--completions", "bash"]
 status = "success"

--- a/spec/tests/cmd/general/help.stdout
+++ b/spec/tests/cmd/general/help.stdout
@@ -1,16 +1,15 @@
 Standard git workflow — commits, versioning, hooks
 
-Usage: git-std [OPTIONS] <COMMAND>
+Usage: git-std [OPTIONS] [COMMAND]
 
 Commands:
-  commit       Interactive conventional commit builder
-  lint         Validate commit messages
-  bump         Version bump, changelog, commit, and tag
-  changelog    Generate a changelog (incremental by default, --full to regenerate)
-  bootstrap    Post-clone environment setup
-  hook         Git hooks management
-  config       Inspect effective git-std configuration
-  doctor       Run health checks on the local git-std setup
-  completions  Generate shell completion scripts
-  help         Print this message or the help of the given subcommand(s)
+  commit     Interactive conventional commit builder
+  lint       Validate commit messages
+  bump       Version bump, changelog, commit, and tag
+  changelog  Generate a changelog (incremental by default, --full to regenerate)
+  bootstrap  Post-clone environment setup
+  hook       Git hooks management
+  config     Inspect effective git-std configuration
+  doctor     Run health checks on the local git-std setup
+  help       Print this message or the help of the given subcommand(s)
 ...


### PR DESCRIPTION
## Summary

- Removes `completions` as a top-level subcommand
- Adds `--completions <shell>` as a global flag on the root `Cli` struct, handled before subcommand dispatch so it works without a subcommand
- Updates the fish wrapper to use current command names (`lint`, `hook`; removes stale `check`, `hooks`, `completions`)
- Updates all tests, spec snapshots, and docs (SPEC.md, USAGE.md, AGENTS.md)

## Test plan

- [x] `git std --completions bash` generates completions to stdout
- [x] `git std --completions zsh` generates completions to stdout
- [x] `git std --completions fish` generates completions to stdout
- [x] `completions` no longer appears as a subcommand in `--help`
- [x] `--completions` appears in global flags in `--help`
- [x] All existing tests pass (`just build` exits 0)
- [x] Zero clippy warnings, dprint and markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)