### PR TITLE
feat(git-std): add git std version command (#402)

### DIFF
--- a/crates/git-std/src/app.rs
+++ b/crates/git-std/src/app.rs
@@ -175,6 +175,24 @@ pub enum Command {
         #[arg(long, default_value = "text")]
         format: OutputFormat,
     },
+    /// Query the current project version.
+    Version {
+        /// Print cargo-style describe: version with distance + hash + dirty flag.
+        #[arg(long)]
+        describe: bool,
+        /// Compute and print the next version from conventional commits.
+        #[arg(long)]
+        next: bool,
+        /// Print the bump label (major/minor/patch).
+        #[arg(long)]
+        label: bool,
+        /// Print the version code integer.
+        #[arg(long)]
+        code: bool,
+        /// Output format.
+        #[arg(long, default_value = "text")]
+        format: OutputFormat,
+    },
 }
 
 /// Config subcommands.

--- a/crates/git-std/src/cli/mod.rs
+++ b/crates/git-std/src/cli/mod.rs
@@ -8,3 +8,4 @@ pub mod doctor;
 pub mod hook;
 pub mod init;
 pub mod lint;
+pub mod version;

--- a/crates/git-std/src/cli/version.rs
+++ b/crates/git-std/src/cli/version.rs
@@ -1,0 +1,696 @@
+//! `git std version` — lightweight, scriptable version queries.
+//!
+//! Queries the current version from the latest git tag, and optionally
+//! computes derived information such as the next version, bump label,
+//! version code, or a cargo-style describe string.
+
+use std::path::Path;
+
+use crate::app::OutputFormat;
+use crate::config::{ProjectConfig, Scheme};
+use crate::git;
+use crate::ui;
+
+/// Options for the version subcommand.
+pub struct VersionOptions {
+    /// Print cargo-style describe string (distance + hash + dirty flag).
+    pub describe: bool,
+    /// Compute and print the next version from conventional commits.
+    pub next: bool,
+    /// Print the bump label (major/minor/patch).
+    pub label: bool,
+    /// Print the version code integer.
+    pub code: bool,
+    /// Output format.
+    pub format: OutputFormat,
+}
+
+/// Run the version subcommand. Returns the process exit code.
+pub fn run(config: &ProjectConfig, opts: &VersionOptions) -> i32 {
+    let dir = Path::new(".");
+
+    match config.scheme {
+        Scheme::Calver => run_calver(config, opts, dir),
+        _ => run_semver(config, opts, dir),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Semver path
+// ---------------------------------------------------------------------------
+
+fn run_semver(config: &ProjectConfig, opts: &VersionOptions, dir: &Path) -> i32 {
+    let tag_prefix = &config.versioning.tag_prefix;
+
+    let current = match git::find_latest_version_tag(dir, tag_prefix) {
+        Ok(Some((oid, ver))) => (oid, ver),
+        Ok(None) => {
+            ui::error("no version tag found");
+            return 1;
+        }
+        Err(e) => {
+            ui::error(&e.to_string());
+            return 1;
+        }
+    };
+
+    let (tag_oid, cur_ver) = &current;
+
+    let version_str = cur_ver.to_string();
+    let describe_str = if opts.describe {
+        match build_describe(dir, tag_oid, &version_str) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                ui::error(&e);
+                return 1;
+            }
+        }
+    } else {
+        None
+    };
+
+    let (next_str, bump_label) = if opts.next || opts.label || opts.format == OutputFormat::Json {
+        match compute_next_semver(dir, cur_ver, tag_oid) {
+            Ok((n, l)) => (Some(n), Some(l)),
+            Err(e) => {
+                ui::error(&e);
+                return 1;
+            }
+        }
+    } else {
+        (None, None)
+    };
+
+    let code_val = if opts.code || opts.format == OutputFormat::Json {
+        Some(semver_code(cur_ver))
+    } else {
+        None
+    };
+
+    match opts.format {
+        OutputFormat::Json => {
+            print_json(
+                &version_str,
+                describe_str.as_deref(),
+                next_str.as_deref(),
+                bump_label.as_deref(),
+                code_val,
+            );
+            0
+        }
+        OutputFormat::Text => print_text(
+            opts,
+            &version_str,
+            describe_str.as_deref(),
+            next_str.as_deref(),
+            bump_label.as_deref(),
+            code_val,
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Calver path
+// ---------------------------------------------------------------------------
+
+fn run_calver(config: &ProjectConfig, opts: &VersionOptions, dir: &Path) -> i32 {
+    let tag_prefix = &config.versioning.tag_prefix;
+
+    let current = match git::find_latest_calver_tag(dir, tag_prefix) {
+        Ok(Some((oid, ver))) => (oid, ver),
+        Ok(None) => {
+            ui::error("no version tag found");
+            return 1;
+        }
+        Err(e) => {
+            ui::error(&e.to_string());
+            return 1;
+        }
+    };
+
+    let (tag_oid, cur_ver) = &current;
+
+    let describe_str = if opts.describe {
+        match build_describe(dir, tag_oid, cur_ver) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                ui::error(&e);
+                return 1;
+            }
+        }
+    } else {
+        None
+    };
+
+    let next_str = if opts.next || opts.format == OutputFormat::Json {
+        match compute_next_calver(config, cur_ver) {
+            Ok(n) => Some(n),
+            Err(e) => {
+                ui::error(&e);
+                return 1;
+            }
+        }
+    } else {
+        None
+    };
+
+    let code_val = if opts.code || opts.format == OutputFormat::Json {
+        match calver_code(cur_ver) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                ui::error(&e);
+                return 1;
+            }
+        }
+    } else {
+        None
+    };
+
+    // For calver, --label is not meaningful (no bump level concept).
+    let bump_label: Option<String> = if opts.label || opts.format == OutputFormat::Json {
+        Some("calver".to_string())
+    } else {
+        None
+    };
+
+    match opts.format {
+        OutputFormat::Json => {
+            print_json(
+                cur_ver,
+                describe_str.as_deref(),
+                next_str.as_deref(),
+                bump_label.as_deref(),
+                code_val,
+            );
+            0
+        }
+        OutputFormat::Text => print_text(
+            opts,
+            cur_ver,
+            describe_str.as_deref(),
+            next_str.as_deref(),
+            bump_label.as_deref(),
+            code_val,
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — describe
+// ---------------------------------------------------------------------------
+
+/// Build a cargo-style describe string: `<version>[-dev.<N>][+<hash>[.dirty]]`.
+///
+/// - `-dev.N` is appended when HEAD is N commits ahead of the tag.
+/// - `+<hash>` is appended when HEAD is ahead of the tag.
+/// - `.dirty` is appended when the working tree has uncommitted changes.
+fn build_describe(dir: &Path, tag_oid: &str, version: &str) -> Result<String, String> {
+    let head_oid = git::head_oid(dir).map_err(|e| e.to_string())?;
+
+    // Count commits between tag and HEAD.
+    let commits = git::walk_commits(dir, &head_oid, Some(tag_oid)).map_err(|e| e.to_string())?;
+    let distance = commits.len();
+
+    let is_dirty = git::is_working_tree_dirty(dir).map_err(|e| e.to_string())?;
+
+    // Short hash — use first 7 hex digits of HEAD.
+    let short_hash = if head_oid.len() >= 7 {
+        &head_oid[..7]
+    } else {
+        &head_oid
+    };
+
+    let mut result = version.to_string();
+
+    if distance > 0 {
+        result.push_str(&format!("-dev.{distance}"));
+    }
+
+    if distance > 0 || is_dirty {
+        result.push('+');
+        result.push_str(&format!("g{short_hash}"));
+        if is_dirty {
+            result.push_str(".dirty");
+        }
+    }
+
+    Ok(result)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — next version / label
+// ---------------------------------------------------------------------------
+
+fn compute_next_semver(
+    dir: &Path,
+    cur_ver: &semver::Version,
+    tag_oid: &str,
+) -> Result<(String, String), String> {
+    let head_oid = git::head_oid(dir).map_err(|e| e.to_string())?;
+    let raw_commits =
+        git::walk_commits(dir, &head_oid, Some(tag_oid)).map_err(|e| e.to_string())?;
+
+    let parsed: Vec<standard_commit::ConventionalCommit> = raw_commits
+        .iter()
+        .filter_map(|(_, msg)| standard_commit::parse(msg).ok())
+        .collect();
+
+    let bump_level = standard_version::determine_bump(&parsed);
+
+    let (next_ver, label) = match bump_level {
+        None => (cur_ver.clone(), "none".to_string()),
+        Some(level) => {
+            let next = standard_version::apply_bump(cur_ver, level);
+            let is_pre1 = cur_ver.major == 0;
+            let label_str = match (level, is_pre1) {
+                (standard_version::BumpLevel::Major, true) => "minor",
+                (standard_version::BumpLevel::Minor, true) => "patch",
+                (standard_version::BumpLevel::Patch, _) => "patch",
+                (standard_version::BumpLevel::Major, false) => "major",
+                (standard_version::BumpLevel::Minor, false) => "minor",
+            };
+            (next, label_str.to_string())
+        }
+    };
+
+    Ok((next_ver.to_string(), label))
+}
+
+fn compute_next_calver(config: &ProjectConfig, cur_ver: &str) -> Result<String, String> {
+    let date = today_calver_date();
+    standard_version::calver::next_version(&config.versioning.calver_format, date, Some(cur_ver))
+        .map_err(|e| e.to_string())
+}
+
+/// Compute today's calver date from the system clock.
+fn today_calver_date() -> standard_version::calver::CalverDate {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    calver_date_from_epoch_days(secs.div_euclid(86400) as i32)
+}
+
+/// Convert days since Unix epoch to a calver date using the Howard Hinnant algorithm.
+fn calver_date_from_epoch_days(days: i32) -> standard_version::calver::CalverDate {
+    let z = days + 719468;
+    let era = z.div_euclid(146097);
+    let doe = z.rem_euclid(146097) as u32;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i32 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+
+    let dow = ((days + 3).rem_euclid(7) + 1) as u32;
+    let jan1_days = {
+        let ys = y - 1;
+        let eras = ys.div_euclid(400);
+        let yoes = ys.rem_euclid(400) as u32;
+        let ms: u32 = 10;
+        let ds: u32 = 1;
+        let doys = (153 * ms + 2) / 5 + ds - 1;
+        let does = yoes * 365 + yoes / 4 - yoes / 100 + doys;
+        eras * 146097 + does as i32 - 719468
+    };
+    let ordinal = days - jan1_days + 1;
+    let jan1_dow = (jan1_days + 3).rem_euclid(7) + 1;
+
+    let iso_week = {
+        let w = (ordinal - dow as i32 + 10) / 7;
+        if w < 1 {
+            let prev_jan1_dow = (jan1_days - 1 + 3).rem_euclid(7) + 1;
+            if prev_jan1_dow == 4
+                || (prev_jan1_dow == 3 && {
+                    let py = y - 1;
+                    py % 4 == 0 && (py % 100 != 0 || py % 400 == 0)
+                })
+            {
+                53
+            } else {
+                52
+            }
+        } else if w > 52 {
+            let is_leap = y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
+            let days_in_year = if is_leap { 366 } else { 365 };
+            if ordinal > days_in_year - 3 && jan1_dow != 4 {
+                1
+            } else {
+                w
+            }
+        } else {
+            w
+        }
+    };
+
+    standard_version::calver::CalverDate {
+        year: y as u32,
+        month: m,
+        day: d,
+        iso_week: iso_week as u32,
+        day_of_week: dow,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — version code
+// ---------------------------------------------------------------------------
+
+/// Compute version code for semver: `((MAJOR * 1_000 + MINOR) * 100 + PATCH) * 100 + stage`.
+pub fn semver_code(ver: &semver::Version) -> u64 {
+    let base = ((ver.major * 1_000 + ver.minor) * 100 + ver.patch) * 100;
+    let stage = prerelease_stage(ver.pre.as_str());
+    base + stage
+}
+
+/// Compute version code for calver: `days_since_epoch * 10_000 + MICRO * 100 + stage`.
+///
+/// Parses `YYYY.MM.PATCH` (and variants) — extracts the last numeric segment as MICRO.
+pub fn calver_code(ver: &str) -> Result<u64, String> {
+    // Split on common separators.
+    let parts: Vec<&str> = ver.split(['.', '-', '_']).collect();
+    if parts.len() < 3 {
+        return Err(format!("cannot parse calver version: '{ver}'"));
+    }
+
+    // Parse the date segments (first one or two segments) as year and month.
+    // The last segment is MICRO (PATCH in calver terms).
+    let micro: u64 = parts[parts.len() - 1]
+        .parse()
+        .map_err(|_| format!("cannot parse MICRO in calver version: '{ver}'"))?;
+
+    // Parse year and month to compute days since epoch.
+    let year: i32 = parts[0]
+        .parse()
+        .map_err(|_| format!("cannot parse year in calver version: '{ver}'"))?;
+
+    // If the year is 2-digit, adjust.
+    let full_year = if year < 100 { year + 2000 } else { year };
+
+    let month: u32 = parts[1]
+        .parse()
+        .map_err(|_| format!("cannot parse month in calver version: '{ver}'"))?;
+
+    // Compute days since Unix epoch for the first day of the given month/year.
+    let days = days_since_epoch(full_year, month, 1) as u64;
+
+    Ok(days * 10_000 + micro * 100 + 99) // stable calver releases use stage 99
+}
+
+/// Compute days since Unix epoch (1970-01-01) for a given date.
+///
+/// Uses the Howard Hinnant civil_to_days algorithm (inverse of civil_from_days).
+fn days_since_epoch(year: i32, month: u32, day: u32) -> i32 {
+    // Shift year to March-based for easier leap-year math.
+    let (y, m) = if month <= 2 {
+        (year - 1, month + 9)
+    } else {
+        (year, month - 3)
+    };
+
+    let era = y.div_euclid(400);
+    let yoe = y.rem_euclid(400) as u32;
+    let doy = (153 * m + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe as i32 - 719468
+}
+
+/// Map a pre-release string to a stage integer.
+///
+/// | Pre-release     | Stage |
+/// |-----------------|-------|
+/// | (unknown)       | 1     |
+/// | dev             | 9     |
+/// | dev.0 – dev.28  | 10–38 |
+/// | alpha           | 39    |
+/// | alpha.0–alpha.18| 40–58 |
+/// | beta            | 59    |
+/// | beta.0–beta.18  | 60–78 |
+/// | rc              | 79    |
+/// | rc.0–rc.18      | 80–98 |
+/// | (stable)        | 99    |
+pub fn prerelease_stage(pre: &str) -> u64 {
+    if pre.is_empty() {
+        return 99; // stable
+    }
+
+    // Try "tag.N" pattern.
+    let (tag, number) = if let Some(dot) = pre.rfind('.') {
+        let tag_part = &pre[..dot];
+        let num_part = &pre[dot + 1..];
+        if let Ok(n) = num_part.parse::<u64>() {
+            (tag_part, Some(n))
+        } else {
+            (pre, None)
+        }
+    } else {
+        (pre, None)
+    };
+
+    match (tag, number) {
+        ("dev", None) => 9,
+        ("dev", Some(n)) if n <= 28 => 10 + n,
+        ("alpha", None) => 39,
+        ("alpha", Some(n)) if n <= 18 => 40 + n,
+        ("beta", None) => 59,
+        ("beta", Some(n)) if n <= 18 => 60 + n,
+        ("rc", None) => 79,
+        ("rc", Some(n)) if n <= 18 => 80 + n,
+        _ => 1, // unknown
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Output rendering
+// ---------------------------------------------------------------------------
+
+fn print_text(
+    opts: &VersionOptions,
+    version: &str,
+    describe: Option<&str>,
+    next: Option<&str>,
+    label: Option<&str>,
+    code: Option<u64>,
+) -> i32 {
+    // When multiple flags are set, print all requested fields.
+    // When no flag is set (bare call), print just the version.
+    let any_flag = opts.describe || opts.next || opts.label || opts.code;
+
+    if !any_flag {
+        println!("{version}");
+        return 0;
+    }
+
+    if opts.describe
+        && let Some(d) = describe
+    {
+        println!("{d}");
+    }
+    if opts.next
+        && let Some(n) = next
+    {
+        println!("{n}");
+    }
+    if opts.label
+        && let Some(l) = label
+    {
+        println!("{l}");
+    }
+    if opts.code
+        && let Some(c) = code
+    {
+        println!("{c}");
+    }
+
+    0
+}
+
+fn print_json(
+    version: &str,
+    describe: Option<&str>,
+    next: Option<&str>,
+    label: Option<&str>,
+    code: Option<u64>,
+) {
+    let obj = serde_json::json!({
+        "version": version,
+        "describe": describe,
+        "next": next,
+        "label": label,
+        "code": code,
+    });
+    println!("{obj}");
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Stage table ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn stage_stable() {
+        assert_eq!(prerelease_stage(""), 99);
+    }
+
+    #[test]
+    fn stage_dev() {
+        assert_eq!(prerelease_stage("dev"), 9);
+    }
+
+    #[test]
+    fn stage_dev_n() {
+        assert_eq!(prerelease_stage("dev.0"), 10);
+        assert_eq!(prerelease_stage("dev.28"), 38);
+    }
+
+    #[test]
+    fn stage_alpha() {
+        assert_eq!(prerelease_stage("alpha"), 39);
+    }
+
+    #[test]
+    fn stage_alpha_n() {
+        assert_eq!(prerelease_stage("alpha.0"), 40);
+        assert_eq!(prerelease_stage("alpha.18"), 58);
+    }
+
+    #[test]
+    fn stage_beta() {
+        assert_eq!(prerelease_stage("beta"), 59);
+    }
+
+    #[test]
+    fn stage_beta_n() {
+        assert_eq!(prerelease_stage("beta.0"), 60);
+        assert_eq!(prerelease_stage("beta.18"), 78);
+    }
+
+    #[test]
+    fn stage_rc() {
+        assert_eq!(prerelease_stage("rc"), 79);
+    }
+
+    #[test]
+    fn stage_rc_n() {
+        assert_eq!(prerelease_stage("rc.0"), 80);
+        assert_eq!(prerelease_stage("rc.18"), 98);
+    }
+
+    #[test]
+    fn stage_unknown() {
+        assert_eq!(prerelease_stage("nightly"), 1);
+    }
+
+    // ── Semver code ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn semver_code_stable() {
+        // 1.2.3 stable: ((1*1000+2)*100+3)*100+99
+        // = (1002*100+3)*100+99
+        // = 100203*100+99
+        // = 10020300+99
+        // = 10020399
+        let ver = semver::Version::new(1, 2, 3);
+        assert_eq!(semver_code(&ver), 10_020_399);
+    }
+
+    #[test]
+    fn semver_code_pre_rc() {
+        // 1.0.0-rc.1: ((1*1000+0)*100+0)*100+81
+        // = (1000*100+0)*100+81
+        // = 100000*100+81
+        // = 10000081
+        let ver = semver::Version::parse("1.0.0-rc.1").unwrap();
+        assert_eq!(semver_code(&ver), 10_000_081);
+    }
+
+    #[test]
+    fn semver_code_zero_zero_zero_stable() {
+        // 0.0.0 stable: ((0*1000+0)*100+0)*100+99 = 99
+        let ver = semver::Version::new(0, 0, 0);
+        assert_eq!(semver_code(&ver), 99);
+    }
+
+    #[test]
+    fn semver_code_pre1_current() {
+        // 0.10.2 stable: ((0*1000+10)*100+2)*100+99
+        // = (10*100+2)*100+99
+        // = 1002*100+99
+        // = 100200+99
+        // = 100299
+        let ver = semver::Version::new(0, 10, 2);
+        assert_eq!(semver_code(&ver), 100_299);
+    }
+
+    // ── Round-trip ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn semver_code_ordering() {
+        let v100 = semver::Version::new(1, 0, 0);
+        let v101 = semver::Version::new(1, 0, 1);
+        let v110 = semver::Version::new(1, 1, 0);
+        let v200 = semver::Version::new(2, 0, 0);
+        assert!(semver_code(&v100) < semver_code(&v101));
+        assert!(semver_code(&v101) < semver_code(&v110));
+        assert!(semver_code(&v110) < semver_code(&v200));
+    }
+
+    #[test]
+    fn semver_code_prerelease_less_than_stable() {
+        let pre = semver::Version::parse("1.0.0-rc.18").unwrap();
+        let stable = semver::Version::new(1, 0, 0);
+        assert!(semver_code(&pre) < semver_code(&stable));
+    }
+
+    // ── Days since epoch ────────────────────────────────────────────────────
+
+    #[test]
+    fn days_since_epoch_unix_epoch() {
+        assert_eq!(days_since_epoch(1970, 1, 1), 0);
+    }
+
+    #[test]
+    fn days_since_epoch_known_date() {
+        // 2026-03-16 = day 20528 (from calver detect tests).
+        assert_eq!(days_since_epoch(2026, 3, 16), 20_528);
+    }
+
+    // ── Calver code ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn calver_code_basic() {
+        // "2026.3.0" — March 1 2026: days * 10000 + 99 (stable, MICRO=0)
+        let days = days_since_epoch(2026, 3, 1);
+        let expected = days as u64 * 10_000 + 99;
+        let code = calver_code("2026.3.0").unwrap();
+        assert_eq!(code, expected);
+    }
+
+    #[test]
+    fn calver_code_patch_1() {
+        let days = days_since_epoch(2026, 3, 1);
+        let expected = days as u64 * 10_000 + 100 + 99;
+        let code = calver_code("2026.3.1").unwrap();
+        assert_eq!(code, expected);
+    }
+
+    #[test]
+    fn calver_code_ordering() {
+        // Later months have higher codes.
+        let code_march = calver_code("2026.3.0").unwrap();
+        let code_april = calver_code("2026.4.0").unwrap();
+        assert!(code_march < code_april);
+    }
+
+    #[test]
+    fn calver_code_invalid() {
+        assert!(calver_code("notaversion").is_err());
+    }
+}

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -196,5 +196,22 @@ fn main() {
             let cwd = std::env::current_dir().unwrap_or_default();
             std::process::exit(cli::doctor::run(&cwd, format));
         }
+        Command::Version {
+            describe,
+            next,
+            label,
+            code,
+            format,
+        } => {
+            let project_config = config::load(&std::env::current_dir().unwrap_or_default());
+            let opts = cli::version::VersionOptions {
+                describe,
+                next,
+                label,
+                code,
+                format,
+            };
+            std::process::exit(cli::version::run(&project_config, &opts));
+        }
     }
 }

--- a/crates/git-std/tests/version.rs
+++ b/crates/git-std/tests/version.rs
@@ -1,0 +1,381 @@
+use std::path::Path;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let output = std::process::Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn init_repo(dir: &Path) {
+    git(dir, &["init"]);
+    git(dir, &["config", "user.name", "Test"]);
+    git(dir, &["config", "user.email", "test@test.com"]);
+    // Write a minimal Cargo.toml so the repo looks like a Rust project.
+    std::fs::write(
+        dir.join("Cargo.toml"),
+        "[package]\nname = \"test-pkg\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    git(dir, &["add", "Cargo.toml"]);
+    git(dir, &["commit", "-m", "chore: init"]);
+}
+
+fn add_commit(dir: &Path, filename: &str, message: &str) {
+    std::fs::write(dir.join(filename), message).unwrap();
+    git(dir, &["add", filename]);
+    git(dir, &["commit", "-m", message]);
+}
+
+fn create_tag(dir: &Path, name: &str) {
+    git(dir, &["tag", "-a", name, "-m", name]);
+}
+
+fn git_std(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("git-std").unwrap();
+    cmd.current_dir(dir);
+    cmd
+}
+
+// ---------------------------------------------------------------------------
+// Help / usage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_help_shows_flags() {
+    let assert = Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["version", "--help"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    for flag in ["--describe", "--next", "--label", "--code", "--format"] {
+        assert!(
+            stdout.contains(flag),
+            "version help should list '{flag}' flag"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bare version — semver
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_bare_prints_current_semver() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v1.2.3");
+
+    git_std(dir.path())
+        .arg("version")
+        .assert()
+        .success()
+        .stdout("1.2.3\n");
+}
+
+#[test]
+fn version_bare_no_v_prefix() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v0.10.2");
+
+    let output = git_std(dir.path())
+        .arg("version")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8_lossy(&output);
+    assert!(
+        !text.trim().starts_with('v'),
+        "output must not have v prefix"
+    );
+    assert_eq!(text.trim(), "0.10.2");
+}
+
+#[test]
+fn version_no_tag_exits_with_error() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    git_std(dir.path())
+        .arg("version")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no version tag found"));
+}
+
+// ---------------------------------------------------------------------------
+// --describe
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_describe_at_tag_is_clean() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+
+    git_std(dir.path())
+        .args(["version", "--describe"])
+        .assert()
+        .success()
+        .stdout("1.0.0\n");
+}
+
+#[test]
+fn version_describe_ahead_includes_distance_and_hash() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "feat: something");
+    add_commit(dir.path(), "b.txt", "fix: another");
+
+    let output = git_std(dir.path())
+        .args(["version", "--describe"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8_lossy(&output).trim().to_string();
+
+    assert!(
+        text.starts_with("1.0.0-dev.2+g"),
+        "describe should have -dev.2+g prefix, got: {text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// --next
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_next_feat_gives_minor_bump() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "feat: add something");
+
+    git_std(dir.path())
+        .args(["version", "--next"])
+        .assert()
+        .success()
+        .stdout("1.1.0\n");
+}
+
+#[test]
+fn version_next_fix_gives_patch_bump() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: something");
+
+    git_std(dir.path())
+        .args(["version", "--next"])
+        .assert()
+        .success()
+        .stdout("1.0.1\n");
+}
+
+#[test]
+fn version_next_no_bump_worthy_commits_prints_current() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "chore: cleanup");
+
+    git_std(dir.path())
+        .args(["version", "--next"])
+        .assert()
+        .success()
+        .stdout("1.0.0\n");
+}
+
+#[test]
+fn version_next_pre1_breaking_gives_minor() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v0.10.2");
+    add_commit(dir.path(), "a.txt", "feat!: breaking change");
+
+    git_std(dir.path())
+        .args(["version", "--next"])
+        .assert()
+        .success()
+        .stdout("0.11.0\n");
+}
+
+// ---------------------------------------------------------------------------
+// --label
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_label_feat_gives_minor() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "feat: add feature");
+
+    git_std(dir.path())
+        .args(["version", "--label"])
+        .assert()
+        .success()
+        .stdout("minor\n");
+}
+
+#[test]
+fn version_label_breaking_pre1_gives_minor() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v0.5.0");
+    add_commit(dir.path(), "a.txt", "feat!: breaking");
+
+    git_std(dir.path())
+        .args(["version", "--label"])
+        .assert()
+        .success()
+        .stdout("minor\n");
+}
+
+#[test]
+fn version_label_no_commits_gives_none() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "chore: nothing");
+
+    git_std(dir.path())
+        .args(["version", "--label"])
+        .assert()
+        .success()
+        .stdout("none\n");
+}
+
+// ---------------------------------------------------------------------------
+// --code
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_code_stable_semver() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v0.10.2");
+
+    // 0.10.2 stable: ((0*1000+10)*100+2)*100+99 = 1002*100+99 = 100299
+    git_std(dir.path())
+        .args(["version", "--code"])
+        .assert()
+        .success()
+        .stdout("100299\n");
+}
+
+#[test]
+fn version_code_outputs_integer() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+
+    let output = git_std(dir.path())
+        .args(["version", "--code"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8_lossy(&output).trim().to_string();
+    assert!(
+        text.parse::<u64>().is_ok(),
+        "--code output should be an integer, got: {text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// --format json
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_format_json_has_all_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "feat: add feature");
+
+    let output = git_std(dir.path())
+        .args(["version", "--format", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let text = String::from_utf8_lossy(&output);
+    let val: serde_json::Value = serde_json::from_str(text.trim()).expect("valid JSON");
+
+    assert_eq!(val["version"], "1.0.0");
+    assert!(val["next"].is_string(), "next should be a string");
+    assert!(val["label"].is_string(), "label should be a string");
+    assert!(val["code"].is_number(), "code should be a number");
+}
+
+#[test]
+fn version_format_json_version_no_v_prefix() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v2.0.0");
+
+    let output = git_std(dir.path())
+        .args(["version", "--format", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let val: serde_json::Value =
+        serde_json::from_str(String::from_utf8_lossy(&output).trim()).unwrap();
+    assert_eq!(val["version"], "2.0.0");
+}
+
+// ---------------------------------------------------------------------------
+// Multiple flags
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_multiple_flags_each_printed() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "feat: feature");
+
+    // Both --next and --label should produce two output lines.
+    let output = git_std(dir.path())
+        .args(["version", "--next", "--label"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8_lossy(&output);
+    let lines: Vec<&str> = text.lines().collect();
+    assert_eq!(lines.len(), 2, "expected two output lines, got: {text}");
+    assert_eq!(lines[0], "1.1.0");
+    assert_eq!(lines[1], "minor");
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -825,7 +825,114 @@ command that project maintainers run once and commit.
 All steps are idempotent — running twice produces the
 same result.
 
-### 2.8 Global Flags
+### 2.8 `git std version`
+
+Lightweight, scriptable version queries without the overhead of `bump --dry-run`.
+
+```bash
+git std version                  # 0.10.2
+git std version --describe       # 0.10.2-dev.7+g3a2b1c.dirty
+git std version --next           # 0.11.0
+git std version --label          # minor
+git std version --code           # 10299
+git std version --format json    # all fields as JSON
+```
+
+Output is always to stdout. No `v` prefix — the command outputs a version
+**value**, not a git tag name.
+
+#### Flags
+
+| Flag             | Description                                                           |
+| ---------------- | --------------------------------------------------------------------- |
+| `--describe`     | Cargo-style describe: `-dev.N` pre-release + `+hash[.dirty]` metadata |
+| `--next`         | Next version computed from conventional commits since the last tag    |
+| `--label`        | Bump label (`major`/`minor`/`patch`/`none`) accounting for pre-1.0    |
+| `--code`         | Integer version code (see §2.8.1)                                     |
+| `--format <fmt>` | `text` (default) or `json`                                            |
+
+Multiple flags may be combined. With `--format json` all fields are always
+included regardless of which other flags are set.
+
+#### `--describe` format
+
+`<version>[-dev.<N>][+g<hash>[.dirty]]`
+
+- `-dev.N` — appended when HEAD is `N` commits ahead of the version tag.
+- `+g<hash>` — the first 7 characters of the HEAD SHA, prefixed with `g`.
+  Present when HEAD is ahead of the tag.
+- `.dirty` — appended when the working tree has uncommitted changes.
+
+Example: `0.10.2-dev.7+g3a2b1c.dirty`
+
+#### `--label` and pre-1.0 rule
+
+For versions `< 1.0.0`, bump levels are downshifted following the Cargo pre-1.0
+convention (same as `git std bump`):
+
+- Breaking change → `minor`
+- New feature → `patch`
+- Bug fix → `patch`
+
+When no bump-worthy commits exist, the label is `none`.
+
+#### `--format json` schema
+
+```json
+{
+  "version": "0.10.2",
+  "describe": "0.10.2-dev.3+g1a2b3c4",
+  "next": "0.11.0",
+  "label": "minor",
+  "code": 100299
+}
+```
+
+Fields `describe`, `next`, `label`, and `code` are always present in JSON
+output (computed unconditionally). Fields may be `null` only if computation
+fails (e.g., no tags).
+
+#### §2.8.1 Version code (`--code`)
+
+A monotonically increasing integer encoding of the version, suitable for
+Android `versionCode`, iOS `CFBundleVersion`, or any platform that requires an
+integer build number.
+
+**Semver formula:**
+
+```text
+code = ((MAJOR × 1 000 + MINOR) × 100 + PATCH) × 100 + stage
+```
+
+**Calver formula:**
+
+```text
+code = days_since_epoch × 10 000 + MICRO × 100 + stage
+```
+
+Where `days_since_epoch` is the number of days since 1970-01-01 for the
+first day of the calver period, and `MICRO` is the PATCH component.
+
+**Stage table (shared):**
+
+| Pre-release          | Stage |
+| -------------------- | ----- |
+| (unknown)            | 1     |
+| `dev`                | 9     |
+| `dev.0`–`dev.28`     | 10–38 |
+| `alpha`              | 39    |
+| `alpha.0`–`alpha.18` | 40–58 |
+| `beta`               | 59    |
+| `beta.0`–`beta.18`   | 60–78 |
+| `rc`                 | 79    |
+| `rc.0`–`rc.18`       | 80–98 |
+| (stable)             | 99    |
+
+The stage range ensures every pre-release build is numerically less than the
+final stable release while remaining monotonically increasing within each
+pre-release track.
+
+### 2.9 Global Flags
 
 | Flag                    | Description                          |
 | ----------------------- | ------------------------------------ |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -256,6 +256,33 @@ git std doctor --format json  # machine-readable JSON on stdout
 **Exit codes:** `0` = all checks pass, `1` = one or more checks failed,
 `2` = not a git repository.
 
+## `git std version`
+
+Lightweight, scriptable version queries.
+
+```bash
+git std version                  # 0.10.2
+git std version --describe       # 0.10.2-dev.7+g3a2b1c.dirty
+git std version --next           # 0.11.0
+git std version --label          # minor
+git std version --code           # 10299
+git std version --format json    # all fields as JSON
+```
+
+Output goes to stdout. No `v` prefix.
+
+**Flags:**
+
+| Flag             | Description                                                           |
+| ---------------- | --------------------------------------------------------------------- |
+| `--describe`     | Cargo-style describe: `-dev.N` pre-release + `+hash[.dirty]` metadata |
+| `--next`         | Next version from conventional commits since the last tag             |
+| `--label`        | Bump label (`major`/`minor`/`patch`/`none`), accounting for pre-1.0   |
+| `--code`         | Integer version code                                                  |
+| `--format <fmt>` | Output format: `text` (default), `json`                               |
+
+**Exit codes:** `0` = success, `1` = error.
+
 ## `--completions <shell>`
 
 Generate shell completion scripts to stdout. The output includes wrappers

--- a/spec/tests/cmd/general/help.stdout
+++ b/spec/tests/cmd/general/help.stdout
@@ -12,6 +12,7 @@ Commands:
   hook       Git hooks management
   config     Inspect effective git-std configuration
   doctor     Run health checks on the local git-std setup
+  version    Query the current project version
   help       Print this message or the help of the given subcommand(s)
 
 Options:


### PR DESCRIPTION
## Summary

- Add `git std version` subcommand for lightweight, scriptable version queries
- Flags: `--describe` (cargo-style), `--next`, `--label`, `--code`, `--format json`
- Implements the version code formula (semver and calver) with full stage table
- 22 unit tests (stage table, semver/calver code, ordering, round-trip) + 18 integration tests

## Details

### New subcommand: `git std version`

```
git std version                  # 0.10.2
git std version --describe       # 0.10.2-dev.7+g3a2b1c.dirty
git std version --next           # 0.11.0
git std version --label          # minor
git std version --code           # 100299
git std version --format json    # all fields as JSON
```

### Version code formula

**Semver:** `((MAJOR × 1_000 + MINOR) × 100 + PATCH) × 100 + stage`  
**Calver:** `days_since_epoch × 10_000 + MICRO × 100 + stage`

Stage values: stable=99, rc.N=80–98, beta.N=60–78, alpha.N=40–58, dev.N=10–38.

### Files changed

- `crates/git-std/src/cli/version.rs` — new command implementation + unit tests
- `crates/git-std/src/app.rs` — added `Version` variant to `Command` enum
- `crates/git-std/src/cli/mod.rs` — registered `version` module
- `crates/git-std/src/main.rs` — dispatch wired
- `crates/git-std/tests/version.rs` — integration tests
- `docs/SPEC.md` — §2.8 and §2.8.1 version code specification added
- `spec/tests/cmd/general/help.stdout` — snapshot updated

## Test plan

- [ ] `cargo test -p git-std --test version` — all 18 integration tests pass
- [ ] `cargo test -p git-std cli::version` — all 22 unit tests pass
- [ ] `cargo clippy --all-targets` — zero warnings
- [ ] `just lint` — passes (fmt + clippy + dprint + markdownlint)
- [ ] `git std version` outputs current version without `v` prefix
- [ ] `git std version --format json` outputs valid JSON with all fields
- [ ] Pre-existing `hooks_list_no_hooks` spec failure is not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)