### PR TITLE
fix(bump): push guard, lifecycle output, JSON pushed_to, init lifecycle templates

### DIFF
--- a/crates/git-std/src/app.rs
+++ b/crates/git-std/src/app.rs
@@ -140,6 +140,7 @@ pub enum Command {
         #[arg(short = 'p', long = "package")]
         packages: Vec<String>,
         /// Push commit and tags to remote after release. Optionally specify a remote name (default: origin).
+        /// Skipped (with a warning) when --no-commit or --no-tag is set.
         #[arg(long, num_args = 0..=1, default_missing_value = "origin", value_name = "REMOTE")]
         push: Option<String>,
         /// Skip branch confirmation prompt (also: GIT_STD_YES=1).

--- a/crates/git-std/src/cli/bump/apply.rs
+++ b/crates/git-std/src/cli/bump/apply.rs
@@ -32,6 +32,8 @@ struct BumpResultJson {
     changelog: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pushed_to: Option<String>,
     dry_run: bool,
 }
 
@@ -120,6 +122,11 @@ pub(super) fn finalize_bump(
                 } else {
                     None
                 },
+                pushed_to: if !opts.no_commit && !opts.no_tag {
+                    opts.push.clone()
+                } else {
+                    None
+                },
                 dry_run: true,
             };
             println!("{}", serde_json::to_string(&result).unwrap());
@@ -156,7 +163,10 @@ pub(super) fn finalize_bump(
             ui::info(&format!("Would tag:    {tag_prefix}{new_version}"));
         }
 
