### PR TITLE
fix(git-std): replace convco with git std lint for commit validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
 
-  convco:
+  commit-lint:
     name: Conventional commits
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -58,11 +58,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - run: |
-          curl -sSfL https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip -o /tmp/convco.zip
-          unzip -o /tmp/convco.zip -d /usr/local/bin
-          chmod +x /usr/local/bin/convco
-      - run: convco check ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo run -p git-std --bin git-std -- lint --range ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
 
   install-test:
     name: Install script tests
@@ -74,7 +72,7 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [fmt, dprint, clippy, test, convco, install-test]
+    needs: [fmt, dprint, clippy, test, commit-lint, install-test]
     runs-on: ubuntu-latest
     steps:
       - name: Check results


### PR DESCRIPTION
## Summary

- The "Conventional commits" CI job downloaded a prebuilt `convco` binary as `convco-ubuntu.zip`. Upstream renamed its release assets to target-triple `.tar.gz` files (e.g. `convco-x86_64-unknown-linux-musl.tar.gz`) as of v0.7.0, so the download 404s and the job fails on every PR regardless of commit content. This job feeds the required `CI` status check, so it currently blocks merging any PR, including #512 and #513.
- git-std already validates conventional commits (`git std lint --range`) and this repo already uses that in its own `just verify` recipe. Point CI at the project's own binary instead of an external tool with a fragile release-asset dependency.

## Test plan

- [x] Built `git-std` locally and ran `git std lint --range <base>..<head>` against the commit ranges for #512 and #513 — both pass (`1/1 valid`).
- [x] `actionlint .github/workflows/ci.yml` — no issues.
- [x] `just fmt` — clean.
- [ ] CI on this PR (once opened) exercises the new `commit-lint` job for real.
