### PR TITLE
feat(bump): add pre-bump, post-version, post-changelog, post-bump lifecycle hooks (#404)

### DIFF
--- a/crates/git-std/src/cli/bump/apply.rs
+++ b/crates/git-std/src/cli/bump/apply.rs
@@ -9,6 +9,7 @@ use crate::config::ProjectConfig;
 use crate::git;
 use crate::ui;
 
+use super::lifecycle::run_lifecycle_hook;
 use super::{BumpOptions, FinalizeContext};
 
 /// JSON output schema for a version file update.
@@ -216,6 +217,13 @@ pub(super) fn finalize_bump(
         );
     }
 
+    // post-changelog hook: runs after CHANGELOG.md is written, before staging/commit.
+    if !opts.skip_changelog
+        && let Err(code) = run_lifecycle_hook("post-changelog", &[])
+    {
+        return code;
+    }
+
     // Create commit.
     if !opts.no_commit {
         let mut rel_paths: Vec<String> = version_results
@@ -283,6 +291,14 @@ pub(super) fn finalize_bump(
         if opts.format != OutputFormat::Json {
             ui::info(&format!("Tagged:    {}", tag_name.green()));
         }
+    }
+
+    // post-bump hook: runs after commit+tag are created.
+    // Skipped when --no-commit is set (nothing was committed or tagged).
+    if !opts.no_commit
+        && let Err(code) = run_lifecycle_hook("post-bump", &[])
+    {
+        return code;
     }
 
     if opts.format == OutputFormat::Json {

--- a/crates/git-std/src/cli/bump/lifecycle.rs
+++ b/crates/git-std/src/cli/bump/lifecycle.rs
@@ -1,0 +1,101 @@
+use std::process::Command;
+
+use standard_githooks::{HookCommand, Prefix};
+
+use crate::{git, ui};
+
+/// Run a bump lifecycle hook file (`.githooks/<hook>.hooks`).
+///
+/// Returns `Ok(())` if all required commands passed (or the file does not
+/// exist), or `Err(exit_code)` if a required command failed and the bump
+/// should be aborted.
+///
+/// - Missing hook file → silently skipped (not an error).
+/// - Advisory commands (`?`) → warning printed, bump continues.
+/// - Required commands (`!` or default) → non-zero exit aborts bump.
+///
+/// `extra_args` are passed as positional arguments after the command
+/// (used by `post-version` to pass the new version string).
+pub(super) fn run_lifecycle_hook(hook_name: &str, extra_args: &[&str]) -> Result<(), i32> {
+    // Honour the same skip-all-hooks escape hatch as `git std hook run`.
+    if let Ok(val) = std::env::var("GIT_STD_SKIP_HOOKS")
+        && (val == "1" || val.eq_ignore_ascii_case("true"))
+    {
+        return Ok(());
+    }
+
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let hooks_dir = match git::workdir(&cwd) {
+        Ok(root) => root.join(".githooks"),
+        Err(_) => {
+            ui::error("bare repository not supported");
+            return Err(1);
+        }
+    };
+
+    let hooks_file = hooks_dir.join(format!("{hook_name}.hooks"));
+
+    // Silently skip if the hook file does not exist.
+    if !hooks_file.exists() {
+        return Ok(());
+    }
+
+    let content = match std::fs::read_to_string(&hooks_file) {
+        Ok(c) => c,
+        Err(e) => {
+            ui::error(&format!("cannot read {}: {e}", hooks_file.display()));
+            return Err(2);
+        }
+    };
+
+    let commands = standard_githooks::parse(&content);
+    if commands.is_empty() {
+        return Ok(());
+    }
+
+    for cmd in &commands {
+        let exit_code = execute_hook_command(cmd, extra_args);
+        let success = exit_code == Some(0);
+        let is_advisory = cmd.prefix == Prefix::Advisory;
+
+        if success {
+            ui::info(&format!("{} {} ({})", ui::pass(), cmd.command, hook_name));
+        } else if is_advisory {
+            let info = match exit_code {
+                Some(code) => format!("(advisory, exit {code})"),
+                None => "(advisory, killed)".to_string(),
+            };
+            ui::warning(&format!("{} {} {info}", cmd.command, hook_name));
+        } else {
+            let info = match exit_code {
+                Some(code) => format!("(exit {code})"),
+                None => "(killed)".to_string(),
+            };
+            ui::error(&format!(
+                "hook {} failed: {} {info}",
+                hook_name, cmd.command
+            ));
+            ui::hint(&format!(
+                "to disable this command: comment it out in .githooks/{hook_name}.hooks"
+            ));
+            return Err(1);
+        }
+    }
+
+    Ok(())
+}
+
+/// Execute a single hook command and return its exit code.
+fn execute_hook_command(cmd: &HookCommand, extra_args: &[&str]) -> Option<i32> {
+    let status = Command::new("sh")
+        .arg("-c")
+        .arg(&cmd.command)
+        .arg("_")
+        .args(extra_args)
+        .status();
+
+    match status {
+        Ok(s) => s.code(),
+        Err(_) => Some(127),
+    }
+}

--- a/crates/git-std/src/cli/bump/mod.rs
+++ b/crates/git-std/src/cli/bump/mod.rs
@@ -1,5 +1,6 @@
 mod apply;
 mod detect;
+mod lifecycle;
 pub(crate) mod monorepo;
 mod plan;
 mod stable;
@@ -51,6 +52,14 @@ pub(super) struct FinalizeContext<'a> {
 
 /// Run the bump subcommand. Returns the exit code.
 pub fn run(config: &crate::config::ProjectConfig, opts: &BumpOptions) -> i32 {
+    // pre-bump gate: runs before version detection, non-zero exit aborts bump.
+    // Skipped for --dry-run.
+    if !opts.dry_run
+        && let Err(code) = lifecycle::run_lifecycle_hook("pre-bump", &[])
+    {
+        return code;
+    }
+
     if opts.stable.is_some() {
         return stable::run_stable(config, opts);
     }

--- a/crates/git-std/src/cli/bump/plan.rs
+++ b/crates/git-std/src/cli/bump/plan.rs
@@ -6,6 +6,7 @@ use crate::ui;
 
 use super::apply::finalize_bump;
 use super::detect::today_calver_date;
+use super::lifecycle::run_lifecycle_hook;
 use super::{BumpOptions, FinalizeContext};
 
 /// Run the bump subcommand in patch-only mode.
@@ -65,8 +66,16 @@ pub(super) fn run_patch(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
 
     let prev_ver_str = current_version.as_ref().map(|(_, v)| v.to_string());
 
+    let new_version_str = new_version.to_string();
+
+    if !opts.dry_run
+        && let Err(code) = run_lifecycle_hook("post-version", &[&new_version_str])
+    {
+        return code;
+    }
+
     let ctx = FinalizeContext {
-        new_version: new_version.to_string(),
+        new_version: new_version_str,
         prev_version: prev_ver_str.as_deref(),
         raw_commits: &raw_commits,
     };
@@ -139,6 +148,12 @@ pub(super) fn run_calver(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
         "{} (calver)",
         format!("{} \u{2192} {new_version}", prev_ver.unwrap_or("none")).bold(),
     ));
+
+    if !opts.dry_run
+        && let Err(code) = run_lifecycle_hook("post-version", &[&new_version])
+    {
+        return code;
+    }
 
     let ctx = FinalizeContext {
         new_version: new_version.clone(),
@@ -274,9 +289,16 @@ pub(super) fn run_semver(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
     ));
 
     let prev_ver_str = current_version.as_ref().map(|(_, v)| v.to_string());
+    let new_version_str = new_version.to_string();
+
+    if !opts.dry_run
+        && let Err(code) = run_lifecycle_hook("post-version", &[&new_version_str])
+    {
+        return code;
+    }
 
     let ctx = FinalizeContext {
-        new_version: new_version.to_string(),
+        new_version: new_version_str,
         prev_version: prev_ver_str.as_deref(),
         raw_commits: &raw_commits,
     };

--- a/crates/git-std/tests/bump.rs
+++ b/crates/git-std/tests/bump.rs
@@ -707,6 +707,323 @@ fn bump_post1_breaking_bumps_major() {
         .stderr(predicate::str::contains("1.2.3 → 2.0.0"));
 }
 
+// ── Bump lifecycle hooks ───────────────────────────────────────
+
+/// Helper: write a `.githooks/<name>.hooks` file with the given content.
+fn write_hooks_file(dir: &std::path::Path, hook_name: &str, content: &str) {
+    let hooks_dir = dir.join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    std::fs::write(hooks_dir.join(format!("{hook_name}.hooks")), content).unwrap();
+}
+
+/// `pre-bump` with a required command that exits 0 — bump proceeds normally.
+#[test]
+fn bump_lifecycle_pre_bump_passes() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: a fix");
+
+    write_hooks_file(dir.path(), "pre-bump", "! true\n");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("1.0.0 → 1.0.1"));
+}
+
+/// `pre-bump` with a required command that exits non-zero — bump is aborted.
+#[test]
+fn bump_lifecycle_pre_bump_aborts_on_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: a fix");
+
+    write_hooks_file(dir.path(), "pre-bump", "! false\n");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump"])
+        .current_dir(dir.path())
+        .assert()
+        .failure();
+
+    // Cargo.toml must not have been updated.
+    let cargo = std::fs::read_to_string(dir.path().join("Cargo.toml")).unwrap();
+    assert!(
+        !cargo.contains("version = \"1.0.1\""),
+        "Cargo.toml must not be updated when pre-bump fails"
+    );
+    // No tag must exist.
+    assert!(!tag_exists(dir.path(), "v1.0.1"), "tag must not exist");
+}
+
+/// `pre-bump` is skipped when `--dry-run` is used.
+#[test]
+fn bump_lifecycle_pre_bump_skipped_on_dry_run() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: a fix");
+
+    // A failing pre-bump hook must not abort dry-run.
+    write_hooks_file(dir.path(), "pre-bump", "! false\n");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+}
+
+/// `post-version` receives the new version as its first argument.
+#[test]
+fn bump_lifecycle_post_version_receives_version() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: a fix");
+
+    // Write the first positional arg ($1) to a file inside the tempdir.
+    let sentinel = dir.path().join("post-version-arg.txt");
+    let sentinel_str = sentinel.to_string_lossy();
+    write_hooks_file(
+        dir.path(),
+        "post-version",
+        &format!("! echo $1 > {sentinel_str}\n"),
+    );
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let written = std::fs::read_to_string(&sentinel)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    assert_eq!(written, "1.0.1", "post-version should receive '1.0.1'");
+}
+
+/// `post-version` aborts bump when it exits non-zero.
+#[test]
+fn bump_lifecycle_post_version_aborts_on_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: a fix");
+
+    write_hooks_file(dir.path(), "post-version", "! false\n");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump"])
+        .current_dir(dir.path())
+        .assert()
+        .failure();
+
+    // No tag should have been created.
+    assert!(!tag_exists(dir.path(), "v1.0.1"), "tag must not exist");
+}
+
+/// `post-changelog` runs after the changelog is written.
+#[test]
+fn bump_lifecycle_post_changelog_runs() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: a fix");
+
+    // Touch a sentinel file inside the tempdir so we know the hook ran.
+    let sentinel = dir.path().join("post-changelog-ran.txt");
+    let sentinel_str = sentinel.to_string_lossy();
+    write_hooks_file(
+        dir.path(),
+        "post-changelog",
+        &format!("! touch {sentinel_str}\n"),
+    );
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    assert!(
+        sentinel.exists(),
+        "post-changelog sentinel file must exist after bump"
+    );
+}
+
+/// `post-changelog` aborts bump when it exits non-zero.
+#[test]
+fn bump_lifecycle_post_changelog_aborts_on_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: a fix");
+
+    write_hooks_file(dir.path(), "post-changelog", "! false\n");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump"])
+        .current_dir(dir.path())
+        .assert()
+        .failure();
+
+    // No release commit should have been created.
+    assert_ne!(
+        head_message(dir.path()),
+        "chore(release): 1.0.1",
+        "release commit must not exist"
+    );
+}
+
+/// `post-changelog` is skipped when `--skip-changelog` is used.
+#[test]
+fn bump_lifecycle_post_changelog_skipped_when_skip_changelog() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: a fix");
+
+    // Failing post-changelog hook must not abort bump when --skip-changelog is passed.
+    write_hooks_file(dir.path(), "post-changelog", "! false\n");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--skip-changelog"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+}
+
+/// `post-bump` runs after the release tag is created.
+#[test]
+fn bump_lifecycle_post_bump_runs_after_tag() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: a fix");
+
+    // Touch a sentinel file inside the tempdir.
+    let sentinel = dir.path().join("post-bump-ran.txt");
+    let sentinel_str = sentinel.to_string_lossy();
+    write_hooks_file(
+        dir.path(),
+        "post-bump",
+        &format!("! touch {sentinel_str}\n"),
+    );
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // Tag must already exist when post-bump runs (hook runs after tag).
+    assert!(tag_exists(dir.path(), "v1.0.1"), "tag must exist");
+    assert!(
+        sentinel.exists(),
+        "post-bump sentinel file must exist after bump"
+    );
+}
+
+/// `post-bump` with advisory command (`?`) — failure is tolerated.
+#[test]
+fn bump_lifecycle_post_bump_advisory_tolerates_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: a fix");
+
+    // Advisory command that always fails.
+    write_hooks_file(dir.path(), "post-bump", "? false\n");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // Tag should still have been created.
+    assert!(tag_exists(dir.path(), "v1.0.1"), "tag must exist");
+}
+
+/// `post-bump` is skipped when `--no-commit` is used (no commit/tag created).
+#[test]
+fn bump_lifecycle_post_bump_skipped_on_no_commit() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: a fix");
+
+    // Failing post-bump hook must not abort bump when --no-commit is passed.
+    write_hooks_file(dir.path(), "post-bump", "! false\n");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--no-commit"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+}
+
+/// `GIT_STD_SKIP_HOOKS=1` skips all lifecycle hooks.
+#[test]
+fn bump_lifecycle_skip_hooks_env_var() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: a fix");
+
+    // All hooks fail — GIT_STD_SKIP_HOOKS=1 must suppress them all.
+    for hook in ["pre-bump", "post-version", "post-changelog", "post-bump"] {
+        write_hooks_file(dir.path(), hook, "! false\n");
+    }
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump"])
+        .current_dir(dir.path())
+        .env("GIT_STD_SKIP_HOOKS", "1")
+        .assert()
+        .success();
+}
+
+/// `--dry-run` skips all lifecycle hooks (`post-version`, `post-changelog`,
+/// `post-bump`).
+#[test]
+fn bump_lifecycle_dry_run_skips_all_hooks() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+    add_commit(dir.path(), "a.txt", "fix: a fix");
+
+    // All four hooks fail if executed — dry-run must not run any of them.
+    for hook in ["pre-bump", "post-version", "post-changelog", "post-bump"] {
+        write_hooks_file(dir.path(), hook, "! false\n");
+    }
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+}
+
 /// Cargo.lock is synced when `cargo` is available and Cargo.toml was updated.
 #[test]
 fn bump_cargo_lock_sync_happy_path() {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -604,6 +604,73 @@ $ git std bump --dry-run
 for a package, the first semver release defaults to
 `0.1.0`. Calver packages use the current date.
 
+#### 2.3.4 Lifecycle Hooks
+
+`git std bump` supports four lifecycle hooks that run at
+defined points in the bump pipeline. Hook files live in
+`.githooks/` with the `.hooks` extension, using the same
+format and sigils as git hooks (see §2.6).
+
+**Lifecycle positions:**
+
+```text
+                      ← pre-bump               (gate: validate, abort)
+1. Detect version
+2. Collect + parse commits
+3. Compute new version
+                      ← post-version {version} (build, generate artifacts)
+4. Update version files
+5. Sync lock files
+6. Generate changelog
+                      ← post-changelog         (lint, rewrite CHANGELOG.md)
+7. Stage files
+8. Create commit
+9. Create tag
+                      ← post-bump              (publish, notify — code is committed and tagged)
+```
+
+**Hook summary:**
+
+| Hook             | Argument    | Use case                                   |
+| ---------------- | ----------- | ------------------------------------------ |
+| `pre-bump`       | —           | Tests pass, clean tree, correct branch     |
+| `post-version`   | `{version}` | Build with new version, stamp binaries     |
+| `post-changelog` | —           | Lint/reformat `CHANGELOG.md`, rewrite URLs |
+| `post-bump`      | —           | `cargo publish`, deploy, notify            |
+
+**Rules:**
+
+- Missing hook file → silently skipped (not an error).
+- `!` (required) commands: non-zero exit aborts the bump.
+- `?` (advisory) commands: non-zero exit prints a warning,
+  bump continues.
+- `--dry-run` skips all lifecycle hooks.
+- `post-changelog` is skipped when `--skip-changelog` is
+  used.
+- `post-version` receives the computed version string as
+  its first positional argument (`$1`).
+- Hook names do not collide with standard git hook names,
+  so `git std hook list` / `enable` / `disable` work for
+  bump hooks too.
+
+**Example:**
+
+```gitconfig
+# .githooks/pre-bump.hooks
+!  just verify
+
+# .githooks/post-version.hooks
+!  cargo build --release
+?  cp target/release/mybin dist/
+
+# .githooks/post-changelog.hooks
+?  dprint fmt CHANGELOG.md
+
+# .githooks/post-bump.hooks
+!  cargo publish
+?  curl -X POST https://hooks.slack.com/...
+```
+
 ### 2.4 `git std changelog`
 
 Generate or update the changelog from git commit history


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds four lifecycle hook points to `git std bump`: `pre-bump`, `post-version`, `post-changelog`, `post-bump`
- Hook files live in `.githooks/` with the `.hooks` extension, using the existing format and `!`/`?` sigils — no new file format needed
- All hooks are skipped when `--dry-run` is passed; `post-changelog` is additionally skipped with `--skip-changelog`
- `post-version` receives the new version string as its first positional argument (`$1`)
- Missing hook files are silently ignored (not an error)
- `git std hook list` / `enable` / `disable` work for these hooks automatically

## Lifecycle positions

```
                      ← pre-bump               (gate: validate, abort)
1. Detect version
2. Collect + parse commits
3. Compute new version
                      ← post-version {version} (build, generate artifacts)
4. Update version files
5. Sync lock files
6. Generate changelog
                      ← post-changelog         (lint, rewrite CHANGELOG.md)
7. Stage files
8. Create commit
9. Create tag
                      ← post-bump              (publish, notify)
```

## Test plan

- [x] `pre-bump` required command passes → bump proceeds
- [x] `pre-bump` required command fails → bump aborted before any writes
- [x] `pre-bump` skipped on `--dry-run`
- [x] `post-version` receives new version as `$1`
- [x] `post-version` required command fails → bump aborted (no tag created)
- [x] `post-changelog` runs after changelog generated
- [x] `post-changelog` required command fails → no release commit
- [x] `post-changelog` skipped with `--skip-changelog`
- [x] `post-bump` runs after tag exists
- [x] `post-bump` advisory command failure tolerated (bump still succeeds)
- [x] `--dry-run` skips all four hooks (all hooks failing → bump still succeeds)
- [x] All pre-existing bump tests still pass (33 + 15 tests)
- [x] Zero clippy warnings, zero lint failures, `cargo audit` clean
- [x] `docs/SPEC.md` updated with new §2.3.4

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)