### PR TITLE
docs: migrate schema path and fix docs accuracy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,8 @@ jobs:
         run: cargo install mdbook --no-default-features
       - name: Build book
         run: mdbook build
+      - name: Copy schemas into book
+        run: cp -r schemas target/book/schemas
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Library crates are pure — no git2, no I/O, no terminal output — except
 `standard-version`, which performs file I/O for version file detection and
 updates.
 
-**Eight subcommands**, each a separate concern:
+**Ten subcommands**, each a separate concern:
 
 | Subcommand          | Purpose                                        |
 | ------------------- | ---------------------------------------------- |
@@ -54,6 +54,9 @@ updates.
 | `git std init`      | Maintainer setup (hooks + bootstrap scaffold)  |
 | `git std bootstrap` | Post-clone environment setup                   |
 | `git std hook`      | Git hooks management (run/list/enable/disable) |
+| `git std doctor`    | Local setup diagnostics (status/hooks/config)  |
+| `git std version`   | Lightweight scriptable version queries         |
+| `git std config`    | Inspect effective configuration                |
 
 **Global flag** (no subcommand required):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,8 @@ git-std/
 **Design principle:** library crates are pure domain logic — strings in, data
 out. They have no dependency on git, the filesystem, or the terminal. The
 `git-std` binary crate is the orchestrator that wires libraries together with
-CLI dispatch, config loading, git operations (via `git2`), and terminal I/O.
+CLI dispatch, config loading, git operations (via git CLI subprocess
+calls), and terminal I/O.
 
 Read [docs/SPEC.md](docs/SPEC.md) for the full specification.
 
@@ -70,8 +71,10 @@ just verify             # Full pre-PR gate (commit lint + build)
 
 ### Test conventions
 