-        if let Some(remote) = &opts.push {
+        if let Some(remote) = &opts.push
+            && !opts.no_commit
+            && !opts.no_tag
+        {
             ui::info(&format!("Would push to {remote}"));
         }
 
@@ -298,12 +308,15 @@ pub(super) fn finalize_bump(
     }
 
     // Push commit and tags to remote.
+    // Skipped (with a warning) when --no-commit or --no-tag is set, because
+    // --follow-tags degenerates to a plain branch push when there is no tag.
     if let Some(remote) = &opts.push {
-        if let Err(e) = git::push_follow_tags(dir, remote) {
+        if opts.no_commit || opts.no_tag {
+            ui::warning("--push skipped: incompatible with --no-commit or --no-tag");
+        } else if let Err(e) = git::push_follow_tags(dir, remote) {
             ui::error(&format!("cannot push to {remote}: {e}"));
             return 1;
-        }
-        if opts.format != OutputFormat::Json {
+        } else if opts.format != OutputFormat::Json {
             ui::info(&format!("Pushed to {remote}"));
         }
     }
@@ -347,6 +360,11 @@ pub(super) fn finalize_bump(
             synced_locks: synced_locks.clone(),
             changelog: !opts.skip_changelog,
             commit: commit_msg,
+            pushed_to: if !opts.no_commit && !opts.no_tag {
+                opts.push.clone()
+            } else {
+                None
+            },
             dry_run: false,
         };
         println!("{}", serde_json::to_string(&result).unwrap());

--- a/crates/git-std/src/cli/bump/lifecycle.rs
+++ b/crates/git-std/src/cli/bump/lifecycle.rs
@@ -59,22 +59,19 @@ pub(super) fn run_lifecycle_hook(hook_name: &str, extra_args: &[&str]) -> Result
         let is_advisory = cmd.prefix == Prefix::Advisory;
 
         if success {
-            ui::info(&format!("{} {} ({})", ui::pass(), cmd.command, hook_name));
+            ui::info(&format!("{} {}", ui::pass(), cmd.command));
         } else if is_advisory {
             let info = match exit_code {
                 Some(code) => format!("(advisory, exit {code})"),
                 None => "(advisory, killed)".to_string(),
             };
-            ui::warning(&format!("{} {} {info}", cmd.command, hook_name));
+            ui::warning(&format!("{} {info}", cmd.command));
         } else {
             let info = match exit_code {
                 Some(code) => format!("(exit {code})"),
                 None => "(killed)".to_string(),
             };
-            ui::error(&format!(
-                "hook {} failed: {} {info}",
-                hook_name, cmd.command
-            ));
+            ui::error(&format!("hook command failed: {} {info}", cmd.command));
             ui::hint(&format!(
                 "to disable this command: comment it out in .githooks/{hook_name}.hooks"
             ));

--- a/crates/git-std/src/cli/init.rs
+++ b/crates/git-std/src/cli/init.rs
@@ -30,6 +30,8 @@ const BOOTSTRAP_HOOKS_FILE: &str = ".githooks/bootstrap.hooks";
 const BOOTSTRAP_SCRIPT: &str = "bootstrap";
 const MARKER: &str = "<!-- git-std:bootstrap -->";
 
+const LIFECYCLE_HOOKS: &[&str] = &["pre-bump", "post-version", "post-changelog", "post-bump"];
+
 // ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------
@@ -74,6 +76,18 @@ pub fn run(force: bool) -> i32 {
         let template_path = hooks_dir.join(format!("{hook_name}.hooks"));
         if !template_path.exists() || force {
             let content = generate_hooks_template(hook_name);
+            if let Err(e) = std::fs::write(&template_path, &content) {
+                ui::error(&format!("cannot write {}: {e}", template_path.display()));
+                return 1;
+            }
+        }
+    }
+
+    // ── Step 3b: write lifecycle hook templates ──────────────────────────────
+    for hook_name in LIFECYCLE_HOOKS {
+        let template_path = hooks_dir.join(format!("{hook_name}.hooks"));
+        if !template_path.exists() || force {
+            let content = generate_lifecycle_hook_template(hook_name);
             if let Err(e) = std::fs::write(&template_path, &content) {
                 ui::error(&format!("cannot write {}: {e}", template_path.display()));
                 return 1;
@@ -312,6 +326,72 @@ fn append_bootstrap_marker(path: &Path) -> std::io::Result<()> {
 // Generated content
 // ---------------------------------------------------------------------------
 
+/// Generate a bump lifecycle hook template for the given hook name.
+fn generate_lifecycle_hook_template(hook_name: &str) -> String {
+    match hook_name {
+        "pre-bump" => "\
+# git-std hooks — pre-bump.hooks
+#
+# Runs before version detection. Non-zero exit aborts the bump.
+# Use for: guard checks (clean tree, correct branch, tests pass).
+#
+#   !  required   abort bump on failure
+#   ?  advisory   warn on failure, never abort
+#
+# Examples:
+#   ! cargo test --workspace
+#   ! git diff --exit-code   # abort if working tree is dirty
+#
+"
+        .to_string(),
+        "post-version" => "\
+# git-std hooks — post-version.hooks
+#
+# Runs after version files are updated. $1 is the new version string.
+# Use for: building artifacts, stamping binaries, generating manifests.
+#
+#   !  required   abort bump on failure
+#   ?  advisory   warn on failure, never abort
+#
+# Examples:
+#   ! cargo build --release
+#   ? cp target/release/mybin dist/
+#
+"
+        .to_string(),
+        "post-changelog" => "\
+# git-std hooks — post-changelog.hooks
+#
+# Runs after CHANGELOG.md is written, before staging and commit.
+# Use for: linting or reformatting the changelog.
+#
+#   !  required   abort bump on failure
+#   ?  advisory   warn on failure, never abort
+#
+# Examples:
+#   ? npx markdownlint CHANGELOG.md
+#
+"
+        .to_string(),
+        "post-bump" => "\
+# git-std hooks — post-bump.hooks
+#
+# Runs after commit and tag are created (and after push if --push).
+# Use for: publishing, deployment, notifications.
+#
+#   !  required   report failure
+#   ?  advisory   warn on failure, always continues
+#
+# Examples:
+#   ! cargo publish
+#   ? curl -X POST https://hooks.slack.com/...
+#
+"
+        .to_string(),
+        _ => format!("# git-std hooks — {hook_name}.hooks\n"),
+    }
+}
+
 /// Generate the `./bootstrap` bash script content.
 fn generate_bootstrap_script() -> String {
     let version = env!("CARGO_PKG_VERSION");
@@ -507,5 +587,49 @@ mod tests {
     fn marker_is_html_comment() {
         assert!(MARKER.starts_with("<!--"));
         assert!(MARKER.ends_with("-->"));
+    }
+
+    #[test]
+    fn lifecycle_hook_templates_have_headers() {
+        for hook in LIFECYCLE_HOOKS {
+            let t = generate_lifecycle_hook_template(hook);
+            assert!(
+                t.contains(&format!("# git-std hooks — {hook}.hooks")),
+                "{hook}.hooks template should have header"
+            );
+            assert!(
+                t.contains("!  required"),
+                "{hook}.hooks should document ! sigil"
+            );
+            assert!(
+                t.contains("?  advisory"),
+                "{hook}.hooks should document ? sigil"
+            );
+        }
+    }
+
+    #[test]
+    fn pre_bump_template_mentions_when_it_runs() {
+        let t = generate_lifecycle_hook_template("pre-bump");
+        assert!(t.contains("before version detection"));
+        assert!(t.contains("abort bump on failure"));
+    }
+
+    #[test]
+    fn post_version_template_mentions_version_arg() {
+        let t = generate_lifecycle_hook_template("post-version");
+        assert!(t.contains("$1 is the new version string"));
+    }
+
+    #[test]
+    fn post_changelog_template_mentions_when_it_runs() {
+        let t = generate_lifecycle_hook_template("post-changelog");
+        assert!(t.contains("after CHANGELOG.md is written"));
+    }
+
+    #[test]
+    fn post_bump_template_mentions_when_it_runs() {
+        let t = generate_lifecycle_hook_template("post-bump");
+        assert!(t.contains("after commit and tag are created"));
     }
 }

--- a/crates/git-std/tests/init.rs
+++ b/crates/git-std/tests/init.rs
@@ -389,3 +389,85 @@ fn init_not_in_git_repo_fails() {
         .failure()
         .stderr(predicate::str::contains("not inside a git repository"));
 }
+
+// ===========================================================================
+// lifecycle hook templates (#443)
+// ===========================================================================
+
+#[test]
+fn init_creates_lifecycle_hook_templates() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    run_init(dir.path(), &[]).success();
+
+    for hook in &["pre-bump", "post-version", "post-changelog", "post-bump"] {
+        let path = dir.path().join(format!(".githooks/{hook}.hooks"));
+        assert!(path.exists(), "{hook}.hooks should be created by init");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains(&format!("# git-std hooks — {hook}.hooks")),
+            "{hook}.hooks should have a header comment"
+        );
+    }
+}
+
+#[test]
+fn init_lifecycle_hooks_not_added_to_shims() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    run_init(dir.path(), &[]).success();
+
+    // Lifecycle hook files must not have corresponding shims
+    for hook in &["pre-bump", "post-version", "post-changelog", "post-bump"] {
+        assert!(
+            !dir.path().join(format!(".githooks/{hook}")).exists(),
+            "no shim should exist for lifecycle hook {hook}"
+        );
+        assert!(
+            !dir.path().join(format!(".githooks/{hook}.off")).exists(),
+            "no .off shim should exist for lifecycle hook {hook}"
+        );
+    }
+}
+
+#[test]
+fn init_skips_existing_lifecycle_hooks_without_force() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    std::fs::create_dir_all(dir.path().join(".githooks")).unwrap();
+    std::fs::write(
+        dir.path().join(".githooks/pre-bump.hooks"),
+        "# custom content\n",
+    )
+    .unwrap();
+
+    run_init(dir.path(), &[]).success();
+
+    let content = std::fs::read_to_string(dir.path().join(".githooks/pre-bump.hooks")).unwrap();
+    assert_eq!(
+        content, "# custom content\n",
+        "existing file should not be overwritten"
+    );
+}
+
+#[test]
+fn init_force_overwrites_lifecycle_hooks() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    std::fs::create_dir_all(dir.path().join(".githooks")).unwrap();
+    std::fs::write(
+        dir.path().join(".githooks/pre-bump.hooks"),
+        "# old content\n",
+    )
+    .unwrap();
+
+    run_init(dir.path(), &["--force"]).success();
+
+    let content = std::fs::read_to_string(dir.path().join(".githooks/pre-bump.hooks")).unwrap();
+    assert!(
+        content.contains("git-std hooks — pre-bump.hooks"),
+        "pre-bump.hooks should have template content after --force"
+    );
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **#426** — Remove `(hook-name)` suffix from bump lifecycle hook output lines to match `git std hook run` style
- **#423** — Guard `--push` against `--no-commit`/`--no-tag`: warn and skip push instead of silently degrading to a plain branch push
- **#424** — Add `pushed_to: Option<String>` field to `bump --format json` output (set to remote name when push runs, absent otherwise)
- **#443** — `git std init` now writes template files for all four bump lifecycle hooks (`pre-bump`, `post-version`, `post-changelog`, `post-bump`); skipped if files exist, overwritten with `--force`

## Test plan

- [ ] `just verify` passes (all tests green, clippy clean, fmt clean)
- [ ] Unit tests for all four lifecycle hook templates in `init.rs`
- [ ] Integration tests: lifecycle files created, no shims written, skip-if-exists, `--force` overwrites
- [ ] `bump --push --no-tag` emits warning and skips push
- [ ] `bump --push --format json` output includes `pushed_to` field; absent when push skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)