### PR TITLE
feat(ecosystem): wire project manifest ecosystem for bump

### DIFF
--- a/crates/git-std/src/ecosystem/mod.rs
+++ b/crates/git-std/src/ecosystem/mod.rs
@@ -10,6 +10,7 @@ mod flutter;
 mod gradle;
 mod node;
 mod plain;
+mod project;
 mod python;
 mod rust;
 
@@ -215,6 +216,7 @@ fn all_ecosystems() -> Vec<Box<dyn Ecosystem>> {
         Box::new(python::Python),
         Box::new(flutter::Flutter),
         Box::new(gradle::Gradle),
+        Box::new(project::Project),
         Box::new(plain::Plain),
     ]
 }

--- a/crates/git-std/src/ecosystem/project.rs
+++ b/crates/git-std/src/ecosystem/project.rs
@@ -1,0 +1,104 @@
+//! Project manifest ecosystem.
+//!
+//! Supports `project.toml`, `project.json`, and `project.yaml` — the
+//! driftsys project manifest format. No ecosystem tooling; always uses
+//! native string manipulation. No lock file to sync.
+
+use std::path::Path;
+
+use standard_version::{
+    ProjectJsonVersionFile, ProjectTomlVersionFile, ProjectYamlVersionFile, VersionFile,
+    VersionFileError,
+};
+
+use super::{Ecosystem, SyncOutcome, WriteOutcome, native_write};
+
+pub struct Project;
+
+impl Ecosystem for Project {
+    fn name(&self) -> &'static str {
+        "project"
+    }
+
+    fn detect(&self, root: &Path) -> bool {
+        root.join("project.toml").exists()
+            || root.join("project.json").exists()
+            || root.join("project.yaml").exists()
+    }
+
+    fn version_files(&self) -> &[&str] {
+        &["project.toml", "project.json", "project.yaml"]
+    }
+
+    fn write_version(&self, root: &Path, new_version: &str) -> WriteOutcome {
+        let engines: [&dyn VersionFile; 3] = [
+            &ProjectTomlVersionFile,
+            &ProjectJsonVersionFile,
+            &ProjectYamlVersionFile,
+        ];
+        let mut all_results = Vec::new();
+        for engine in engines {
+            if let WriteOutcome::Fallback { results } = native_write(root, engine, new_version) {
+                all_results.extend(results);
+            }
+        }
+        if all_results.is_empty() {
+            WriteOutcome::NotDetected
+        } else {
+            WriteOutcome::Fallback {
+                results: all_results,
+            }
+        }
+    }
+
+    fn sync_lock(&self, _root: &Path) -> Vec<SyncOutcome> {
+        vec![SyncOutcome::NoLockFile]
+    }
+
+    fn version_file_engine(&self) -> Option<Box<dyn VersionFile>> {
+        Some(Box::new(ProjectMultiVersionFile))
+    }
+}
+
+/// Combined version file engine used for dry-run detection across all three
+/// project manifest formats.
+///
+/// Detection and reading dispatch by content, since TOML, JSON, and YAML
+/// patterns are mutually exclusive.
+struct ProjectMultiVersionFile;
+
+impl VersionFile for ProjectMultiVersionFile {
+    fn name(&self) -> &str {
+        "project"
+    }
+
+    fn filenames(&self) -> &[&str] {
+        &["project.toml", "project.json", "project.yaml"]
+    }
+
+    fn detect(&self, content: &str) -> bool {
+        ProjectTomlVersionFile.detect(content)
+            || ProjectJsonVersionFile.detect(content)
+            || ProjectYamlVersionFile.detect(content)
+    }
+
+    fn read_version(&self, content: &str) -> Option<String> {
+        ProjectTomlVersionFile
+            .read_version(content)
+            .or_else(|| ProjectJsonVersionFile.read_version(content))
+            .or_else(|| ProjectYamlVersionFile.read_version(content))
+    }
+
+    fn write_version(&self, content: &str, new_version: &str) -> Result<String, VersionFileError> {
+        if ProjectTomlVersionFile.detect(content) {
+            return ProjectTomlVersionFile.write_version(content, new_version);
+        }
+        if ProjectJsonVersionFile.detect(content) {
+            return ProjectJsonVersionFile.write_version(content, new_version);
+        }
+        if ProjectYamlVersionFile.detect(content) {
+            return ProjectYamlVersionFile.write_version(content, new_version);
+        }
+        Err(VersionFileError::NoVersionField)
+    }
+}

--- a/spec/support/mod.rs
+++ b/spec/support/mod.rs
@@ -92,6 +92,42 @@ impl TestRepo {
         self
     }
 
