### PR TITLE
docs(git-std): improve hook help and add missing hook templates

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,2 +1,4 @@
 #!/bin/bash
+# Managed by git-std — do not edit.
+# Configure commands in .githooks/commit-msg.hooks
 exec git std hook run commit-msg -- "$@"

--- a/.githooks/commit-msg.hooks
+++ b/.githooks/commit-msg.hooks
@@ -1,1 +1,13 @@
+# git-std hooks — commit-msg.hooks
+#
+# Commands run during the commit-msg hook. $1 is the path to the
+# file containing the commit message.
+# Prefix controls behavior:
+#
+#   !  required   abort commit on failure
+#   ?  advisory   warn on failure, never abort
+#
+# Examples:
+#   ! git std lint -f $1   # validate conventional commit format
+#
 ! git std lint --file {msg}

--- a/.githooks/post-commit.hooks
+++ b/.githooks/post-commit.hooks
@@ -1,0 +1,13 @@
+# git-std hooks — post-commit.hooks
+#
+# Commands run after a successful commit (informational only —
+# cannot abort the commit).
+# Prefix controls behavior:
+#
+#   !  required   report failure
+#   ?  advisory   warn on failure, always continues
+#
+# Examples:
+#   ? echo "committed — remember to push"
+#   ? npx semantic-release --dry-run
+#

--- a/.githooks/post-commit.off
+++ b/.githooks/post-commit.off
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Managed by git-std — do not edit.
+# Configure commands in .githooks/post-commit.hooks
+exec git std hook run post-commit -- "$@"

--- a/.githooks/post-merge.hooks
+++ b/.githooks/post-merge.hooks
@@ -1,0 +1,12 @@
+# git-std hooks — post-merge.hooks
+#
+# Commands run after a successful merge (e.g. after git pull).
+# Prefix controls behavior:
+#
+#   !  required   report failure
+#   ?  advisory   warn on failure, always continues
+#
+# Examples:
+#   ? npm install      # reinstall if package.json changed
+#   ? cargo build      # rebuild after dependency updates
+#

--- a/.githooks/post-merge.off
+++ b/.githooks/post-merge.off
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Managed by git-std — do not edit.
+# Configure commands in .githooks/post-merge.hooks
+exec git std hook run post-merge -- "$@"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,4 @@
 #!/bin/bash
+# Managed by git-std — do not edit.
+# Configure commands in .githooks/pre-commit.hooks
 exec git std hook run pre-commit -- "$@"

--- a/.githooks/pre-commit.hooks
+++ b/.githooks/pre-commit.hooks
@@ -1,1 +1,15 @@
-! just lint
+# git-std hooks — pre-commit.hooks
+#
+# Commands run during the pre-commit hook. $@ contains staged files.
+# Prefix controls behavior:
+#
+#   ~  fix        stash unstaged changes, run, re-stage result, restore
+#   !  required   abort commit on failure
+#   ?  advisory   warn on failure, never abort
+#
+# Examples:
+#   ~ cargo fmt -- $@                        # format staged Rust files
+#   ~ npx prettier --write $@   *.{js,ts}   # format staged JS/TS files
+#   ! cargo clippy --workspace -- -D warnings
+#
+~ just fmt

--- a/.githooks/pre-push.hooks
+++ b/.githooks/pre-push.hooks
@@ -1,0 +1,13 @@
+# git-std hooks — pre-push.hooks
+#
+# Commands run during the pre-push hook before pushing to remote.
+# Prefix controls behavior:
+#
+#   !  required   abort push on failure
+#   ?  advisory   warn on failure, never abort
+#
+# Examples:
+#   ! cargo test --workspace
+#   ! npx markdownlint "**/*.md"
+#
+! just lint

--- a/.githooks/pre-push.off
+++ b/.githooks/pre-push.off
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Managed by git-std — do not edit.
+# Configure commands in .githooks/pre-push.hooks
+exec git std hook run pre-push -- "$@"

