### PR TITLE
docs(git-std): fix USAGE.md and CONFIG.md consistency with implementation

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -34,6 +34,8 @@ types = ["feat", "fix", "docs", "style",
 scopes = ["auth", "api", "ci", "deps"]         # "auto" | string[] | omit
 strict = true                         # enforce types/scopes
 monorepo = false                      # per-package versioning
+release_branch = "main"               # expected branch for bumps
+refs_required = ["feat", "fix"]       # types that require a footer ref
 
 # ── Versioning ────────────────────────────────────────────────────
 [versioning]
@@ -71,13 +73,15 @@ path = "crates/core"
 
 ### Top-level
 
-| Field      | Type                 | Default           | Description                                             |
-| ---------- | -------------------- | ----------------- | ------------------------------------------------------- |
-| `scheme`   | string               | `"semver"`        | Versioning scheme (see below)                           |
-| `types`    | string[]             | 11 standard types | Allowed conventional commit types                       |
-| `scopes`   | `"auto"` or string[] | None              | Scope discovery or explicit allowlist                   |
-| `strict`   | bool                 | `false`           | Enforce types/scopes validation without `--strict` flag |
-| `monorepo` | bool                 | `false`           | Enable per-package versioning                           |
+| Field            | Type                 | Default           | Description                                             |
+| ---------------- | -------------------- | ----------------- | ------------------------------------------------------- |
+| `scheme`         | string               | `"semver"`        | Versioning scheme (see below)                           |
+| `types`          | string[]             | 11 standard types | Allowed conventional commit types                       |
+| `scopes`         | `"auto"` or string[] | None              | Scope discovery or explicit allowlist                   |
+| `strict`         | bool                 | `false`           | Enforce types/scopes validation without `--strict` flag |
+| `monorepo`       | bool                 | `false`           | Enable per-package versioning                           |
+| `release_branch` | string               | _(none)_          | Branch that `git std bump` is expected to run on        |
+| `refs_required`  | string[]             | `[]`              | Commit types that require a footer reference            |
 
 Default types: `feat`, `fix`, `docs`, `style`, `refactor`,
 `perf`, `test`, `chore`, `ci`, `build`, `revert`.
@@ -106,6 +110,15 @@ When scopes is set (either `"auto"` or an array) and
 `--strict` is used, a scope is required and must be in the
 resolved list. For `git std commit`, the resolved scopes
 populate the interactive scope prompt.
+
+**`release_branch`:** When set, bumping on a different branch
+triggers a confirmation prompt (or an error in non-interactive
+mode unless `--yes` is supplied). When unset, both `main` and
+`master` are accepted without prompting.
+
+**`refs_required`:** Types listed here must include a footer
+reference (e.g. `Refs: #123`). Validated during `git std lint`
+with `--strict`.
 
 ### `[versioning]`
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -219,7 +219,6 @@ configures the local environment.
 ```bash
 git std bootstrap              # run built-in checks + bootstrap.hooks
 git std bootstrap --dry-run    # print what would be done
-git std bootstrap install      # scaffold bootstrap files for contributors
 ```
 
 **Built-in checks:**
@@ -232,13 +231,7 @@ git std bootstrap install      # scaffold bootstrap files for contributors
 
 After built-in checks, runs `.githooks/bootstrap.hooks` if present.
 
-**`bootstrap install` flags:**
-
-| Flag      | Description              |
-| --------- | ------------------------ |
-| `--force` | Overwrite existing files |
-
-**`bootstrap` flags:**
+**Flags:**
 
 | Flag        | Description                             |
 | ----------- | --------------------------------------- |
@@ -348,52 +341,6 @@ eval "$(git-std --completions zsh)"
 
 # Fish (~/.config/fish/config.fish)
 git-std --completions fish | source
-```
-
-## `git std config`
-
-Inspect effective configuration loaded from `.git-std.toml`.
-
-```bash
-git std config list              # print all settings with source annotations
-git std config list --format json  # machine-readable JSON on stdout
-git std config get <key>         # print a single value to stdout
-git std config get <key> --format json  # value as JSON
-```
-
-**Subcommands:**
-
-| Subcommand  | Description                                   |
-| ----------- | --------------------------------------------- |
-| `list`      | Print all effective config grouped by section |
-| `get <key>` | Print a single dot-separated key value        |
-
-**Flags (list and get):**
-
-| Flag             | Description                             |
-| ---------------- | --------------------------------------- |
-| `--format <fmt>` | Output format: `text` (default), `json` |
-
-**Supported keys for `get`:**
-
-`scheme`, `strict`, `types`, `scopes`,
-`versioning.tag_prefix`, `versioning.prerelease_tag`, `versioning.calver_format`,
-`changelog.title`, `changelog.hidden`, `changelog.sections`, `changelog.bug_url`
-
-**Exit codes:** `0` = success, `1` = unknown key or error.
-
-**Example output:**
-
-```text
-$ git std config list
-  scheme = semver                            (default)
-  strict = false                             (default)
-  types = [feat, fix, docs, ...]             (default)
-  scopes = none                              (default)
-
-  [versioning]
-  tag_prefix = v                             (default)
-  ...
 ```
 
 ## Update Check


### PR DESCRIPTION
## What
Fix documentation inconsistencies found during cross-referencing docs with the actual CLI implementation.

### USAGE.md
- **Removed** `git std config` section — command is not implemented (code exists in `cli/config.rs` but not wired into `app.rs`/`main.rs`)
- **Removed** `bootstrap install` subcommand — not implemented; `bootstrap` only has `--dry-run`

### CONFIG.md
- **Added** `release_branch` field — branch that `git std bump` expects to run on; triggers confirmation prompt on other branches
- **Added** `refs_required` field — commit types that require a footer reference during strict linting
- Updated full schema example to include both new fields