### PR TITLE
test(git-std): remove captured_output dead field and add calver tests

### DIFF
--- a/crates/git-std/src/cli/hook/run.rs
+++ b/crates/git-std/src/cli/hook/run.rs
@@ -17,11 +17,6 @@ struct CommandResult {
     exit_code: Option<i32>,
     /// Whether this command was advisory.
     advisory: bool,
-    /// Combined stdout+stderr captured from the child process.
-    /// Empty when the command succeeded (pass) or when quiet=true.
-    /// Used only in human-readable output path, not in JSON path.
-    #[allow(dead_code)]
-    captured_output: String,
 }
 
 /// JSON output schema for a single executed command.
@@ -149,7 +144,6 @@ fn execute_and_print(
         CommandResult {
             exit_code,
             advisory: is_advisory,
-            captured_output: if quiet { String::new() } else { captured },
         },
         failed,
     )

--- a/crates/git-std/src/cli/version.rs
+++ b/crates/git-std/src/cli/version.rs
@@ -621,4 +621,48 @@ mod tests {
     fn calver_code_invalid() {
         assert!(calver_code("notaversion").is_err());
     }
+
+    #[test]
+    fn calver_code_prerelease_segment_uses_last_numeric() {
+        // "2026.3.1-rc.1" splits as ["2026","3","1","rc","1"]; micro = 1
+        let days = days_since_epoch(2026, 3, 1);
+        let expected = days as u64 * 10_000 + 1 * 100 + 99;
+        assert_eq!(calver_code("2026.3.1-rc.1").unwrap(), expected);
+    }
+
+    #[test]
+    fn calver_code_leap_year_feb() {
+        // 2024 is a leap year — Feb 1 2024 should parse without error.
+        assert!(calver_code("2024.2.0").is_ok());
+    }
+
+    #[test]
+    fn calver_code_year_rollover_ordering() {
+        // Dec 2025 code must be less than Jan 2026 code.
+        let dec = calver_code("2025.12.0").unwrap();
+        let jan = calver_code("2026.1.0").unwrap();
+        assert!(dec < jan, "dec={dec} should be less than jan={jan}");
+    }
+
+    #[test]
+    fn calver_code_invalid_year() {
+        assert!(calver_code("XXXX.3.1").is_err());
+    }
+
+    #[test]
+    fn calver_code_invalid_month() {
+        assert!(calver_code("2026.X.1").is_err());
+    }
+
+    #[test]
+    fn calver_code_invalid_micro() {
+        assert!(calver_code("2026.3.X").is_err());
+    }
+
+    #[test]
+    fn calver_code_two_digit_year_adjusted() {
+        // year=26 → full_year=2026; same as 4-digit 2026.
+        let expected = calver_code("2026.3.0").unwrap();
+        assert_eq!(calver_code("26.3.0").unwrap(), expected);
+    }
 }

--- a/crates/git-std/tests/version.rs
+++ b/crates/git-std/tests/version.rs
@@ -403,3 +403,149 @@ fn version_multiple_flags_each_printed() {
     assert_eq!(lines[0], "1.1.0");
     assert_eq!(lines[1], "minor");
 }
