### PR TITLE
feat(git-std): complete agent skills scaffolding acceptance criteria

### DIFF
--- a/crates/git-std/src/cli/init/mod.rs
+++ b/crates/git-std/src/cli/init/mod.rs
@@ -268,12 +268,7 @@ pub fn run(force: bool) -> i32 {
                     ui::pass()
                 ));
             }
-            FileResult::Skipped => {
-                ui::info(&format!(
-                    "{}  {skill_dir}/SKILL.md already exists (use --force to overwrite)",
-                    ui::warn()
-                ));
-            }
+            FileResult::Skipped => {}
             FileResult::Error => return 1,
         }
         // Create symlink in .claude/skills/<name> → ../../.agents/skills/<name>

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -165,8 +165,9 @@ git std init --force    # overwrite existing files
 5. Generates `./bootstrap` script.
 6. Generates `.githooks/bootstrap.hooks`.
 7. Creates `.git-std.toml` with taplo schema directive (if absent).
-8. Appends post-clone section to `README.md` and `AGENTS.md` (if found).
-9. Stages all created files.
+8. Scaffolds agent skills in `.agents/skills/` with `.claude/skills/` symlinks.
+9. Appends post-clone section to `README.md` and `AGENTS.md` (if found).
+10. Stages all created files.
 
 **Flags:**
 


### PR DESCRIPTION
Closes #460

## Changes

- **Silence skip message** — `git std init` now skips existing skills silently instead of printing a warning (AC #5).
- **Document scaffolding in USAGE.md** — Added Step 8 (agent skills) to the `git std init` docs (AC #7).

## Acceptance criteria status

All 7 criteria from #460 are now satisfied:

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Creates `.agents/skills/std-commit/SKILL.md` when absent | ✅ (symlink to source) |
| 2 | Creates `.claude/skills/std-commit` symlink when absent | ✅ |
| 3 | Symlink target is `../../.agents/skills/std-commit` (relative) | ✅ |
| 4 | Both paths staged by final `git add` | ✅ |
| 5 | Skips silently if already exists | ✅ (this PR) |
| 6 | `--force` overwrites and recreates | ✅ |
| 7 | `docs/USAGE.md` documents scaffolded files | ✅ (this PR) |
