### PR TITLE
feat(git-std): extend --release-as to accept patch/minor/major level names

### DIFF
--- a/crates/git-std/src/cli/bump/monorepo.rs
+++ b/crates/git-std/src/cli/bump/monorepo.rs
@@ -13,6 +13,7 @@ use crate::git;
 use crate::ui;
 
 use super::BumpOptions;
+use super::plan::parse_release_level;
 
 /// A per-package bump plan entry.
 pub(crate) struct PackageBumpPlan {
@@ -155,6 +156,7 @@ fn plan_package(
     tag_template: &str,
     tags: &[(String, String)],
     config: &ProjectConfig,
+    release_as: Option<&str>,
 ) -> Option<PackageBumpPlan> {
     let scheme = resolve_scheme(pkg, &config.scheme);
     if scheme == Scheme::Calver {
@@ -181,7 +183,12 @@ fn plan_package(
         .filter_map(|(_, msg)| standard_commit::parse(msg).ok())
         .collect();
 
-    let bump_level = standard_version::determine_bump(&parsed)?;
+    let commit_bump_level = standard_version::determine_bump(&parsed)?;
+
+    // Override bump level with level name from --release-as, if provided.
+    let bump_level = release_as
+        .and_then(parse_release_level)
+        .unwrap_or(commit_bump_level);
 
     let cur_ver = latest_tag
         .as_ref()
@@ -328,8 +335,15 @@ pub(super) fn plan_monorepo_bump(
     // Plan per-package bumps.
     let mut package_plans: Vec<PackageBumpPlan> = Vec::new();
     for pkg in &packages {
-        if let Some(plan) = plan_package(&workdir, pkg, &head_oid, tag_template, &all_tags, config)
-        {
+        if let Some(plan) = plan_package(
+            &workdir,
+            pkg,
+            &head_oid,
+            tag_template,
+            &all_tags,
+            config,
+            opts.release_as.as_deref(),
+        ) {
             package_plans.push(plan);
         }
     }

--- a/crates/git-std/src/cli/bump/plan.rs
+++ b/crates/git-std/src/cli/bump/plan.rs
@@ -9,6 +9,19 @@ use super::detect::today_calver_date;
 use super::lifecycle::run_lifecycle_hook;
 use super::{BumpOptions, FinalizeContext};
 
+/// Parse a `--release-as` value as a semver bump level.
+///
+/// Returns `Some(level)` for `"patch"`, `"minor"`, `"major"` (case-insensitive).
+/// Returns `None` for anything else (treated as an exact version string).
+pub(super) fn parse_release_level(s: &str) -> Option<standard_version::BumpLevel> {
+    match s.to_ascii_lowercase().as_str() {
+        "patch" => Some(standard_version::BumpLevel::Patch),
+        "minor" => Some(standard_version::BumpLevel::Minor),
+        "major" => Some(standard_version::BumpLevel::Major),
+        _ => None,
+    }
+}
+
 /// Run the bump subcommand in patch-only mode.
 pub(super) fn run_patch(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
     let dir = std::path::Path::new(".");
@@ -48,6 +61,13 @@ pub(super) fn run_patch(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
 
     if has_breaking && !opts.force {
         ui::error("breaking change not allowed on patch-only branch (use --force to override)");
+        return 1;
+    }
+
+    if let Some(ref forced) = opts.release_as
+        && parse_release_level(forced).is_some_and(|l| l != standard_version::BumpLevel::Patch)
+    {
+        ui::error("patch-only scheme does not support --release-as minor or --release-as major");
         return 1;
     }
 
@@ -92,6 +112,13 @@ pub(super) fn run_calver(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
 
     if opts.prerelease.is_some() {
         ui::error("--prerelease is not supported with scheme = \"calver\"");
+        return 1;
+    }
+
+    if let Some(ref forced) = opts.release_as
+        && parse_release_level(forced).is_some()
+    {
+        ui::error("--release-as patch/minor/major is not supported with scheme = \"calver\"");
         return 1;
     }
 
@@ -216,11 +243,15 @@ pub(super) fn run_semver(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
 
     // Step 4: Determine new version.
     let new_version = if let Some(ref forced) = opts.release_as {
-        match semver::Version::parse(forced) {
-            Ok(v) => v,
-            Err(e) => {
-                ui::error(&format!("invalid --release-as version '{forced}': {e}"));
-                return 1;
+        if let Some(level) = parse_release_level(forced) {
+            standard_version::apply_bump(&cur_ver, level)
+        } else {
+            match semver::Version::parse(forced) {
+                Ok(v) => v,
+                Err(e) => {
+                    ui::error(&format!("invalid --release-as version '{forced}': {e}"));
+                    return 1;
+                }
             }
         }
     } else if opts.first_release {
@@ -263,7 +294,16 @@ pub(super) fn run_semver(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
     let bump_reason = if opts.first_release {
         "first release".to_string()
     } else if let Some(ref forced) = opts.release_as {
-        format!("forced as {forced}")
+        if let Some(level) = parse_release_level(forced) {
+            let level_name = match level {
+                standard_version::BumpLevel::Patch => "patch",
+                standard_version::BumpLevel::Minor => "minor",
+                standard_version::BumpLevel::Major => "major",
+            };
+            format!("forced {level_name}")
+        } else {
+            format!("forced as {forced}")
+        }
     } else {
         let level = standard_version::determine_bump(&parsed).unwrap();
         let is_pre1 = cur_ver.major == 0;
@@ -335,4 +375,47 @@ pub(super) fn dispatch(config: &ProjectConfig, opts: &BumpOptions) -> i32 {
         return run_patch(config, opts);
     }
     run_semver(config, opts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_release_level_recognises_all_levels() {
+        assert_eq!(
+            parse_release_level("patch"),
+            Some(standard_version::BumpLevel::Patch)
+        );
+        assert_eq!(
+            parse_release_level("minor"),
+            Some(standard_version::BumpLevel::Minor)
+        );
+        assert_eq!(
+            parse_release_level("major"),
+            Some(standard_version::BumpLevel::Major)
+        );
+        // Case-insensitive.
+        assert_eq!(
+            parse_release_level("PATCH"),
+            Some(standard_version::BumpLevel::Patch)
+        );
+        assert_eq!(
+            parse_release_level("Minor"),
+            Some(standard_version::BumpLevel::Minor)
+        );
+        assert_eq!(
+            parse_release_level("MAJOR"),
+            Some(standard_version::BumpLevel::Major)
+        );
+    }
+
+    #[test]
+    fn parse_release_level_returns_none_for_version_string() {
+        assert_eq!(parse_release_level("1.2.3"), None);
+        assert_eq!(parse_release_level("2.0.0"), None);
+        assert_eq!(parse_release_level("0.1.0-rc.1"), None);
+        assert_eq!(parse_release_level(""), None);
+        assert_eq!(parse_release_level("minorr"), None);
+    }
 }

--- a/crates/git-std/tests/bump.rs
+++ b/crates/git-std/tests/bump.rs
@@ -1479,3 +1479,137 @@ serde = "1"
         "serde (non-path dep) must not be modified"
     );
 }
+
+// ── --release-as with level names ─────────────────────────────
+
+/// `--release-as patch` forces a patch bump from the current version.
+#[test]
+fn release_as_patch_forces_patch_bump() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.2.3");
+
+    // Add a feat commit (would normally be a minor bump).
+    add_commit(dir.path(), "a.txt", "feat: new feature");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run", "--release-as", "patch"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("1.2.3 → 1.2.4"));
+}
+
+/// `--release-as minor` forces a minor bump from the current version.
+#[test]
+fn release_as_minor_forces_minor_bump() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.2.3");
+
+    // Add a fix commit (would normally be a patch bump).
+    add_commit(dir.path(), "b.txt", "fix: small fix");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run", "--release-as", "minor"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("1.2.3 → 1.3.0"));
+}
+
+/// `--release-as major` forces a major bump from the current version.
+#[test]
+fn release_as_major_forces_major_bump() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.2.3");
+
+    // Add a fix commit (would normally be a patch bump).
+    add_commit(dir.path(), "c.txt", "fix: a fix");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run", "--release-as", "major"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("1.2.3 → 2.0.0"));
+}
+
+/// `--dry-run` with `--release-as minor` shows version but makes no changes.
+#[test]
+fn release_as_level_respects_dry_run() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+
+    add_commit(dir.path(), "d.txt", "fix: a fix");
+
+    let before = std::fs::read_to_string(dir.path().join("Cargo.toml")).unwrap();
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run", "--release-as", "minor"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("1.0.0 → 1.1.0"))
+        .stderr(predicate::str::contains("Would commit"))
+        .stderr(predicate::str::contains("Would tag"));
+
+    // No files changed.
+    let after = std::fs::read_to_string(dir.path().join("Cargo.toml")).unwrap();
+    assert_eq!(before, after);
+    assert!(!dir.path().join("CHANGELOG.md").exists());
+}
+
+/// `--release-as minor` is rejected on the patch-only scheme.
+#[test]
+fn release_as_minor_rejected_on_patch_scheme() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+
+    std::fs::write(dir.path().join(".git-std.toml"), "scheme = \"patch\"\n").unwrap();
+    git(dir.path(), &["add", ".git-std.toml"]);
+    git(dir.path(), &["commit", "-m", "chore: add config"]);
+
+    add_commit(dir.path(), "e.txt", "fix: a fix");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run", "--release-as", "minor"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "patch-only scheme does not support --release-as minor or --release-as major",
+        ));
+}
+
+/// `--release-as major` is rejected on the patch-only scheme.
+#[test]
+fn release_as_major_rejected_on_patch_scheme() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+
+    std::fs::write(dir.path().join(".git-std.toml"), "scheme = \"patch\"\n").unwrap();
+    git(dir.path(), &["add", ".git-std.toml"]);
+    git(dir.path(), &["commit", "-m", "chore: add config"]);
+
+    add_commit(dir.path(), "f.txt", "fix: a fix");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run", "--release-as", "major"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "patch-only scheme does not support --release-as minor or --release-as major",
+        ));
+}


### PR DESCRIPTION
Closes #437.

## Summary

- Added `parse_release_level` helper (`pub(super)`) to `plan.rs` that maps `"patch"`, `"minor"`, `"major"` (case-insensitive) to `BumpLevel`, returning `None` for anything else (exact version strings).
- `run_semver`: when `--release-as` is a level name, calls `standard_version::apply_bump(&cur_ver, level)` instead of parsing a semver string. Bump reason shows `"forced patch"` / `"forced minor"` / `"forced major"`.
- `run_patch`: rejects `--release-as minor` and `--release-as major` with a clear error message.
- `run_calver`: rejects all level names with a clear error message.
- `plan_package` in `monorepo.rs`: accepts `release_as: Option<&str>`, overrides the commit-determined bump level with the parsed level if provided. Call site in `plan_monorepo_bump` passes `opts.release_as.as_deref()`.

## Test plan

- [ ] `release_as_patch_forces_patch_bump` — `--release-as patch` with a feat commit produces a patch bump (1.2.3 → 1.2.4)
- [ ] `release_as_minor_forces_minor_bump` — `--release-as minor` with a fix commit produces a minor bump (1.2.3 → 1.3.0)
- [ ] `release_as_major_forces_major_bump` — `--release-as major` with a fix commit produces a major bump (1.2.3 → 2.0.0)
- [ ] `release_as_level_respects_dry_run` — `--dry-run --release-as minor` shows new version and "Would commit/tag" but makes no changes
- [ ] `release_as_minor_rejected_on_patch_scheme` — `--release-as minor` with `scheme = "patch"` exits with failure and error message
- [ ] `release_as_major_rejected_on_patch_scheme` — `--release-as major` with `scheme = "patch"` exits with failure and error message
- [ ] `parse_release_level_recognises_all_levels` (unit test) — all three levels, case-insensitive
- [ ] `parse_release_level_returns_none_for_version_string` (unit test) — exact version strings return `None`
- [ ] `just verify` passes (commitlint + build + test + clippy + fmt + audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)