+    /// Write a minimal `project.toml` with the given version.
+    // Used by: spec/tests/bump.rs (not referenced in every test binary)
+    #[allow(dead_code)]
+    pub fn with_project_toml(self, version: &str) -> Self {
+        std::fs::write(
+            self.dir.path().join("project.toml"),
+            format!("name = \"io.driftsys.test\"\nversion = \"{version}\"\nlicense = \"MIT\"\n"),
+        )
+        .expect("failed to write project.toml");
+        self
+    }
+
+    /// Write a minimal `project.json` with the given version.
+    // Used by: spec/tests/bump.rs (not referenced in every test binary)
+    #[allow(dead_code)]
+    pub fn with_project_json(self, version: &str) -> Self {
+        std::fs::write(
+            self.dir.path().join("project.json"),
+            format!("{{\n  \"name\": \"io.driftsys.test\",\n  \"version\": \"{version}\"\n}}\n"),
+        )
+        .expect("failed to write project.json");
+        self
+    }
+
+    /// Write a minimal `project.yaml` with the given version.
+    // Used by: spec/tests/bump.rs (not referenced in every test binary)
+    #[allow(dead_code)]
+    pub fn with_project_yaml(self, version: &str) -> Self {
+        std::fs::write(
+            self.dir.path().join("project.yaml"),
+            format!("name: io.driftsys.test\nversion: \"{version}\"\nlicense: MIT\n"),
+        )
+        .expect("failed to write project.yaml");
+        self
+    }
+
     /// Create a file, stage it, and commit with the given message.
     // Used by: spec/tests/hooks.rs (not referenced in every test binary)
     #[allow(dead_code)]

--- a/spec/tests/bump.rs
+++ b/spec/tests/bump.rs
@@ -444,6 +444,90 @@ fn bump_push_to_local_remote() {
     );
 }
 
+/// `project.toml` version field is updated during bump.
+#[test]
+fn bump_project_toml() {
+    let mut repo = TestRepo::new().with_project_toml("1.0.0");
+    repo.add_commit("chore: init");
+    repo.create_tag("v1.0.0");
+    repo.add_commit("feat: new feature");
+
+    Command::new(TestRepo::bin_path())
+        .args(["bump", "--skip-changelog"])
+        .current_dir(repo.path())
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(repo.path().join("project.toml")).unwrap();
+    assert!(
+        content.contains("version = \"1.1.0\""),
+        "expected version 1.1.0 in project.toml, got: {content}"
+    );
+}
+
+/// `project.json` version field is updated during bump.
+#[test]
+fn bump_project_json() {
+    let mut repo = TestRepo::new().with_project_json("1.0.0");
+    repo.add_commit("chore: init");
+    repo.create_tag("v1.0.0");
+    repo.add_commit("feat: new feature");
+
+    Command::new(TestRepo::bin_path())
+        .args(["bump", "--skip-changelog"])
+        .current_dir(repo.path())
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(repo.path().join("project.json")).unwrap();
+    assert!(
+        content.contains("\"version\": \"1.1.0\""),
+        "expected version 1.1.0 in project.json, got: {content}"
+    );
+}
+
+/// `project.yaml` version field is updated during bump.
+#[test]
+fn bump_project_yaml() {
+    let mut repo = TestRepo::new().with_project_yaml("1.0.0");
+    repo.add_commit("chore: init");
+    repo.create_tag("v1.0.0");
+    repo.add_commit("feat: new feature");
+
+    Command::new(TestRepo::bin_path())
+        .args(["bump", "--skip-changelog"])
+        .current_dir(repo.path())
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(repo.path().join("project.yaml")).unwrap();
+    assert!(
+        content.contains("version: \"1.1.0\""),
+        "expected version 1.1.0 in project.yaml, got: {content}"
+    );
+}
+
+/// `--dry-run` lists `project.toml` under "Would update:".
+#[test]
+fn bump_project_toml_dry_run() {
+    let mut repo = TestRepo::new().with_project_toml("1.0.0");
+    repo.add_commit("chore: init");
+    repo.create_tag("v1.0.0");
+    repo.add_commit("feat: new feature");
+
+    let output = std::process::Command::new(TestRepo::bin_path())
+        .args(["bump", "--dry-run"])
+        .current_dir(repo.path())
+        .output()
+        .expect("failed to run");
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("project.toml"),
+        "expected project.toml in dry-run output, stderr was: {stderr}"
+    );
+}
+
 /// `--push` with a nonexistent remote exits non-zero.
 #[test]
 fn bump_push_failure_exits_nonzero() {


### PR DESCRIPTION
## Summary

- Registers `Project` ecosystem in `git-std` using the existing `ProjectTomlVersionFile`, `ProjectJsonVersionFile`, and `ProjectYamlVersionFile` engines from `standard-version` (added in #358)
- All three formats updated during `git std bump` — zero-config, no `.git-std.toml` entry needed
- `--dry-run` lists whichever project manifest is present via a `ProjectMultiVersionFile` adapter that dispatches detect/read by content
- No lock file sync (project manifests have no associated lock file)

## Test plan

- [x] `bump_project_toml` — verifies `project.toml` version written after bump
- [x] `bump_project_json` — verifies `project.json` version written after bump
- [x] `bump_project_yaml` — verifies `project.yaml` version written after bump
- [x] `bump_project_toml_dry_run` — verifies `project.toml` appears in `--dry-run` output
- [x] `just check` passes (pre-existing `init_creates_shims` snapshot failure unrelated)

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)