### PR TITLE
fix(git-std): isolate pre-commit stash from the shared worktree stack

### DIFF
--- a/crates/git-std/src/cli/hook/run.rs
+++ b/crates/git-std/src/cli/hook/run.rs
@@ -262,19 +262,24 @@ pub fn run(hook: &str, args: &[String], format: OutputFormat) -> i32 {
     };
 
     // Perform the stash dance if needed.
-    // stash_active tracks whether a stash entry was actually created.
-    let stash_active = if use_stash_dance {
+    // `hook_stash` holds the SHA of the stash this hook created, or `None`
+    // when nothing was stashed. It is used to apply and drop only the
+    // hook's own stash, never one left on the shared stack by another
+    // worktree (#511).
+    let hook_stash = if use_stash_dance {
         stash::stash_push()
-        // If stash_push returns false (nothing to stash or error), we skip
+        // If stash_push returns None (nothing to stash or error), we skip
         // the stash dance but still run commands normally.
     } else {
-        false
+        None
     };
 
-    if use_stash_dance && stash_active && !stash::stash_apply() {
+    if let Some(ref stash_sha) = hook_stash
+        && !stash::stash_apply(stash_sha)
+    {
         ui::error("stash apply failed — working tree has conflicting unstaged changes");
         ui::hint("commit or stash your unstaged changes first, then retry");
-        stash::stash_drop();
+        stash::stash_drop(stash_sha);
         print_failure_hints(hook);
         return 1;
     }
@@ -358,15 +363,15 @@ pub fn run(hook: &str, args: &[String], format: OutputFormat) -> i32 {
                 {
                     // Already returning 1 for the fail-fast failure, but
                     // ensure the stash is cleaned up before returning.
-                    if stash_active {
-                        stash::stash_drop();
+                    if let Some(ref stash_sha) = hook_stash {
+                        stash::stash_drop(stash_sha);
                     }
                     ui::blank();
                     print_failure_hints(hook);
                     return 1;
                 }
-                if stash_active {
-                    stash::stash_drop();
+                if let Some(ref stash_sha) = hook_stash {
+                    stash::stash_drop(stash_sha);
                 }
             }
 
@@ -412,14 +417,14 @@ pub fn run(hook: &str, args: &[String], format: OutputFormat) -> i32 {
         // was created (no stash means no unstaged changes to protect, but
         // re-staging is still needed to pick up formatter output).
         if !stash::restage_files(&staged_files) || !stash::restage_deletions(&staged_deletions) {
-            if stash_active {
-                stash::stash_drop();
+            if let Some(ref stash_sha) = hook_stash {
+                stash::stash_drop(stash_sha);
             }
             print_failure_hints(hook);
             return 1;
         }
 
-        if stash_active {
+        if let Some(ref stash_sha) = hook_stash {
             // Warn about any unstaged files that the formatter also touched.
             // These are files in `git diff --name-only` that were NOT in
             // the original staged set.
@@ -430,7 +435,7 @@ pub fn run(hook: &str, args: &[String], format: OutputFormat) -> i32 {
                 }
             }
 
-            stash::stash_drop();
+            stash::stash_drop(stash_sha);
         }
 
         // Re-stage renamed files after the stash dance completes.

--- a/crates/git-std/src/cli/hook/stash.rs
+++ b/crates/git-std/src/cli/hook/stash.rs
@@ -105,18 +105,54 @@ pub(super) fn has_staged_submodules() -> bool {
     }
 }
 
-/// Run `git stash push --quiet --include-untracked`. Returns `true` if the
-/// stash was created successfully (something was stashed), `false` otherwise
-/// (nothing to stash or git error).
+/// Read the commit SHA at the top of the shared stash stack, or `None`
+/// when the stack is empty.
+///
+/// Git worktrees share a single `refs/stash`, so the top may be a stash
+/// created by another worktree. Callers use this to identify the exact
+/// stash this hook created rather than trusting the positional
+/// `stash@{0}`.
+fn stash_top() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", "refs/stash"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if sha.is_empty() { None } else { Some(sha) }
+}
+
+/// Run `git stash push --quiet --include-untracked` and return the commit
+/// SHA of the stash it created, or `None` when nothing was stashed.
+///
+/// `git stash push` exits `0` even when there is nothing to stash, so its
+/// exit code cannot be used to detect stash creation. Because the stash
+/// stack is shared across all worktrees of a repository (#511), trusting
+/// the exit code would let the hook mistake an orphan stash left by
+/// another worktree for one it created — and later apply or drop it. We
+/// instead compare the top of `refs/stash` before and after: a new stash
+/// exists iff the top SHA changed.
 ///
 /// `--include-untracked` ensures formatter-generated new files are captured
 /// in the stash backup so they can be detected by the post-run diff check.
-pub(super) fn stash_push() -> bool {
-    Command::new("git")
+pub(super) fn stash_push() -> Option<String> {
+    let before = stash_top();
+    let pushed = Command::new("git")
         .args(["stash", "push", "--quiet", "--include-untracked"])
         .status()
         .map(|s| s.success())
-        .unwrap_or(false)
+        .unwrap_or(false);
+    if !pushed {
+        return None;
+    }
+    let after = stash_top();
+    if after.is_some() && after != before {
+        after
+    } else {
+        None
+    }
 }
 
 /// Get the new names of any files staged as renames.
@@ -152,18 +188,30 @@ pub(super) fn unstage_renames(rename_targets: &[String]) -> bool {
     matches!(cmd.status(), Ok(s) if s.success())
 }
 
-/// Run `git stash apply --quiet`. Returns `true` on success, `false` on
-/// failure (e.g. merge conflicts).
-pub(super) fn stash_apply() -> bool {
+/// Apply the stash identified by `stash_sha` to the working tree.
+///
+/// Applies the exact commit this hook created, never the positional
+/// `stash@{0}`, so a stash left on the shared worktree stash stack by
+/// another worktree is never applied (#511). Returns `true` on success,
+/// `false` on failure (e.g. merge conflicts).
+pub(super) fn stash_apply(stash_sha: &str) -> bool {
     Command::new("git")
-        .args(["stash", "apply", "--quiet"])
+        .args(["stash", "apply", "--quiet", stash_sha])
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
 }
 
-/// Run `git stash drop --quiet`. Warns on failure.
-pub(super) fn stash_drop() {
+/// Drop the hook's own stash entry, identified by `stash_sha`.
+///
+/// Only drops when that commit is still the top of the shared stash stack,
+/// so a stash created by another worktree is never dropped (#511). Warns if
+/// the entry is no longer on top or the drop fails.
+pub(super) fn stash_drop(stash_sha: &str) {
+    if stash_top().as_deref() != Some(stash_sha) {
+        ui::warning("hook stash is no longer at the top of the stash stack — leaving it in place");
+        return;
+    }
     let ok = Command::new("git")
         .args(["stash", "drop", "--quiet"])
         .status()

--- a/crates/git-std/tests/hooks.rs
+++ b/crates/git-std/tests/hooks.rs
@@ -1121,3 +1121,128 @@ fn hooks_run_from_subdirectory() {
         "hooks run from subdirectory should succeed and show check mark, got:\n{combined}"
     );
 }
+
+// --- Shared stash-stack isolation regression tests (#511) ---
+
+/// #511 — A fix-mode pre-commit hook must not touch a stash it did not
+/// create. Git worktrees share one stash stack (`refs/stash`); when the
+/// committing worktree has nothing to stash, `git stash push` is a no-op
+/// but exits 0. The hook must not then apply/drop whatever stash sits on
+/// top of the shared stack (e.g. an orphan stash from another worktree).
+#[test]
+fn hooks_run_fix_mode_does_not_apply_foreign_stash_when_nothing_to_stash() {
+    let dir = tempfile::tempdir().unwrap();
+    init_hooks_repo(dir.path());
+
+    // Fix-mode hook committed so the working tree can be fully clean
+    // (nothing tracked or untracked left to stash).
+    let hooks_dir = dir.path().join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    std::fs::write(hooks_dir.join("pre-commit.hooks"), "~ true\n").unwrap();
+    std::fs::write(dir.path().join("base.txt"), "base\n").unwrap();
+    git(
+        dir.path(),
+        &["add", "base.txt", ".githooks/pre-commit.hooks"],
+    );
+    git(dir.path(), &["commit", "-m", "base"]);
+
+    // Simulate an orphan stash left on the shared stack by another worktree.
+    std::fs::write(dir.path().join("foreign.txt"), "foreign\n").unwrap();
+    git(dir.path(), &["add", "foreign.txt"]);
+    git(dir.path(), &["stash", "push", "--include-untracked"]);
+    let stash_before = git(dir.path(), &["stash", "list"]);
+    assert!(
+        stash_before.contains("stash@{0}"),
+        "precondition: orphan stash should be on the stack, got:\n{stash_before}"
+    );
+
+    // Precondition: the working tree is completely clean — nothing to stash.
+    let clean = git(dir.path(), &["status", "--porcelain"]);
+    assert!(
+        clean.is_empty(),
+        "precondition: tree must be clean, got:\n{clean}"
+    );
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["--color", "never", "hook", "run", "pre-commit"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // The orphan stash must be untouched.
+    let stash_after = git(dir.path(), &["stash", "list"]);
+    assert_eq!(
+        stash_before, stash_after,
+        "the foreign stash must not be dropped or altered, got:\n{stash_after}"
+    );
+
+    // The orphan stash's file must not be dumped into the working tree.
+    assert!(
+        !dir.path().join("foreign.txt").exists(),
+        "foreign stash contents must not be applied into the working tree"
+    );
+
+    // The working tree must remain clean.
+    let status = git(dir.path(), &["status", "--porcelain"]);
+    assert!(
+        status.is_empty(),
+        "working tree should be clean after the hook, got:\n{status}"
+    );
+}
+
+/// #511 — With a foreign stash on the shared stack AND real staged changes,
+/// the fix-mode hook must apply/drop only its own stash, leaving the foreign
+/// stash intact while still re-staging the formatter's changes.
+#[test]
+fn hooks_run_fix_mode_isolates_own_stash_from_foreign_stash() {
+    let dir = tempfile::tempdir().unwrap();
+    init_hooks_repo(dir.path());
+
+    std::fs::write(dir.path().join("base.txt"), "base\n").unwrap();
+    git(dir.path(), &["add", "base.txt"]);
+    git(dir.path(), &["commit", "-m", "base"]);
+
+    // Orphan stash from another worktree.
+    std::fs::write(dir.path().join("foreign.txt"), "foreign\n").unwrap();
+    git(dir.path(), &["add", "foreign.txt"]);
+    git(dir.path(), &["stash", "push", "--include-untracked"]);
+    let stash_before = git(dir.path(), &["stash", "list"]);
+
+    // Real staged change plus a formatter that appends to it.
+    std::fs::write(dir.path().join("fmt.txt"), "line1\n").unwrap();
+    git(dir.path(), &["add", "fmt.txt"]);
+
+    let hooks_dir = dir.path().join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    std::fs::write(
+        hooks_dir.join("pre-commit.hooks"),
+        "~ for f in \"$@\"; do echo 'formatted' >> \"$f\"; done\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["--color", "never", "hook", "run", "pre-commit"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // The formatter's change must be staged.
+    let staged = git(dir.path(), &["show", ":fmt.txt"]);
+    assert!(
+        staged.contains("formatted"),
+        "staged content should include formatter output, got:\n{staged}"
+    );
+
+    // The foreign stash must be untouched, and its file not dumped.
+    let stash_after = git(dir.path(), &["stash", "list"]);
+    assert_eq!(
+        stash_before, stash_after,
+        "the foreign stash must remain intact, got:\n{stash_after}"
+    );
+    assert!(
+        !dir.path().join("foreign.txt").exists(),
+        "foreign stash contents must not leak into the working tree"
+    );
+}


### PR DESCRIPTION
Git worktrees share a single stash stack (refs/stash). The fix-mode
pre-commit stash dance detected stash creation from `git stash push`'s
exit code, which is 0 even when nothing is stashed, and then applied and
dropped the positional `stash@{0}`. When the committing worktree had
nothing to stash, the hook applied and dropped an orphan stash left by
another worktree — dumping foreign files into the tree and destroying
another worktree's stash.

Detect stash creation by comparing the top of refs/stash before and
after the push, and apply/drop the exact stash commit the hook created,
never the positional top. A stash from another worktree is now never
touched.

Closes #511