### PR TITLE
docs(git-std): hide internal SPEC from published book

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,5 +6,4 @@
 - [Recipes](recipes.md)
 - [Configuration](CONFIG.md)
 - [Skills](skills.md)
-- [Specification](SPEC.md)
 - [API Reference](REFERENCE.md)


### PR DESCRIPTION
## Summary

- Removes \`Specification\` from \`docs/SUMMARY.md\` so \`SPEC.md\` no longer appears in the published mdBook sidebar.
- The file itself stays in \`docs/\` for contributors and is still reachable via the repo.
- The book is for users; SPEC is for contributors — keeping them separate reduces noise on the public site.

## Verification

- Local \`mdbook build\` succeeds with no warnings (no orphan-file complaint).
- \`grep\` confirms no other doc page links to \`SPEC.md\`.
- \`just check\` is green.

## Checklist

- [x] \`just check\` passes
- [x] One commit, conventional commit format