### PR TITLE
test(git-std): add integration test for version --describe with dirty tree

### DIFF
--- a/crates/git-std/tests/version.rs
+++ b/crates/git-std/tests/version.rs
@@ -163,6 +163,30 @@ fn version_describe_ahead_includes_distance_and_hash() {
     );
 }
 
+#[test]
+fn version_describe_dirty_tree() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    create_tag(dir.path(), "v1.0.0");
+
+    // Create an unstaged file to make the tree dirty
+    std::fs::write(dir.path().join("dirty.txt"), "uncommitted").unwrap();
+
+    let output = git_std(dir.path())
+        .args(["version", "--describe"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8_lossy(&output).trim().to_string();
+
+    assert!(
+        text.ends_with(".dirty"),
+        "describe should end with .dirty for dirty tree, got: {text}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // --next
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #421

Adds `version_describe_dirty_tree` integration test that:
1. Initialises a repo with a version tag
2. Writes a file without staging it (dirty tree)
3. Asserts `git std version --describe` output ends with `.dirty`

Fully isolated via `tempdir`.