### PR TITLE
feat(bump): add --push flag to push commit and tags after release (#405)

### DIFF
--- a/crates/git-std/src/app.rs
+++ b/crates/git-std/src/app.rs
@@ -131,6 +131,9 @@ pub enum Command {
         /// Filter bump to specific package(s) (monorepo only).
         #[arg(short = 'p', long = "package")]
         packages: Vec<String>,
+        /// Push commit and tags to remote after release. Optionally specify a remote name (default: origin).
+        #[arg(long, num_args = 0..=1, default_missing_value = "origin", value_name = "REMOTE")]
+        push: Option<String>,
     },
     /// Generate a changelog (incremental by default, --full to regenerate).
     Changelog {

--- a/crates/git-std/src/cli/bump/apply.rs
+++ b/crates/git-std/src/cli/bump/apply.rs
@@ -156,6 +156,10 @@ pub(super) fn finalize_bump(
             ui::info(&format!("Would tag:    {tag_prefix}{new_version}"));
         }
 
+        if let Some(remote) = &opts.push {
+            ui::info(&format!("Would push to {remote}"));
+        }
+
         ui::blank();
         return 0;
     }
@@ -293,7 +297,18 @@ pub(super) fn finalize_bump(
         }
     }
 
-    // post-bump hook: runs after commit+tag are created.
+    // Push commit and tags to remote.
+    if let Some(remote) = &opts.push {
+        if let Err(e) = git::push_follow_tags(dir, remote) {
+            ui::error(&format!("cannot push to {remote}: {e}"));
+            return 1;
+        }
+        if opts.format != OutputFormat::Json {
+            ui::info(&format!("Pushed to {remote}"));
+        }
+    }
+
+    // post-bump hook: runs after commit+tag are created (and after push if --push).
     // Skipped when --no-commit is set (nothing was committed or tagged).
     if !opts.no_commit
         && let Err(code) = run_lifecycle_hook("post-bump", &[])
@@ -337,7 +352,9 @@ pub(super) fn finalize_bump(
         println!("{}", serde_json::to_string(&result).unwrap());
     } else {
         ui::blank();
-        ui::info("Push with: git push --follow-tags");
+        if opts.push.is_none() {
+            ui::info("Push with: git push --follow-tags");
+        }
         ui::blank();
     }
 

--- a/crates/git-std/src/cli/bump/mod.rs
+++ b/crates/git-std/src/cli/bump/mod.rs
@@ -38,6 +38,10 @@ pub struct BumpOptions {
     pub format: OutputFormat,
     /// Filter bump to specific package(s) (monorepo only).
     pub packages: Vec<String>,
+    /// Push commit and tags to the given remote after tagging.
+    ///
+    /// `None` = flag not used, `Some(name)` = push to the named remote.
+    pub push: Option<String>,
 }
 
 /// Context passed from the version-computation phase to the shared finalize logic.