-- **Acceptance tests** go in `crates/git-std/tests/` — these test the CLI
-  binary end-to-end.
+- **Acceptance tests** go in `crates/git-std/spec/` — blackbox e2e snapshot
+  tests driven by the story's acceptance criteria (binary input/output only).
+- **Integration tests** go in `crates/git-std/tests/` — functional coverage
+  of the CLI wiring.
 - **Unit tests** go inline in `#[cfg(test)]` modules alongside the code they
   test.
 - Follow ATDD + TDD: write acceptance tests from the story's acceptance

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ git push --follow-tags
 **Shell completions:**
 
 ```bash
-eval "$(git-std completions bash)"   # or zsh, fish
+eval "$(git-std --completions bash)"   # or zsh, fish
 ```
 
 See the [user guide](https://driftsys.github.io/git-std/)

--- a/crates/git-std/src/cli/bump/apply.rs
+++ b/crates/git-std/src/cli/bump/apply.rs
@@ -163,11 +163,14 @@ pub(super) fn finalize_bump(
             ui::info(&format!("Would tag:    {tag_prefix}{new_version}"));
         }
 
-        if let Some(remote) = &opts.push
-            && !opts.no_commit
-            && !opts.no_tag
-        {
-            ui::info(&format!("Would push to {remote}"));
+        if let Some(remote) = &opts.push {
+            if !opts.no_commit && !opts.no_tag {
+                ui::info(&format!("Would push to {remote}"));
+            } else {
+                ui::warning(&format!(
+                    "Would skip push to {remote}: incompatible with --no-commit or --no-tag"
+                ));
+            }
         }
 
         ui::blank();

--- a/crates/git-std/src/cli/bump/lifecycle.rs
+++ b/crates/git-std/src/cli/bump/lifecycle.rs
@@ -65,7 +65,7 @@ pub(super) fn run_lifecycle_hook(hook_name: &str, extra_args: &[&str]) -> Result
                 Some(code) => format!("(advisory, exit {code})"),
                 None => "(advisory, killed)".to_string(),
             };
-            ui::warning(&format!("{} {info}", cmd.command));
+            ui::info(&format!("{} {} {}", ui::warn(), cmd.command, info));
         } else {
             let info = match exit_code {
                 Some(code) => format!("(exit {code})"),

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -6,21 +6,21 @@ file is absent or a field is omitted.
 
 ## Editor schema
 
-A [JSON Schema](schema/v1/git-std.toml.json) is available
+A [JSON Schema](../schemas/v1/git-std.schema.json) is available
 for validation and autocomplete in any JSON Schema-aware
 TOML editor.
 
 Add the `$schema` key to your `.git-std.toml`:
 
 ```toml
-"$schema" = "https://driftsys.github.io/git-std/schema/v1/git-std.toml.json"
+"$schema" = "https://driftsys.github.io/git-std/schemas/v1/git-std.schema.json"
 ```
 
 Or use a [taplo](https://taplo.tamasfe.dev) inline directive
 (does not modify the file):
 
 ```toml
-#:schema https://driftsys.github.io/git-std/schema/v1/git-std.toml.json
+#:schema https://driftsys.github.io/git-std/schemas/v1/git-std.schema.json
 ```
 
 ## Full schema

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -263,7 +263,7 @@ git std doctor --format json  # machine-readable JSON on stdout
   Status
     git 2.43.0
     git-lfs 3.4.1
-    git-std 0.10.2 (update available: 0.11.0)
+    git-std 0.11.3 (update available: 0.12.0)
 
   Hooks
     commit-msg
@@ -297,9 +297,9 @@ git std doctor --format json  # machine-readable JSON on stdout
 Lightweight, scriptable version queries.
 
 ```bash
-git std version                  # 0.10.2
-git std version --describe       # 0.10.2-dev.7+g3a2b1c.dirty
-git std version --next           # 0.11.0
+git std version                  # 0.11.3
+git std version --describe       # 0.11.3-dev.7+g3a2b1c.dirty
+git std version --next           # 0.12.0
 git std version --label          # minor
 git std version --code           # 10299
 git std version --format json    # all fields as JSON

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,13 +18,13 @@ cargo install git-std
 
 ```bash
 # Bash (~/.bashrc)
-eval "$(git-std completions bash)"
+eval "$(git-std --completions bash)"
 
 # Zsh (~/.zshrc)
-eval "$(git-std completions zsh)"
+eval "$(git-std --completions zsh)"
 
 # Fish (~/.config/fish/config.fish)
-git-std completions fish | source
+git-std --completions fish | source
 ```
 
 ## Set up hooks

--- a/schemas/v1/git-std.schema.json
+++ b/schemas/v1/git-std.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://driftsys.github.io/git-std/schema/v1/git-std.toml.json",
+  "$id": "https://driftsys.github.io/git-std/schemas/v1/git-std.schema.json",
   "title": "git-std configuration",
   "description": "Schema for .git-std.toml — the configuration file for git-std, a single CLI that replaces commitizen, commitlint, standard-version, husky, and lefthook.",
   "type": "object",


### PR DESCRIPTION
## Summary

- Move JSON Schema from `docs/schema/v1/git-std.toml.json` → `schemas/v1/git-std.schema.json` with canonical public URL `driftsys.github.io/git-std/schemas/v1/git-std.schema.json`
- Update `docs.yml` CI to copy `schemas/` into the mdbook output so the schema is served at the correct path
- Fix `--completions` flag syntax in README and getting-started (was `git-std completions bash`, should be `git-std --completions bash`)
- Update AGENTS.md: 8 → 10 subcommands, add `doctor` / `version` / `config` rows to the table
- Update CONTRIBUTING.md: fix stale `git2` reference → git CLI subprocess calls; fix test layer paths (`spec/` vs `tests/`)
- Update USAGE.md: bump example versions from 0.10.x → 0.11.3
- Fix dry-run push message when `--no-commit`/`--no-tag` also set — now shows a warning instead of silently omitting
- Fix advisory hook output in lifecycle runner to use the warn symbol consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)