### PR TITLE
refactor(git-std): remove unused captured_output field from CommandResult

### DIFF
--- a/crates/git-std/src/cli/hook/run.rs
+++ b/crates/git-std/src/cli/hook/run.rs
@@ -17,11 +17,6 @@ struct CommandResult {
     exit_code: Option<i32>,
     /// Whether this command was advisory.
     advisory: bool,
-    /// Combined stdout+stderr captured from the child process.
-    /// Empty when the command succeeded (pass) or when quiet=true.
-    /// Used only in human-readable output path, not in JSON path.
-    #[allow(dead_code)]
-    captured_output: String,
 }
 
 /// JSON output schema for a single executed command.
@@ -149,7 +144,6 @@ fn execute_and_print(
         CommandResult {
             exit_code,
             advisory: is_advisory,
-            captured_output: if quiet { String::new() } else { captured },
         },
         failed,
     )


### PR DESCRIPTION
Closes #485

## What
Remove the unused `captured_output` field from `CommandResult` in `hook/run.rs`.

The field was populated but never read after construction — the captured output is already printed inline at the call site (lines 138-143). The `#[allow(dead_code)]` suppression violated the project's zero-warnings convention.

## Changes
- Removed `captured_output: String` field and its doc comments
- Removed `#[allow(dead_code)]` annotation
- Removed the field initialization at the construction site