--- a/.githooks/prepare-commit-msg.hooks
+++ b/.githooks/prepare-commit-msg.hooks
@@ -1,0 +1,13 @@
+# git-std hooks — prepare-commit-msg.hooks
+#
+# Commands run before the commit message editor opens. $1 is the
+# path to the message file, $2 is the commit source (message,
+# template, merge, squash, commit).
+# Prefix controls behavior:
+#
+#   !  required   abort commit on failure
+#   ?  advisory   warn on failure, never abort
+#
+# Examples:
+#   ? git std --context >> $1   # prepend project context as a comment
+#

--- a/.githooks/prepare-commit-msg.off
+++ b/.githooks/prepare-commit-msg.off
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Managed by git-std — do not edit.
+# Configure commands in .githooks/prepare-commit-msg.hooks
+exec git std hook run prepare-commit-msg -- "$@"

--- a/crates/git-std/src/app.rs
+++ b/crates/git-std/src/app.rs
@@ -163,6 +163,57 @@ pub enum Command {
         force: bool,
     },
     /// Git hooks management.
+    ///
+    /// Git hooks (triggered by git):
+    ///
+    ///   pre-commit          runs before a commit is created
+    ///   commit-msg          validates the commit message ($1 = message file)
+    ///   pre-push            runs before pushing to a remote
+    ///   post-commit         runs after a commit is created (informational)
+    ///   prepare-commit-msg  runs before the commit message editor opens
+    ///   post-merge          runs after a successful merge or pull
+    ///
+    /// Bootstrap hook (triggered by `git std bootstrap`):
+    ///
+    ///   bootstrap           runs after built-in post-clone checks
+    ///
+    /// Bump lifecycle hooks (triggered by `git std bump`):
+    ///
+    ///   pre-bump            gate before version detection — abort to cancel
+    ///   post-version        runs after version files are updated ($1 = new version)
+    ///   post-changelog      runs after CHANGELOG.md is written
+    ///   post-bump           runs after commit + tag (use for publish, notify)
+    ///
+    /// Hook commands are defined in `.githooks/<hook>.hooks` — one command per
+    /// line. Each line may start with an optional sigil:
+    ///
+    ///   !  required   — run the command; abort the hook on non-zero exit
+    ///   ~  fix        — stash unstaged changes, run, re-stage result, restore
+    ///   ?  advisory   — run the command; warn on failure, never abort
+    ///
+    /// Lines without a sigil use the hook's default mode (fail-fast for most
+    /// git hooks, advisory for bootstrap).
+    ///
+    /// A glob pattern at the end of a line restricts the command to matching
+    /// files only (populated as $@ when the hook is invoked by git):
+    ///
+    ///   ~ cargo fmt -- $@   *.rs
+    ///   ! cargo clippy
+    ///
+    /// Examples (.githooks/pre-commit.hooks):
+    ///
+    ///   ~ cargo fmt -- $@
+    ///   ~ npx prettier --write $@   *.{js,ts,json}
+    ///   ! cargo clippy --workspace -- -D warnings
+    ///
+    /// Examples (.githooks/pre-push.hooks):
+    ///
+    ///   ! cargo test --workspace
+    ///   ! npx markdownlint "**/*.md"
+    ///
+    /// Examples (.githooks/commit-msg.hooks):
+    ///
+    ///   ! git std lint -f $1
     Hook {
         #[command(subcommand)]
         subcommand: HookCommand,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Expand `git std hook --help` with full hook language reference: sigils (`!` `~` `?`), glob patterns, all available hooks grouped by category (git hooks, bootstrap, bump lifecycle), and concrete examples
- Add missing `.hooks` template files for `pre-push`, `post-commit`, `post-merge`, `prepare-commit-msg` with accurate headers and hook-specific examples
- Update `pre-commit.hooks` to use `~` (fix mode) for `just fmt`
- Update `pre-push.hooks` to use `just lint`
- Fix `post-commit` and `post-merge` templates which had wrong examples (were showing fmt/clippy — not appropriate for post-hooks)

## Test plan

- [ ] `git std hook --help` shows all three hook categories with descriptions
- [ ] `git std hook --help` shows sigil reference and examples
- [ ] `.githooks/pre-push.hooks`, `post-commit.hooks`, `post-merge.hooks`, `prepare-commit-msg.hooks` exist with correct headers
- [ ] `pre-commit.hooks` uses `~` sigil

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)