### PR TITLE
fix(git-std): fail init before mutating state when no TTY

### DIFF
--- a/crates/git-std/src/cli/init/mod.rs
+++ b/crates/git-std/src/cli/init/mod.rs
@@ -49,6 +49,61 @@ enum FileResult {
     Error,
 }
 
+/// Resolve which hooks to enable for `git std init`.
+///
+/// Honours the `GIT_STD_HOOKS_ENABLE` escape hatch (`all`, `none`, or a
+/// comma-separated list); otherwise prompts interactively. Returns `Err(1)`
+/// when there is no TTY and the env override is unset, or when the user
+/// cancels the prompt. Callers must resolve the selection *before* mutating
+/// any repository state so a non-interactive failure leaves nothing behind
+/// (#504).
+fn resolve_enabled_hooks() -> Result<Vec<&'static str>, i32> {
+    let default_enabled = ["pre-commit", "commit-msg"];
+
+    // Test/CI escape hatch — not a supported public API.
+    // Accepts "all", "none", or a comma-separated list of hook names.
+    if let Ok(val) = std::env::var("GIT_STD_HOOKS_ENABLE") {
+        let selected = match val.to_lowercase().as_str() {
+            "all" => KNOWN_HOOKS.to_vec(),
+            "none" => vec![],
+            _ => val
+                .split(',')
+                .map(|s| s.trim())
+                .filter_map(|s| KNOWN_HOOKS.iter().find(|h| **h == s).copied())
+                .collect(),
+        };
+        return Ok(selected);
+    }
+
+    if !std::io::stdin().is_terminal() {
+        ui::error("interactive prompt requires a TTY");
+        ui::hint("set GIT_STD_HOOKS_ENABLE to select hooks non-interactively");
+        ui::hint("  GIT_STD_HOOKS_ENABLE=all            enable all hooks");
+        ui::hint("  GIT_STD_HOOKS_ENABLE=pre-commit     comma-separated list");
+        ui::hint("  GIT_STD_HOOKS_ENABLE=none            skip all hooks");
+        return Err(1);
+    }
+
+    let options: Vec<&str> = KNOWN_HOOKS.to_vec();
+    match MultiSelect::new("Which hooks do you want to enable?", options)
+        .with_default(
+            &KNOWN_HOOKS
+                .iter()
+                .enumerate()
+                .filter(|(_, h)| default_enabled.contains(h))
+                .map(|(i, _)| i)
+                .collect::<Vec<_>>(),
+        )
+        .prompt()
+    {
+        Ok(s) => Ok(s),
+        Err(_) => {
+            ui::error("init cancelled");
+            Err(1)
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------
@@ -85,6 +140,14 @@ pub fn run(force: bool, refresh: bool) -> i32 {
     }
 
     let hooks_dir = root.join(".githooks");
+
+    // Resolve which hooks to enable *before* touching the repository, so a
+    // non-interactive run without a TTY fails cleanly with no partial state
+    // (#504).
+    let selected = match resolve_enabled_hooks() {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
 
     // ── Step 1: ensure .githooks/ exists ────────────────────────────────────
     if let Err(e) = std::fs::create_dir_all(&hooks_dir) {
@@ -132,50 +195,7 @@ pub fn run(force: bool, refresh: bool) -> i32 {
         }
     }
 
-    // ── Step 4: determine which hooks to enable and write shims ─────────────
-    let default_enabled = ["pre-commit", "commit-msg"];
-
-    // Test/CI escape hatch — not a supported public API.
-    // Accepts "all", "none", or a comma-separated list of hook names.
-    let env_enable = std::env::var("GIT_STD_HOOKS_ENABLE").ok();
-    let selected: Vec<&str> = if let Some(ref val) = env_enable {
-        match val.to_lowercase().as_str() {
-            "all" => KNOWN_HOOKS.to_vec(),
-            "none" => vec![],
-            _ => val
-                .split(',')
-                .map(|s| s.trim())
-                .filter(|s| KNOWN_HOOKS.contains(s))
-                .collect(),
-        }
-    } else if !std::io::stdin().is_terminal() {
-        ui::error("interactive prompt requires a TTY");
-        ui::hint("set GIT_STD_HOOKS_ENABLE to select hooks non-interactively");
-        ui::hint("  GIT_STD_HOOKS_ENABLE=all            enable all hooks");
-        ui::hint("  GIT_STD_HOOKS_ENABLE=pre-commit     comma-separated list");
-        ui::hint("  GIT_STD_HOOKS_ENABLE=none            skip all hooks");
-        return 1;
-    } else {
-        let options: Vec<&str> = KNOWN_HOOKS.to_vec();
-        match MultiSelect::new("Which hooks do you want to enable?", options)
-            .with_default(
-                &KNOWN_HOOKS
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, h)| default_enabled.contains(h))
-                    .map(|(i, _)| i)
-                    .collect::<Vec<_>>(),
-            )
-            .prompt()
-        {
-            Ok(s) => s,
-            Err(_) => {
-                ui::error("init cancelled");
-                return 1;
-            }
-        }
-    };
-
+    // ── Step 4: write shims for the resolved hook selection ─────────────────
     ui::blank();
 
     // Write shims — active for selected, .off for the rest

--- a/crates/git-std/tests/init.rs
+++ b/crates/git-std/tests/init.rs
@@ -247,6 +247,54 @@ fn init_non_tty_without_env_fails() {
         .stderr(predicate::str::contains("GIT_STD_HOOKS_ENABLE"));
 }
 
+/// #504 — a non-TTY init without the env override must fail *before*
+/// mutating any repository state: no `core.hooksPath`, no `.githooks/`
+/// contents, and no "git hooks configured" side-effect message.
+#[test]
+fn init_non_tty_without_env_makes_no_changes() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+
+    let assert = Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["--color", "never", "init"])
+        .current_dir(dir.path())
+        .assert()
+        .failure();
+
+    let err = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        !err.contains("git hooks configured"),
+        "no side effect should be applied before the TTY error, got:\n{err}"
+    );
+
+    // core.hooksPath must not have been set.
+    let hooks_path = std::process::Command::new("git")
+        .args(["config", "--get", "core.hooksPath"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        hooks_path.stdout.is_empty(),
+        "core.hooksPath must not be set after an early-failing init, got:\n{}",
+        String::from_utf8_lossy(&hooks_path.stdout)
+    );
+
+    // No hook templates or shims should have been written.
+    let githooks = dir.path().join(".githooks");
+    if githooks.exists() {
+        let entries: Vec<_> = std::fs::read_dir(&githooks)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            entries.is_empty(),
+            ".githooks/ must be empty after an early-failing init, got:\n{entries:?}"
+        );
+    }
+}
+
 #[test]
 fn init_outputs_hooks_configured() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
`git std init` resolved the interactive hook selection at step 4, after
it had already created `.githooks/`, set `core.hooksPath`, and written
the hook templates. In a non-TTY environment without GIT_STD_HOOKS_ENABLE
it then errored, leaving the repository in a partially-configured state
and printing "git hooks configured" before the failure.

Resolve the hook selection up front, before any filesystem or git
mutation. A non-interactive run without a TTY and without the env
override now fails cleanly with the same hint and leaves nothing behind.

Closes #504