### PR TITLE
fix(ecosystem): skip Plain fallback when specific ecosystem matched

### DIFF
--- a/crates/git-std/src/ecosystem/mod.rs
+++ b/crates/git-std/src/ecosystem/mod.rs
@@ -59,6 +59,16 @@ pub trait Ecosystem {
     fn version_file_engine(&self) -> Option<Box<dyn VersionFile>> {
         None
     }
+
+    /// Whether this ecosystem is a last-resort fallback.
+    ///
+    /// Fallback ecosystems (e.g. `Plain`) are skipped when any specific
+    /// ecosystem has already matched and written version files. This prevents
+    /// a bare `VERSION` file from being updated in projects that already have
+    /// a dedicated ecosystem (Node, Rust, etc.) managing their version.
+    fn is_fallback(&self) -> bool {
+        false
+    }
 }
 
 /// Outcome of a version-write operation.
@@ -219,13 +229,20 @@ fn all_ecosystems() -> Vec<Box<dyn Ecosystem>> {
 /// 2. Write versions (CLI-first, fallback to string manipulation).
 /// 3. Sync lock files (always delegated to ecosystem tool).
 /// 4. Process custom `[[version_files]]` via regex engine.
+///
+/// Fallback ecosystems (e.g. `Plain`) are skipped when a specific ecosystem
+/// has already matched, preventing duplicate updates in mixed-ecosystem repos.
 pub fn run_bump(root: &Path, new_version: &str, custom_files: &[CustomVersionFile]) -> BumpResult {
     let ecosystems = all_ecosystems();
     let mut update_results: Vec<UpdateResult> = Vec::new();
     let mut modified_paths: Vec<PathBuf> = Vec::new();
     let mut synced_locks: Vec<String> = Vec::new();
+    let mut any_specific_updated = false;
 
     for eco in &ecosystems {
+        if eco.is_fallback() && any_specific_updated {
+            continue;
+        }
         if !eco.detect(root) {
             continue;
         }
@@ -246,6 +263,10 @@ pub fn run_bump(root: &Path, new_version: &str, custom_files: &[CustomVersionFil
             }
             WriteOutcome::NotDetected => false,
         };
+
+        if version_updated && !eco.is_fallback() {
+            any_specific_updated = true;
+        }
 
         // Only sync lock files if version was actually updated.
         if !version_updated {
@@ -354,17 +375,25 @@ pub fn dry_run_lock_sync(root: &Path) {
 /// Uses each ecosystem's `detect()` gate and `version_file_engine()` to
 /// find version files, mirroring the detection that [`run_bump`] would
 /// perform. Custom `[[version_files]]` are appended via the regex engine.
+///
+/// Fallback ecosystems are skipped when a specific ecosystem detected files,
+/// consistent with the write-path behaviour in [`run_bump`].
 pub fn dry_run_version_files(root: &Path, custom_files: &[CustomVersionFile]) -> Vec<DetectedFile> {
     let ecosystems = all_ecosystems();
     let mut results: Vec<DetectedFile> = Vec::new();
+    let mut any_specific_detected = false;
 
     for eco in &ecosystems {
+        if eco.is_fallback() && any_specific_detected {
+            continue;
+        }
         if !eco.detect(root) {
             continue;
         }
         let Some(engine) = eco.version_file_engine() else {
             continue;
         };
+        let before = results.len();
         for filename in engine.filenames() {
             let path = root.join(filename);
             if !path.exists() {
@@ -385,6 +414,9 @@ pub fn dry_run_version_files(root: &Path, custom_files: &[CustomVersionFile]) ->
                 name: engine.name().to_string(),
                 old_version,
             });
+        }
+        if !eco.is_fallback() && results.len() > before {
+            any_specific_detected = true;
         }
     }
 

--- a/crates/git-std/src/ecosystem/plain.rs
+++ b/crates/git-std/src/ecosystem/plain.rs
@@ -35,4 +35,8 @@ impl Ecosystem for Plain {
     fn version_file_engine(&self) -> Option<Box<dyn VersionFile>> {
         Some(Box::new(PlainVersionFile))
     }
+
+    fn is_fallback(&self) -> bool {
+        true
+    }
 }

--- a/crates/git-std/tests/bump_custom.rs
+++ b/crates/git-std/tests/bump_custom.rs
@@ -256,3 +256,85 @@ regex = 'version = "(\d+\.\d+\.\d+)"'
         .stderr(predicate::str::contains("Cargo.toml"))
         .stderr(predicate::str::contains("Would update"));
 }
+
+// --- Ecosystem fallback (Plain) conflict resolution tests ---
+
+#[test]
+fn bump_plain_version_skipped_when_specific_ecosystem_present() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path()); // creates Cargo.toml with version = "0.0.0"
+    create_tag(dir.path(), "v1.0.0");
+
+    // Patch the Cargo.toml version to match the tag.
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"test-pkg\"\nversion = \"1.0.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+
+    // Add a plain VERSION file alongside Cargo.toml.
+    std::fs::write(dir.path().join("VERSION"), "1.0.0\n").unwrap();
+
+    git(dir.path(), &["add", "."]);
+    git(
+        dir.path(),
+        &["commit", "-m", "chore: set version files to 1.0.0"],
+    );
+
+    add_commit(dir.path(), "a.txt", "feat: add feature");
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--skip-changelog"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // Cargo.toml should be updated.
+    let cargo = std::fs::read_to_string(dir.path().join("Cargo.toml")).unwrap();
+    assert!(
+        cargo.contains("version = \"1.1.0\""),
+        "Cargo.toml should be updated to 1.1.0"
+    );
+
+    // VERSION should NOT be updated — Plain is skipped when Rust matched.
+    let version_file = std::fs::read_to_string(dir.path().join("VERSION")).unwrap();
+    assert_eq!(
+        version_file.trim(),
+        "1.0.0",
+        "VERSION should be unchanged when Rust ecosystem matched"
+    );
+}
+
+#[test]
+fn bump_dry_run_plain_skipped_when_specific_ecosystem_present() {
+    let dir = tempfile::tempdir().unwrap();
+    init_bump_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"test-pkg\"\nversion = \"1.0.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+
+    std::fs::write(dir.path().join("VERSION"), "1.0.0\n").unwrap();
+
+    git(dir.path(), &["add", "."]);
+    git(
+        dir.path(),
+        &["commit", "-m", "chore: set version files to 1.0.0"],
+    );
+
+    add_commit(dir.path(), "a.txt", "feat: add feature");
+
+    // Dry-run should show Cargo.toml but NOT VERSION.
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["bump", "--dry-run"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Cargo.toml"))
+        .stderr(predicate::str::contains("VERSION").not());
+}


### PR DESCRIPTION
## Summary

- Adds `is_fallback() -> bool` to the `Ecosystem` trait (default `false`)
- `Plain` overrides it to `true`
- `run_bump` and `dry_run_version_files` now skip fallback ecosystems once any specific ecosystem has matched and written version files
- A repo with both `Cargo.toml` and `VERSION` will only update `Cargo.toml`; dry-run output is consistent with the real run

## Test plan

- [ ] `bump_plain_version_skipped_when_specific_ecosystem_present` — real bump: `VERSION` unchanged when `Cargo.toml` present
- [ ] `bump_dry_run_plain_skipped_when_specific_ecosystem_present` — dry-run: `VERSION` absent from `Would update` output
- [ ] All existing bump/custom tests pass

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)