### PR TITLE
docs(git-std): add glob version_files recipe

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -152,6 +152,19 @@ path = "src/version.h"
 regex = '#define\s+VERSION\s+"([^"]+)"'
 ```
 
+**Glob pattern (many similar files):**
+
+```toml
+[[version_files]]
+path = "skills/*/SKILL.md"
+regex = 'version:\s*(\S+)'
+```
+
+A `path` containing `* ? [ {` is treated as a glob and expanded
+against every matching file, sharing the same `regex`. See
+[CONFIG.md](CONFIG.md#version_files) for details on glob syntax and
+warning behavior.
+
 These are updated alongside auto-detected files during
 `git std bump`. Use `--dry-run` to preview which files
 would be updated.


### PR DESCRIPTION
## Summary

Small follow-up to #515 — adds a glob-pattern example to the "Multiple files at once" recipe in `docs/recipes.md`, which previously only showed repeated literal `[[version_files]]` entries. Links to `CONFIG.md` for full glob syntax and warning behavior.

Docs-only change; no code changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>