### PR TITLE
feat(git-std): add missing health hints for doctor (#321)

### DIFF
--- a/crates/git-std/src/cli/doctor.rs
+++ b/crates/git-std/src/cli/doctor.rs
@@ -239,9 +239,13 @@ struct ConfigRow {
 fn build_config_section(root: &Path) -> (Vec<ConfigRow>, Vec<Hint>) {
     let mut hints = Vec::new();
 
-    // Bootstrap health check: .git-blame-ignore-revs present but blame.ignoreRevsFile not set.
+    // Bootstrap health checks: .git-blame-ignore-revs and blame.ignoreRevsFile.
     let ignore_revs = root.join(".git-blame-ignore-revs");
-    if ignore_revs.exists() {
+    if !ignore_revs.exists() {
+        hints.push(Hint(
+            ".git-blame-ignore-revs not found — add to suppress noise in git blame".to_owned(),
+        ));
+    } else {
         let configured = std::process::Command::new("git")
             .current_dir(root)
             .args(["config", "blame.ignoreRevsFile"])
@@ -256,8 +260,8 @@ fn build_config_section(root: &Path) -> (Vec<ConfigRow>, Vec<Hint>) {
             });
         if configured.as_deref() != Some(".git-blame-ignore-revs") {
             hints.push(Hint(
-                ".git-blame-ignore-revs found but blame.ignoreRevsFile not configured \
-                 — run 'git std bootstrap'"
+                "blame.ignoreRevsFile not set \
+                 — run 'git config blame.ignoreRevsFile .git-blame-ignore-revs'"
                     .to_owned(),
             ));
         }
@@ -267,6 +271,9 @@ fn build_config_section(root: &Path) -> (Vec<ConfigRow>, Vec<Hint>) {
     // We need to detect parse errors to show as hints.
     let config_path = root.join(".git-std.toml");
     let has_file = config_path.exists();
+    if !has_file {
+        hints.push(Hint(".git-std.toml not found — using defaults".to_owned()));
+    }
 
     // Check for invalid TOML — if so, add a hint but still display defaults.
     // We parse the file ourselves to avoid load_with_raw emitting an eprintln!
@@ -449,8 +456,7 @@ fn render_text(
                     Prefix::Fix => "~",
                     Prefix::Default => " ",
                 };
-                // 6-space indent for commands within a hook
-                eprintln!("      {}  {}", sigil, cmd.command);
+                ui::check_line(sigil, &cmd.command);
             }
         }
     }
@@ -466,10 +472,10 @@ fn render_text(
         let key_padded = format!("{:<width$}", row.key, width = key_width);
         if row.from_file {
             // Bold for explicit file values
-            eprintln!("    {}   {}", key_padded.bold(), row.value.bold());
+            ui::detail(&format!("{}   {}", key_padded.bold(), row.value.bold()));
         } else {
             // Dim for defaults
-            eprintln!("    {}   {}", key_padded.dim(), row.value.dim());
+            ui::detail(&format!("{}   {}", key_padded.dim(), row.value.dim()));
         }
     }
 
@@ -647,8 +653,9 @@ mod tests {
     #[test]
     fn build_config_section_defaults_have_from_file_false() {
         let dir = tempfile::tempdir().unwrap();
-        let (rows, hints) = build_config_section(dir.path());
-        assert!(hints.is_empty(), "no hints for valid config");
+        std::fs::write(dir.path().join(".git-std.toml"), "").unwrap();
+        std::fs::write(dir.path().join(".git-blame-ignore-revs"), "").unwrap();
+        let (rows, _hints) = build_config_section(dir.path());
         let scheme = rows.iter().find(|r| r.key == "scheme").unwrap();
         assert!(!scheme.from_file, "scheme should be default when no file");
         assert_eq!(scheme.value, "semver");
@@ -672,6 +679,61 @@ mod tests {
         assert!(
             hints.iter().any(|h| h.0.contains(".git-std.toml invalid")),
             "should produce hint for invalid TOML"
+        );
+    }
+
+    #[test]
+    fn build_config_section_hint_when_toml_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".git-blame-ignore-revs"), "").unwrap();
+        let (_, hints) = build_config_section(dir.path());
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.0.contains(".git-std.toml not found")),
+            "should emit hint when .git-std.toml is absent"
+        );
+    }
+
+    #[test]
+    fn build_config_section_no_absent_hint_when_toml_present() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".git-std.toml"), "").unwrap();
+        std::fs::write(dir.path().join(".git-blame-ignore-revs"), "").unwrap();
+        let (_, hints) = build_config_section(dir.path());
+        assert!(
+            hints
+                .iter()
+                .all(|h| !h.0.contains(".git-std.toml not found")),
+            "should not emit absent hint when .git-std.toml exists"
+        );
+    }
+
+    #[test]
+    fn build_config_section_hint_when_blame_ignore_revs_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".git-std.toml"), "").unwrap();
+        let (_, hints) = build_config_section(dir.path());
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.0.contains(".git-blame-ignore-revs not found")),
+            "should emit hint when .git-blame-ignore-revs is absent"
+        );
+    }
+
+    #[test]
+    fn build_config_section_hint_when_blame_config_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".git-std.toml"), "").unwrap();
+        std::fs::write(dir.path().join(".git-blame-ignore-revs"), "").unwrap();
+        // blame.ignoreRevsFile is not configured (no git repo, so git config returns nothing)
+        let (_, hints) = build_config_section(dir.path());
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.0.contains("blame.ignoreRevsFile not set")),
+            "should emit hint when blame.ignoreRevsFile is not configured"
         );
     }
 }

