### PR TITLE
docs(git-std): clarify bump rules and --release-as escape hatch

### DIFF
--- a/.agents/skills/std-bump/SKILL.md
+++ b/.agents/skills/std-bump/SKILL.md
@@ -70,7 +70,19 @@ Ask user: "What type of bump?" with options:
 
 - Run `git std bump --dry-run` with all flags determined so far
 - Display the **full dry-run output** to user
-- Show what will be bumped, new versions, and tags that will be created
+- If the output shows **"no bump-worthy commits found"**:
+  - Only `feat`/`fix`/`perf`/`revert`/breaking changes trigger a bump —
+    `docs`/`style`/`refactor`/`test`/`chore`/`ci`/`build` never do (matches
+    the Conventional Commits spec; not configurable).
+  - Ask: "No bump-worthy commits since the last tag. Force a release anyway
+    (e.g. for a docs-only change)?" with options:
+    - "No, don't bump" (stop here)
+    - "Yes, force patch" → add `--release-as patch`
+    - "Yes, force minor" → add `--release-as minor`
+    - "Yes, force major" → add `--release-as major`
+  - Re-run `git std bump --dry-run` with the chosen `--release-as` flag and
+    show the updated plan
+- Otherwise, show what will be bumped, new versions, and tags that will be created
 - Ask: "Proceed with this version bump?" (Yes/No)
 - **Do not proceed without explicit approval**
 
@@ -84,6 +96,7 @@ Ask user: "What type of bump?" with options:
 - Run `git std bump` with all confirmed flags:
   - `--prerelease` if user selected prerelease
   - `--first-release` if applicable
+  - `--release-as <level>` if the user chose to force a bump in Step 7
   - `--package <name>` for each selected package
   - `--push` if user confirmed push in Step 8
 - Display the result (commit hash, new version, tags created)