+
+// ---------------------------------------------------------------------------
+// Calver
+// ---------------------------------------------------------------------------
+
+fn init_calver_repo(dir: &Path) {
+    init_repo(dir);
+    std::fs::write(dir.join(".git-std.toml"), "scheme = \"calver\"\n").unwrap();
+    git(dir, &["add", ".git-std.toml"]);
+    git(dir, &["commit", "-m", "chore: add calver config"]);
+}
+
+#[test]
+fn version_calver_bare_prints_current() {
+    let dir = tempfile::tempdir().unwrap();
+    init_calver_repo(dir.path());
+    create_tag(dir.path(), "v2026.3.0");
+
+    git_std(dir.path())
+        .arg("version")
+        .assert()
+        .success()
+        .stdout("2026.3.0\n");
+}
+
+#[test]
+fn version_calver_no_tag_exits_with_error() {
+    let dir = tempfile::tempdir().unwrap();
+    init_calver_repo(dir.path());
+
+    git_std(dir.path())
+        .arg("version")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no version tag found"));
+}
+
+#[test]
+fn version_calver_code_is_integer() {
+    let dir = tempfile::tempdir().unwrap();
+    init_calver_repo(dir.path());
+    create_tag(dir.path(), "v2026.3.0");
+
+    let output = git_std(dir.path())
+        .args(["version", "--code"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8_lossy(&output).trim().to_string();
+    assert!(
+        text.parse::<u64>().is_ok(),
+        "--code output should be an integer for calver, got: {text}"
+    );
+}
+
+#[test]
+fn version_calver_label_is_calver() {
+    let dir = tempfile::tempdir().unwrap();
+    init_calver_repo(dir.path());
+    create_tag(dir.path(), "v2026.3.0");
+
+    git_std(dir.path())
+        .args(["version", "--label"])
+        .assert()
+        .success()
+        .stdout("calver\n");
+}
+
+#[test]
+fn version_calver_next_prints_next_version() {
+    let dir = tempfile::tempdir().unwrap();
+    init_calver_repo(dir.path());
+    create_tag(dir.path(), "v2026.3.0");
+    add_commit(dir.path(), "a.txt", "feat: new feature");
+
+    // --next should succeed and print a non-empty version string.
+    let output = git_std(dir.path())
+        .args(["version", "--next"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8_lossy(&output).trim().to_string();
+    assert!(!text.is_empty(), "--next should print a version string");
+}
+
+#[test]
+fn version_calver_format_json_has_all_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    init_calver_repo(dir.path());
+    create_tag(dir.path(), "v2026.3.0");
+    add_commit(dir.path(), "a.txt", "feat: feature");
+
+    let output = git_std(dir.path())
+        .args(["version", "--format", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let text = String::from_utf8_lossy(&output);
+    let val: serde_json::Value = serde_json::from_str(text.trim()).expect("valid JSON");
+
+    assert_eq!(val["version"], "2026.3.0");
+    assert_eq!(val["label"], "calver");
+    assert!(val["next"].is_string(), "next should be a string");
+    assert!(val["code"].is_number(), "code should be a number");
+}
+
+#[test]
+fn version_calver_describe_at_tag_is_clean() {
+    let dir = tempfile::tempdir().unwrap();
+    init_calver_repo(dir.path());
+    create_tag(dir.path(), "v2026.3.0");
+
+    git_std(dir.path())
+        .args(["version", "--describe"])
+        .assert()
+        .success()
+        .stdout("2026.3.0\n");
+}
+
+#[test]
+fn version_calver_describe_ahead_includes_distance() {
+    let dir = tempfile::tempdir().unwrap();
+    init_calver_repo(dir.path());
+    create_tag(dir.path(), "v2026.3.0");
+    add_commit(dir.path(), "a.txt", "feat: something");
+
+    let output = git_std(dir.path())
+        .args(["version", "--describe"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8_lossy(&output).trim().to_string();
+    assert!(
+        text.starts_with("2026.3.0-dev.1+g"),
+        "describe should have -dev.1+g prefix, got: {text}"
+    );
+}


### PR DESCRIPTION
Closes #485, #487, #484

## Summary

- **#485** — Removed the unused `captured_output` field from `CommandResult` in `hook/run.rs` and deleted the `#[allow(dead_code)]` suppression. The `captured` local variable inside `execute_and_print` still exists and correctly prints failure output; only the redundant struct field was removed.
- **#487** — Added 7 unit tests for `calver_code()` in `version.rs` covering prerelease segments, leap-year February, year-rollover ordering, invalid year/month/MICRO inputs, and 2-digit year adjustment.
- **#484** — Added 8 calver integration tests in `tests/version.rs` covering bare version output, no-tag error, `--code`, `--label`, `--next`, `--format json`, `--describe` at tag, and `--describe` ahead of tag.

## Checklist

- [x] `just check` passes (all tests green, clippy clean, audit clean)
- [x] No `#[allow(...)]` suppressions added
- [x] One commit