### PR TITLE
refactor(git-std): extract shared exec_sh primitives from hook runner

### DIFF
--- a/crates/git-std/src/cli/bump/lifecycle.rs
+++ b/crates/git-std/src/cli/bump/lifecycle.rs
@@ -1,7 +1,6 @@
-use std::process::Command;
+use standard_githooks::Prefix;
 
-use standard_githooks::{HookCommand, Prefix};
-
+use crate::cli::hook::exec_sh;
 use crate::{git, ui};
 
 /// Run a bump lifecycle hook file (`.githooks/<hook>.hooks`).
@@ -54,7 +53,7 @@ pub(super) fn run_lifecycle_hook(hook_name: &str, extra_args: &[&str]) -> Result
     }
 
     for cmd in &commands {
-        let exit_code = execute_hook_command(cmd, extra_args);
+        let exit_code = exec_sh(&cmd.command, extra_args);
         let success = exit_code == Some(0);
         let is_advisory = cmd.prefix == Prefix::Advisory;
 
@@ -80,19 +79,4 @@ pub(super) fn run_lifecycle_hook(hook_name: &str, extra_args: &[&str]) -> Result
     }
 
     Ok(())
-}
-
-/// Execute a single hook command and return its exit code.
-fn execute_hook_command(cmd: &HookCommand, extra_args: &[&str]) -> Option<i32> {
-    let status = Command::new("sh")
-        .arg("-c")
-        .arg(&cmd.command)
-        .arg("_")
-        .args(extra_args)
-        .status();
-
-    match status {
-        Ok(s) => s.code(),
-        Err(_) => Some(127),
-    }
 }

--- a/crates/git-std/src/cli/hook/mod.rs
+++ b/crates/git-std/src/cli/hook/mod.rs
@@ -8,10 +8,50 @@ pub use list::list;
 pub use run::run;
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use standard_githooks::HookCommand;
 
 use crate::{git, ui};
+
+/// Execute a shell command via `sh -c`, passing extra positional args.
+///
+/// Returns the exit code, or `Some(127)` on spawn failure.
+pub(crate) fn exec_sh(command: &str, args: &[impl AsRef<std::ffi::OsStr>]) -> Option<i32> {
+    let status = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .arg("_")
+        .args(args)
+        .status();
+    match status {
+        Ok(s) => s.code(),
+        Err(_) => Some(127),
+    }
+}
+
+/// Execute a shell command via `sh -c`, capturing stdout+stderr.
+///
+/// Returns `(exit_code, combined_output)`.
+pub(crate) fn exec_sh_capture(
+    command: &str,
+    args: &[impl AsRef<std::ffi::OsStr>],
+) -> (Option<i32>, String) {
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .arg("_")
+        .args(args)
+        .output();
+    match output {
+        Ok(o) => {
+            let mut combined = String::from_utf8_lossy(&o.stdout).into_owned();
+            combined.push_str(&String::from_utf8_lossy(&o.stderr));
+            (o.status.code(), combined.trim_end().to_string())
+        }
+        Err(_) => (Some(127), String::new()),
+    }
+}
 
 /// Resolve the `.githooks/` directory from the repository root.
 ///

--- a/crates/git-std/src/cli/hook/run.rs
+++ b/crates/git-std/src/cli/hook/run.rs
@@ -100,47 +100,16 @@ fn execute_and_print(
     let (exit_code, captured) = if !quiet && ui::is_tty() {
         // TTY: use spinner and capture output to show only on failure
         ui::spin_while(&display, || {
-            let output = Command::new("sh")
-                .arg("-c")
-                .arg(&command_text)
-                .arg("_")
-                .args(staged_files)
-                .output();
-            match output {
-                Ok(o) => {
-                    let mut combined = String::from_utf8_lossy(&o.stdout).into_owned();
-                    combined.push_str(&String::from_utf8_lossy(&o.stderr));
-                    (o.status.code(), combined.trim_end().to_string())
-                }
-                Err(_) => (Some(127), String::new()),
-            }
+            super::exec_sh_capture(&command_text, staged_files)
         })
     } else if !quiet {
         // Non-TTY: show pending, let output inherit, print result
         ui::pending_non_tty(&display);
-        let status = Command::new("sh")
-            .arg("-c")
-            .arg(&command_text)
-            .arg("_")
-            .args(staged_files)
-            .status();
-        let code = match status {
-            Ok(s) => s.code(),
-            Err(_) => Some(127),
-        };
+        let code = super::exec_sh(&command_text, staged_files);
         (code, String::new())
     } else {
         // JSON / quiet mode: no spinner, no output capture or display.
-        let status = Command::new("sh")
-            .arg("-c")
-            .arg(&command_text)
-            .arg("_")
-            .args(staged_files)
-            .status();
-        let code = match status {
-            Ok(s) => s.code(),
-            Err(_) => Some(127),
-        };
+        let code = super::exec_sh(&command_text, staged_files);
         (code, String::new())
     };
 


### PR DESCRIPTION
Closes #427

Extracts `exec_sh` and `exec_sh_capture` into `cli::hook` module as `pub(crate)` primitives, replacing the duplicated `sh -c` invocation pattern in:

- `cli/bump/lifecycle.rs` — removed `execute_hook_command`, now calls `exec_sh`
- `cli/hook/run.rs` — replaced 3 inline `Command::new("sh")` blocks with `exec_sh`/`exec_sh_capture`

The spinner/stash/glob/output concerns remain in `hook/run.rs` only — the shared primitives cover only bare execution.