--- a/crates/git-std/src/app.rs
+++ b/crates/git-std/src/app.rs
@@ -113,7 +113,9 @@ pub enum Command {
         /// Bump as pre-release (e.g. `2.0.0-rc.1`). Uses default tag from config if no value given.
         #[arg(long, num_args = 0..=1, default_missing_value = "")]
         prerelease: Option<String>,
-        /// Force a specific version, skip calculation.
+        /// Force a specific version, or "patch"/"minor"/"major" to force that
+        /// bump level even with no bump-worthy commits (e.g. a docs-only
+        /// release).
         #[arg(long)]
         release_as: Option<String>,
         /// Use current version for initial changelog (no bump).

--- a/crates/git-std/src/cli/bump/mod.rs
+++ b/crates/git-std/src/cli/bump/mod.rs
@@ -16,7 +16,9 @@ pub struct BumpOptions {
     pub dry_run: bool,
     /// Bump as pre-release (e.g. `2.0.0-rc.1`).
     pub prerelease: Option<String>,
-    /// Force a specific version, skip calculation.
+    /// Force a specific version, or "patch"/"minor"/"major" to force that
+    /// bump level even with no bump-worthy commits (e.g. a docs-only
+    /// release).
     pub release_as: Option<String>,
     /// Use current version for initial changelog (no bump).
     pub first_release: bool,

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -332,6 +332,13 @@ changelog, commit, and tag.
    - `BREAKING CHANGE` footer or `!` suffix → major
    - `feat` → minor
    - `fix` / `perf` / `revert` → patch
+   - all other types (`docs`, `style`, `refactor`, `test`,
+     `chore`, `ci`, `build`) → no bump
+
+   This matches the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+   specification and the default rules used by `semantic-release`.
+   It is intentional and not configurable: types other than
+   `feat`/`fix` have no implicit effect on the version.
 
    **Pre-1.0 convention** (major == 0): bump levels are
    downshifted following the Rust/Cargo convention:
@@ -346,6 +353,9 @@ changelog, commit, and tag.
    `0.10.2` + feat → `0.10.3`.
    To force a 1.0.0 release: `git std bump --release-as 1.0.0`.
 5. If no bump-worthy commits exist, print a message and exit `0` (not an error).
+   To release anyway (e.g. for a docs-only change), force a bump level
+   explicitly: `git std bump --release-as patch` (also accepts `minor`
+   or `major`).
 6. Compute the new version string.
 7. Update all version files:
    a. Auto-detected built-in files (see §2.3.1).
@@ -378,20 +388,20 @@ changelog, commit, and tag.
 
 **Flags:**
 
-| Flag                     | Description                                                                               |
-| ------------------------ | ----------------------------------------------------------------------------------------- |
-| `--dry-run`              | Print the full plan without writing anything                                              |
-| `--prerelease [tag]`     | Bump as pre-release (e.g., `2.0.0-rc.1`). Default tag from `[versioning] prerelease_tag`. |
-| `--release-as <version>` | Force a specific version, skip calculation                                                |
-| `--first-release`        | Use current version for initial changelog. No bump.                                       |
-| `--no-tag`               | Update files and commit, skip tag creation                                                |
-| `--no-commit`            | Update files only, no commit or tag                                                       |
-| `--sign` / `-S`          | GPG-sign the release commit and annotated tag                                             |
-| `--skip-changelog`       | Bump version files without changelog generation                                           |
-| `--force`                | Allow breaking changes in patch-only scheme                                               |
-| `--stable [branch]`      | Create a stable branch for patch-only releases (optional custom branch name)              |
-| `--push [remote]`        | Push commit and tags after release. Without a remote, pushes to `origin`                  |
-| `--minor`                | Use minor bump (instead of major) when advancing main after `--stable`                    |
+| Flag                     | Description                                                                                                                                        |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--dry-run`              | Print the full plan without writing anything                                                                                                       |
+| `--prerelease [tag]`     | Bump as pre-release (e.g., `2.0.0-rc.1`). Default tag from `[versioning] prerelease_tag`.                                                          |
+| `--release-as <version>` | Force a specific version, skip calculation. Also accepts `patch`/`minor`/`major` to force that bump level (e.g. when no bump-worthy commits exist) |
+| `--first-release`        | Use current version for initial changelog. No bump.                                                                                                |
+| `--no-tag`               | Update files and commit, skip tag creation                                                                                                         |
+| `--no-commit`            | Update files only, no commit or tag                                                                                                                |
+| `--sign` / `-S`          | GPG-sign the release commit and annotated tag                                                                                                      |
+| `--skip-changelog`       | Bump version files without changelog generation                                                                                                    |
+| `--force`                | Allow breaking changes in patch-only scheme                                                                                                        |
+| `--stable [branch]`      | Create a stable branch for patch-only releases (optional custom branch name)                                                                       |
+| `--push [remote]`        | Push commit and tags after release. Without a remote, pushes to `origin`                                                                           |
+| `--minor`                | Use minor bump (instead of major) when advancing main after `--stable`                                                                             |
 
 **Exit codes:** `0` = success (or no bump needed), `1` = error.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -85,23 +85,23 @@ update version files, generate changelog, commit, and tag.
 
 **Flags:**
 
-| Flag                 | Description                                                        |
-| -------------------- | ------------------------------------------------------------------ |
-| `--dry-run`          | Print plan without writing                                         |
-| `--prerelease [tag]` | Bump as pre-release (e.g. `2.0.0-rc.1`)                            |
-| `--release-as <ver>` | Force a specific version                                           |
-| `--first-release`    | Initial changelog, no bump                                         |
-| `--no-tag`           | Skip tag creation                                                  |
-| `--no-commit`        | Update files only                                                  |
-| `--sign` / `-S`      | GPG-sign commit and tag                                            |
-| `--skip-changelog`   | Bump without changelog                                             |
-| `--force`            | Allow breaking changes in patch-only scheme                        |
-| `--stable [branch]`  | Create a stable branch for patch-only releases                     |
-| `--minor`            | Use minor bump (instead of major) when advancing main after stable |
-| `--format <fmt>`     | Output format: `text` (default) or `json`                          |
-| `--package <name>`   | Filter bump to specific package(s) (monorepo only, repeatable)     |
-| `--push [remote]`    | Push commit and tags after release (default remote: `origin`)      |
-| `--yes` / `-y`       | Skip branch confirmation prompt                                    |
+| Flag                 | Description                                                                                                            |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `--dry-run`          | Print plan without writing                                                                                             |
+| `--prerelease [tag]` | Bump as pre-release (e.g. `2.0.0-rc.1`)                                                                                |
+| `--release-as <ver>` | Force a specific version, or `patch`/`minor`/`major` to force that bump level (e.g. when no bump-worthy commits exist) |
+| `--first-release`    | Initial changelog, no bump                                                                                             |
+| `--no-tag`           | Skip tag creation                                                                                                      |
+| `--no-commit`        | Update files only                                                                                                      |
+| `--sign` / `-S`      | GPG-sign commit and tag                                                                                                |
+| `--skip-changelog`   | Bump without changelog                                                                                                 |
+| `--force`            | Allow breaking changes in patch-only scheme                                                                            |
+| `--stable [branch]`  | Create a stable branch for patch-only releases                                                                         |
+| `--minor`            | Use minor bump (instead of major) when advancing main after stable                                                     |
+| `--format <fmt>`     | Output format: `text` (default) or `json`                                                                              |
+| `--package <name>`   | Filter bump to specific package(s) (monorepo only, repeatable)                                                         |
+| `--push [remote]`    | Push commit and tags after release (default remote: `origin`)                                                          |
+| `--yes` / `-y`       | Skip branch confirmation prompt                                                                                        |
 
 **Exit codes:** `0` = success, `1` = error.
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -29,13 +29,19 @@ Bump rules are inferred from conventional commits:
 
 - `BREAKING CHANGE` or `!` suffix → **major**
 - `feat` → **minor**
-- Everything else → **patch**
+- `fix` / `perf` / `revert` → **patch**
+- `docs` / `style` / `refactor` / `test` / `chore` / `ci` / `build` → **no bump**
+
+This matches the Conventional Commits spec and isn't configurable.
+If no commits warrant a bump but you still want a release (e.g. a
+docs-only change), force the level explicitly:
 
 ```bash
 git std bump               # auto-detect bump type
 git std bump --dry-run     # preview without writing
 git std bump --prerelease  # e.g. 2.0.0-rc.1
 git std bump --release-as 3.0.0  # force a specific version
+git std bump --release-as patch  # force a patch bump with no bump-worthy commits
 ```
 
 ## Calver workflow


### PR DESCRIPTION
## Summary

Addresses part of #518 (bump-rule clarity) as a doc-only fix. Research confirmed:

- The current bump rules (feat->minor, fix/perf/revert->patch, breaking->major, everything else->no bump) exactly match the [Conventional Commits spec](https://www.conventionalcommits.org/en/v1.0.0/) and semantic-release's default rules -- not a bug, and not something to make configurable right now.
- `git std bump --release-as` already accepts `patch`/`minor`/`major` as bump-level keywords (not just exact versions), which forces a release even when no bump-worthy commits exist (e.g. a docs-only release). This was previously undocumented anywhere.
- `docs/recipes.md` had a genuine factual bug: it said "everything else -> patch", which is wrong (only fix/perf/revert bump patch; docs/style/refactor/test/chore/ci/build never bump). This likely contributed to the original confusion in #510/#518.

## Changes

- `crates/git-std/src/app.rs` + `crates/git-std/src/cli/bump/mod.rs`: clarify the `--release-as` doc comment (feeds `--help` text) to mention the patch/minor/major keyword support.
- `docs/SPEC.md`: explicitly enumerate non-bumping commit types, note this matches the CC spec/semantic-release and is intentional/non-configurable, document the `--release-as` escape hatch, update the flags table.
- `docs/USAGE.md`: update the `--release-as` flag table row.
- `docs/recipes.md`: fix the incorrect "everything else -> patch" claim, add the accurate breakdown, add a `--release-as patch` example.
- `.agents/skills/std-bump/SKILL.md`: Step 7 now detects "no bump-worthy commits found" in dry-run output and offers to force a release via `--release-as patch/minor/major`; Step 9 passes the flag through if chosen.

No logic changes -- `parse_release_level()` and the bump-rule inference already worked this way; this PR only makes the behavior discoverable in docs, CLI help, and the agent skill.

## Verification

- `cargo build -p git-std` -- clean
- `just fmt && just lint` -- clean (zero warnings)
- `cargo test -p git-std --test bump` / `cargo test -p git-std-spec --test bump` -- all pass except 3 pre-existing, unrelated push-related test failures (local git remote push mechanics, not touched by this change)
- Manually verified `--help` text renders correctly