--- a/crates/git-std/src/git/mod.rs
+++ b/crates/git-std/src/git/mod.rs
@@ -11,7 +11,7 @@ mod tag;
 pub use mutate::{
     amend_commit, branch_exists, checkout_branch, create_annotated_tag, create_branch,
     create_commit, create_signed_commit, create_signed_commit_amend, create_signed_tag,
-    is_working_tree_dirty, stage_files, stage_tracked_modified, workdir,
+    is_working_tree_dirty, push_follow_tags, stage_files, stage_tracked_modified, workdir,
 };
 pub use query::{
     commit_date, config_value, current_branch, detect_host, head_oid, resolve_rev, walk_commits,

--- a/crates/git-std/src/git/mutate.rs
+++ b/crates/git-std/src/git/mutate.rs
@@ -86,3 +86,8 @@ pub fn branch_exists(dir: &Path, name: &str) -> Result<bool, GitError> {
 pub fn checkout_branch(dir: &Path, name: &str) -> Result<(), GitError> {
     git_ok(dir, &["checkout", name])
 }
+
+/// Push the current branch and all tags to the given remote using `--follow-tags`.
+pub fn push_follow_tags(dir: &Path, remote: &str) -> Result<(), GitError> {
+    git_ok(dir, &["push", "--follow-tags", remote, "HEAD"])
+}

--- a/crates/git-std/src/main.rs
+++ b/crates/git-std/src/main.rs
@@ -139,6 +139,7 @@ fn main() {
             minor,
             format,
             packages,
+            push,
         } => {
             let project_config = config::load(&std::env::current_dir().unwrap_or_default());
             let stable = stable.map(|s| if s.is_empty() { None } else { Some(s) });
@@ -156,6 +157,7 @@ fn main() {
                 minor,
                 format,
                 packages,
+                push,
             };
             let code = cli::bump::run(&project_config, &opts);
             std::process::exit(code);

--- a/crates/git-std/tests/bump.rs
+++ b/crates/git-std/tests/bump.rs
@@ -95,6 +95,7 @@ fn bump_help_shows_flags() {
         "--force",
         "--stable",
         "--minor",
+        "--push",
     ] {
         assert!(stdout.contains(flag), "bump help should list '{flag}' flag");
     }
@@ -1022,6 +1023,149 @@ fn bump_lifecycle_dry_run_skips_all_hooks() {
         .current_dir(dir.path())
         .assert()
         .success();
+}
+
+/// Helper: initialise a bare repo and add it as a remote to `local_dir`.
+fn init_remote(local_dir: &Path, remote_dir: &Path, remote_name: &str) {
+    // Init bare remote.
+    std::process::Command::new("git")
+        .args(["init", "--bare"])
+        .arg(remote_dir)
+        .output()
+        .unwrap();
+    // Add as a named remote.
+    git(
+        local_dir,
+        &[
+            "remote",
+            "add",
+            remote_name,
+            &remote_dir.display().to_string(),
+        ],
+    );
+}
+
+/// Helper: check whether a tag exists in a bare remote repo.
+fn remote_tag_exists(remote_dir: &Path, tag: &str) -> bool {
+    std::process::Command::new("git")
+        .current_dir(remote_dir)
+        .args(["rev-parse", "--verify", &format!("refs/tags/{tag}")])
+        .output()
+        .unwrap()
+        .status
+        .success()
+}
+
+// ── --push flag ────────────────────────────────────────────────
+
+/// --push pushes the commit and tag to the default remote (origin).
+#[test]
+fn bump_push_default_remote() {
+    let local = tempfile::tempdir().unwrap();
+    let remote = tempfile::tempdir().unwrap();
+    init_bump_repo(local.path());
+    create_tag(local.path(), "v1.0.0");
+    add_commit(local.path(), "a.txt", "fix: a fix");
+    init_remote(local.path(), remote.path(), "origin");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--push"])
+        .current_dir(local.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Pushed to origin"));
+
+    // Tag should be present in the remote.
+    assert!(
+        remote_tag_exists(remote.path(), "v1.0.1"),
+        "tag v1.0.1 should be pushed to remote"
+    );
+}
+
+/// --push <remote> pushes to the specified remote.
+#[test]
+fn bump_push_named_remote() {
+    let local = tempfile::tempdir().unwrap();
+    let remote = tempfile::tempdir().unwrap();
+    init_bump_repo(local.path());
+    create_tag(local.path(), "v1.0.0");
+    add_commit(local.path(), "a.txt", "fix: a fix");
+    init_remote(local.path(), remote.path(), "upstream");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--push", "upstream"])
+        .current_dir(local.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Pushed to upstream"));
+
+    assert!(
+        remote_tag_exists(remote.path(), "v1.0.1"),
+        "tag v1.0.1 should be pushed to upstream remote"
+    );
+}
+
+/// --dry-run --push reports "Would push to <remote>" without actually pushing.
+#[test]
+fn bump_dry_run_push_reports_would_push() {
+    let local = tempfile::tempdir().unwrap();
+    let remote = tempfile::tempdir().unwrap();
+    init_bump_repo(local.path());
+    create_tag(local.path(), "v1.0.0");
+    add_commit(local.path(), "a.txt", "fix: a fix");
+    init_remote(local.path(), remote.path(), "origin");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run", "--push"])
+        .current_dir(local.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Would push to origin"));
+
+    // Nothing pushed to remote.
+    assert!(
+        !remote_tag_exists(remote.path(), "v1.0.1"),
+        "dry-run should not push anything"
+    );
+}
+
+/// --dry-run --push <remote> reports "Would push to <remote>".
+#[test]
+fn bump_dry_run_push_named_remote() {
+    let local = tempfile::tempdir().unwrap();
+    let remote = tempfile::tempdir().unwrap();
+    init_bump_repo(local.path());
+    create_tag(local.path(), "v1.0.0");
+    add_commit(local.path(), "a.txt", "fix: a fix");
+    init_remote(local.path(), remote.path(), "upstream");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run", "--push", "upstream"])
+        .current_dir(local.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Would push to upstream"));
+}
+
+/// --push to a non-existent remote fails with a non-zero exit code.
+#[test]
+fn bump_push_failure_exits_nonzero() {
+    let local = tempfile::tempdir().unwrap();
+    init_bump_repo(local.path());
+    create_tag(local.path(), "v1.0.0");
+    add_commit(local.path(), "a.txt", "fix: a fix");
+    // No remote configured — push should fail.
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--push", "nonexistent-remote"])
+        .current_dir(local.path())
+        .assert()
+        .failure();
 }
 
 /// Cargo.lock is synced when `cargo` is available and Cargo.toml was updated.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -626,17 +626,18 @@ format and sigils as git hooks (see §2.6).
 7. Stage files
 8. Create commit
 9. Create tag
-                      ← post-bump              (publish, notify — code is committed and tagged)
+10. Push (if `--push`)
+                      ← post-bump              (publish, notify — code is pushed)
 ```
 
 **Hook summary:**
 
-| Hook             | Argument    | Use case                                   |
-| ---------------- | ----------- | ------------------------------------------ |
-| `pre-bump`       | —           | Tests pass, clean tree, correct branch     |
-| `post-version`   | `{version}` | Build with new version, stamp binaries     |
-| `post-changelog` | —           | Lint/reformat `CHANGELOG.md`, rewrite URLs |
-| `post-bump`      | —           | `cargo publish`, deploy, notify            |
+| Hook             | Argument    | Use case                                     |
+| ---------------- | ----------- | -------------------------------------------- |
+| `pre-bump`       | —           | Tests pass, clean tree, correct branch       |
+| `post-version`   | `{version}` | Build with new version, stamp binaries       |
+| `post-changelog` | —           | Lint/reformat `CHANGELOG.md`, rewrite URLs   |
+| `post-bump`      | —           | `cargo publish`, deploy, notify (after push) |
 
 **Rules:**
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -98,6 +98,7 @@ update version files, generate changelog, commit, and tag.
 | `--minor`            | Use minor bump (instead of major) when advancing main after stable |
 | `--format <fmt>`     | Output format: `text` (default) or `json`                          |
 | `--package <name>`   | Filter bump to specific package(s) (monorepo only, repeatable)     |
+| `--push [remote]`    | Push commit and tags after release (default remote: `origin`)      |
 
 **Exit codes:** `0` = success, `1` = error.
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `--push [remote]` flag to `git std bump` that runs `git push --follow-tags <remote> HEAD` after tag creation
- Defaults to `origin` when invoked as `--push` without an argument; accepts an explicit remote name via `--push <remote>`
- `--dry-run --push` reports "Would push to <remote>" without pushing; push failure exits non-zero
- Suppresses the existing "Push with: git push --follow-tags" hint when `--push` is used
- Documents the new flag in `docs/USAGE.md`

## Test plan

- [x] `bump_push_default_remote` — `--push` pushes commit + tag to `origin`
- [x] `bump_push_named_remote` — `--push upstream` pushes to a named remote
- [x] `bump_dry_run_push_reports_would_push` — `--dry-run --push` reports intent, does not push
- [x] `bump_dry_run_push_named_remote` — dry-run with explicit remote name reports correctly
- [x] `bump_push_failure_exits_nonzero` — push to non-existent remote exits 1
- [x] `bump_help_shows_flags` updated to assert `--push` appears in help output
- [x] `usage_md_documents_all_flags` passes (USAGE.md updated)
- [x] `just build` (compile + test + lint + audit) exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)