--- a/crates/git-std/tests/doctor.rs
+++ b/crates/git-std/tests/doctor.rs
@@ -20,12 +20,18 @@ fn init_repo(dir: &std::path::Path) {
     git(dir, &["config", "user.email", "test@test.com"]);
 }
 
-/// Fully-configured repo: git init + .githooks/ dir + core.hooksPath set.
+/// Fully-configured repo: all doctor health checks satisfied.
 /// Doctor exits 0 (no hints) from this baseline.
 fn init_full_repo(dir: &std::path::Path) {
     init_repo(dir);
     std::fs::create_dir_all(dir.join(".githooks")).unwrap();
     git(dir, &["config", "core.hooksPath", ".githooks"]);
+    std::fs::write(dir.join(".git-std.toml"), "").unwrap();
+    std::fs::write(dir.join(".git-blame-ignore-revs"), "").unwrap();
+    git(
+        dir,
+        &["config", "blame.ignoreRevsFile", ".git-blame-ignore-revs"],
+    );
 }
 
 // ===========================================================================
@@ -276,6 +282,95 @@ fn doctor_no_hints_when_all_ok() {
 }
 
 // ===========================================================================
+// Hooks hints (ACs 1-3)
+// ===========================================================================
+
+#[test]
+fn doctor_hint_when_githooks_dir_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    init_full_repo(dir.path());
+    std::fs::remove_dir(dir.path().join(".githooks")).unwrap();
+    git_std()
+        .args(["doctor"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(contains(".githooks/ not found"));
+}
+
+#[test]
+fn doctor_hint_when_hooks_path_misconfigured() {
+    let dir = tempfile::tempdir().unwrap();
+    init_full_repo(dir.path());
+    git(dir.path(), &["config", "core.hooksPath", ".git/hooks"]);
+    git_std()
+        .args(["doctor"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(contains("core.hooksPath is '.git/hooks'"));
+}
+
+#[test]
+fn doctor_hint_when_shim_not_executable() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    init_full_repo(dir.path());
+    let shim = dir.path().join(".githooks/pre-commit");
+    std::fs::write(&shim, "#!/bin/sh\n").unwrap();
+    std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o644)).unwrap();
+    git_std()
+        .args(["doctor"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(contains("pre-commit shim is not executable"));
+}
+
+// ===========================================================================
+// Config hints (ACs 5-7)
+// ===========================================================================
+
+#[test]
+fn doctor_hint_when_git_std_toml_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    init_full_repo(dir.path());
+    std::fs::remove_file(dir.path().join(".git-std.toml")).unwrap();
+    git_std()
+        .args(["doctor"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(contains(".git-std.toml not found"));
+}
+
+#[test]
+fn doctor_hint_when_blame_ignore_revs_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    init_full_repo(dir.path());
+    std::fs::remove_file(dir.path().join(".git-blame-ignore-revs")).unwrap();
+    git_std()
+        .args(["doctor"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(contains(".git-blame-ignore-revs not found"));
+}
+
+#[test]
+fn doctor_hint_when_blame_ignore_revs_not_configured() {
+    let dir = tempfile::tempdir().unwrap();
+    init_full_repo(dir.path());
+    git(dir.path(), &["config", "--unset", "blame.ignoreRevsFile"]);
+    git_std()
+        .args(["doctor"])
+        .current_dir(dir.path())
+        .assert()
+        .code(1)
+        .stderr(contains("blame.ignoreRevsFile not set"));
+}
+
+// ===========================================================================
 // --format json
 // ===========================================================================
 
@@ -493,10 +588,15 @@ fn doctor_from_git_worktree() {
         "[versioning]\ntag_prefix = \"v\"\n",
     )
     .unwrap();
+    std::fs::write(dir.path().join(".git-blame-ignore-revs"), "").unwrap();
     git(dir.path(), &["add", "."]);
     git(dir.path(), &["commit", "-m", "initial commit"]);
 
     git(dir.path(), &["config", "core.hooksPath", ".githooks"]);
+    git(
+        dir.path(),
+        &["config", "blame.ignoreRevsFile", ".git-blame-ignore-revs"],
+    );
 
     // Create a real git worktree.
     let wt_parent = tempfile::tempdir().unwrap();

--- a/spec/support/mod.rs
+++ b/spec/support/mod.rs
@@ -26,14 +26,23 @@ impl TestRepo {
         }
     }
 
-    /// Create `.githooks/` and set `core.hooksPath = .githooks`.
-    /// Required for `doctor` to exit 0 (no hints about missing hooks setup).
+    /// Create `.githooks/`, set `core.hooksPath = .githooks`, create `.git-std.toml`,
+    /// and set up `.git-blame-ignore-revs` with `blame.ignoreRevsFile` configured.
+    /// Required for `doctor` to exit 0 (all health checks satisfied).
     // Used by: spec/tests/doctor.rs
     #[allow(dead_code)]
     pub fn with_hooks_setup(self) -> Self {
         let hooks_dir = self.dir.path().join(".githooks");
         std::fs::create_dir_all(&hooks_dir).expect("failed to create .githooks dir");
         git(self.dir.path(), &["config", "core.hooksPath", ".githooks"]);
+        std::fs::write(self.dir.path().join(".git-std.toml"), "")
+            .expect("failed to write .git-std.toml");
+        std::fs::write(self.dir.path().join(".git-blame-ignore-revs"), "")
+            .expect("failed to write .git-blame-ignore-revs");
+        git(
+            self.dir.path(),
+            &["config", "blame.ignoreRevsFile", ".git-blame-ignore-revs"],
+        );
         self
     }
 


### PR DESCRIPTION
Epic: #321

## Summary

Implements the remaining acceptance criteria from #445 that were not covered by the previous `fix/321-doctor-debt` PR:

- **AC #5** — emit hint when `.git-std.toml` is absent: `hint: .git-std.toml not found — using defaults`
- **AC #6** — emit hint when `.git-blame-ignore-revs` is absent: `hint: .git-blame-ignore-revs not found — add to suppress noise in git blame`
- **AC #7** — restructured blame block so the `blame.ignoreRevsFile not set` hint only fires when the file exists but the config is missing (was previously partial)
- **`eprintln!` cleanup** — replaced two direct `eprintln!` sites in `render_text` with `ui::check_line` and `ui::detail` per AGENTS.md UI consistency rule

## Tests

- 4 new unit tests in `doctor.rs` for the new config hints
- 6 new integration tests in `tests/doctor.rs` for all new hints and the three hooks health checks (missing dir, wrong hooksPath, non-executable shim)
- `init_full_repo` (integration) and `TestRepo::with_hooks_setup` (spec) updated to satisfy all health checks — establishes the clean baseline required for `doctor` to exit 0

## Test plan

- [x] `just verify` — all 964 tests pass, lint clean, audit clean
- [x] `doctor_no_hints_when_all_ok` exits 0 with fully-configured repo
- [x] Each new hint fires exactly when its condition is present
- [x] JSON output (`--format json`) includes all new hints via `hints[]`
