### PR TITLE
fix(doctor): address #321 debt (#339, #345, #347)

### DIFF
--- a/crates/git-std/src/cli/doctor.rs
+++ b/crates/git-std/src/cli/doctor.rs
@@ -379,8 +379,8 @@ fn build_config_section(root: &Path) -> (Vec<ConfigRow>, Vec<Hint>) {
 pub fn run(cwd: &Path, format: OutputFormat) -> i32 {
     let root = match workdir(cwd) {
         Ok(p) => p,
-        Err(_) => {
-            ui::error("not a git repository");
+        Err(e) => {
+            ui::error(&format!("not a git repository: {e}"));
             return 2;
         }
     };

--- a/crates/git-std/tests/doctor.rs
+++ b/crates/git-std/tests/doctor.rs
@@ -324,6 +324,41 @@ fn doctor_json_has_pass_status_when_no_problems() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
     assert_eq!(parsed["status"], "pass");
+    // hints must be an empty array (not absent, not null) when clean
+    let hints = parsed["hints"].as_array().expect("hints must be an array");
+    assert!(hints.is_empty(), "hints must be empty when no problems");
+    assert!(
+        output.stderr.is_empty(),
+        "stderr should be empty in JSON mode"
+    );
+}
+
+#[test]
+fn doctor_json_status_tools_have_version_string() {
+    let dir = tempfile::tempdir().unwrap();
+    init_full_repo(dir.path());
+
+    let output = git_std()
+        .args(["doctor", "--format", "json"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let tools = parsed["sections"]["status"].as_array().unwrap();
+    for tool in tools {
+        assert!(
+            tool["name"].is_string(),
+            "every status tool must have a name string"
+        );
+        // version is present and is a string for tools that are found
+        assert!(
+            tool["version"].is_string(),
+            "tool '{}' must have a version string",
+            tool["name"]
+        );
+    }
 }
 
 #[test]

--- a/spec/tests/cmd/doctor/help.stdout
+++ b/spec/tests/cmd/doctor/help.stdout
@@ -1,0 +1,26 @@
+Run health checks on the local git-std setup
+
+Usage: git-std doctor [OPTIONS]
+
+Options:
+      --color <COLOR>
+          When to use coloured output
+
+          Possible values:
+          - auto:   Colour if stdout is a TTY
+          - always: Always use colour
+          - never:  Never use colour
+          
+          [default: auto]
+
+      --format <FORMAT>
+          Output format
+
+          Possible values:
+          - text: Human-readable text (default)
+          - json: Machine-readable JSON
+          
+          [default: text]
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/spec/tests/cmd/doctor/help.toml
+++ b/spec/tests/cmd/doctor/help.toml
@@ -1,0 +1,3 @@
+bin.name = "git-std"
+args = ["doctor", "--help"]
+status = "success"

--- a/spec/tests/doctor.rs
+++ b/spec/tests/doctor.rs
@@ -4,6 +4,11 @@ mod support;
 use snapbox::cmd::Command;
 use support::TestRepo;
 
+#[test]
+fn trycmd_doctor() {
+    trycmd::TestCases::new().case("tests/cmd/doctor/*.toml");
+}
+
 /// `doctor` exits 0 in a fully-configured git repo (no problems).
 #[test]
 fn doctor_exits_0_in_basic_repo() {


### PR DESCRIPTION
## Summary

- **#339** Surface `workdir` error message instead of silently discarding it — `Err(_)` → `Err(e)` with message in the error output
- **#345** Add `spec/tests/cmd/doctor/` trycmd snapshot fixtures: `doctor --help` help output is now regression-tested as a static snapshot
- **#347** Strengthen JSON tests: `hints` is an empty array (not absent/null) when clean; all status tools have a `version` string; `stderr` is empty in JSON mode

## Closed as stale (already fixed or superseded by doctor refactor)

- #338 — `CheckStatus`/`Check`/`Section` public types no longer exist in the current code
- #341 — `doctor_status_skips_lfs_without_filter_lfs` test already exists in `tests/doctor.rs:84`
- #342 — bootstrap warn test refers to a state machine that was replaced by the hints model
- #343 — `doctor_config_warn_when_no_config_file` refers to a Warn state that no longer exists
- #344 — `doctor_config_hint_for_invalid_toml` already asserts `hint:` and `.git-std.toml invalid`
- #346 — both JSON tests already had `output.stderr.is_empty()` assertions

## Test plan

- [ ] `just check` passes
- [ ] `trycmd_doctor` snapshot matches `doctor --help` output
- [ ] `doctor_json_has_pass_status_when_no_problems` — hints is empty array, stderr empty
- [ ] `doctor_json_status_tools_have_version_string` — each tool entry has name + version strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)