### PR TITLE
feat(git-std): surface unmatched scopes in --context and commit prompt

### DIFF
--- a/.agents/skills/std-commit/SKILL.md
+++ b/.agents/skills/std-commit/SKILL.md
@@ -24,10 +24,19 @@ description: Author a conventional commit for staged changes using git std — u
   - Available **Types** from context (e.g., feat, fix, docs, test, chore)
   - Available **Scopes** from context
   - Whether scopes are `(required, strict)` — if so, `--scope` flag is mandatory
+  - Any `⚠ Staged path '<dir>/' doesn't match any configured scope` warning
 
 **Step 3: Determine commit type and scope**
 
 - Use **only** the types and scopes from context — never invent either.
+- Scopes are configurable in `.git-std.toml`. In `scopes = "auto"` mode, scopes
+  are discovered only from `crates/*`, `packages/*`, `modules/*` — a new
+  top-level folder outside those patterns won't appear as a scope on its own.
+- If `--context` warned about an unmatched scope path, **don't silently fall
+  back** to a generic type/scope (e.g. `docs`/`chore`). Ask the user: "Staged
+  changes touch `<dir>/`, which isn't a configured scope. Add `<dir>` as a new
+  scope in `.git-std.toml` now, use an existing scope instead, or skip the
+  scope for this commit?" Only edit `.git-std.toml` if the user agrees.
 - Ask user to select from available types
 - If scopes are configured, ask user to select or skip
 - For scope: match changed file paths against workspace package names if

--- a/crates/git-std/src/cli/commit/prompt.rs
+++ b/crates/git-std/src/cli/commit/prompt.rs
@@ -69,9 +69,22 @@ pub(super) fn prompt_scope(config: &ProjectConfig) -> Result<Option<String>> {
                     Ok(Some(scope))
                 }
             } else {
-                let items: Vec<&str> = discovered.iter().map(|s| s.as_str()).collect();
-                let selection = Select::new("scope:", items).prompt()?;
-                Ok(Some(selection.to_string()))
+                let staged = crate::git::staged_files(&cwd).unwrap_or_default();
+                let unmatched_dir = crate::config::unmatched_scope_dir(&staged, &discovered);
+                if let Some(dir) = &unmatched_dir {
+                    crate::ui::hint(&format!(
+                        "staged path '{dir}/' doesn't match any configured scope"
+                    ));
+                }
+                let items = scope_select_items(&discovered, unmatched_dir.as_deref());
+                let item_refs: Vec<&str> = items.iter().map(|s| s.as_str()).collect();
+                let selection = Select::new("scope:", item_refs).prompt()?;
+                if selection == OTHER_SCOPE {
+                    let scope = Text::new("new scope:").prompt()?;
+                    Ok(Some(scope))
+                } else {
+                    Ok(Some(selection.to_string()))
+                }
             }
         }
     }
@@ -145,4 +158,37 @@ pub(super) fn prompt_footers() -> Result<Vec<String>> {
         footers.push(input);
     }
     Ok(footers)
+}
+
+/// Sentinel item appended to the scope `Select` when a staged path doesn't
+/// match any discovered scope, letting the user type a new one instead.
+const OTHER_SCOPE: &str = "other (type a new scope)";
+
+/// Build the choice list for the Auto-mode scope `Select` prompt.
+///
+/// Appends [`OTHER_SCOPE`] when `unmatched_dir` is `Some`, signalling that a
+/// staged path didn't match any discovered scope.
+fn scope_select_items(discovered: &[String], unmatched_dir: Option<&str>) -> Vec<String> {
+    let mut items = discovered.to_vec();
+    if unmatched_dir.is_some() {
+        items.push(OTHER_SCOPE.to_string());
+    }
+    items
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_select_items_plain_when_no_unmatched_dir() {
+        let items = scope_select_items(&["api".to_string(), "cli".to_string()], None);
+        assert_eq!(items, vec!["api", "cli"]);
+    }
+
+    #[test]
+    fn scope_select_items_appends_other_when_unmatched_dir() {
+        let items = scope_select_items(&["api".to_string()], Some("services"));
+        assert_eq!(items, vec!["api", OTHER_SCOPE]);
+    }
 }

--- a/crates/git-std/src/cli/context.rs
+++ b/crates/git-std/src/cli/context.rs
@@ -188,6 +188,9 @@ struct CommitConfig {
     /// Suggested type based on staged files. `None` means no confident suggestion.
     /// May be a single type or a shortlist like "feat or fix".
     suggested_type: Option<String>,
+    /// Top-level directory of a staged file that doesn't match any resolved
+    /// scope in `Auto` mode. `None` when scopes aren't `Auto` or everything matches.
+    scope_hint: Option<String>,
 }
 
 enum GitState {
@@ -289,7 +292,7 @@ fn build_workspace_groups(root: &Path, cfg: &ProjectConfig) -> Vec<WorkspaceGrou
     groups
 }
 
-fn build_commit_config(cfg: &ProjectConfig, files: &[String]) -> CommitConfig {
+fn build_commit_config(cfg: &ProjectConfig, repo_root: &Path, files: &[String]) -> CommitConfig {
     let types = cfg.types.clone();
 
     let scopes_line = match &cfg.scopes {
@@ -312,6 +315,14 @@ fn build_commit_config(cfg: &ProjectConfig, files: &[String]) -> CommitConfig {
         }
     };
 
+    let scope_hint = match &cfg.scopes {
+        ScopesConfig::Auto => {
+            let resolved = cfg.resolved_scopes(repo_root, None);
+            config::unmatched_scope_dir(files, &resolved)
+        }
+        ScopesConfig::None | ScopesConfig::List(_) => None,
+    };
+
     let refs_required = cfg.refs_required.clone();
     let suggested_type = suggest_type(files, &types);
 
@@ -320,6 +331,7 @@ fn build_commit_config(cfg: &ProjectConfig, files: &[String]) -> CommitConfig {
         scopes_line,
         refs_required,
         suggested_type,
+        scope_hint,
     }
 }
 
@@ -390,7 +402,7 @@ pub fn run(cwd: &Path, format: OutputFormat) -> i32 {
     // Get staged files for type suggestion
     let staged_files = git::staged_files(&root).unwrap_or_default();
 
-    let commit_cfg = build_commit_config(&cfg, &staged_files);
+    let commit_cfg = build_commit_config(&cfg, &root, &staged_files);
 
     let state = match gather_git_state(&root) {
         Ok(s) => s,
@@ -442,6 +454,11 @@ fn render_text(
     }
     if !commit_cfg.refs_required.is_empty() {
         println!("Refs: required for {}", commit_cfg.refs_required.join(", "));
+    }
+    if let Some(dir) = &commit_cfg.scope_hint {
+        println!(
+            "⚠ Staged path '{dir}/' doesn't match any configured scope — consider adding it to `scopes` in `.git-std.toml`"
+        );
     }
 
     match state {
@@ -557,6 +574,7 @@ fn render_json(
             "suggested_type": commit_cfg.suggested_type,
             "scopes": commit_cfg.scopes_line,
             "refs_required": commit_cfg.refs_required,
+            "scope_hint": commit_cfg.scope_hint,
         },
         "staged_diff": staged_diff,
         "unstaged_files": unstaged_files,
@@ -624,7 +642,8 @@ mod tests {
     #[test]
     fn scopes_line_none_when_no_scopes() {
         let cfg = config::ProjectConfig::default();
-        let cc = build_commit_config(&cfg, &[]);
+        let dir = tempfile::tempdir().unwrap();
+        let cc = build_commit_config(&cfg, dir.path(), &[]);
         assert!(cc.scopes_line.is_none());
     }
 
@@ -635,7 +654,8 @@ mod tests {
             strict: true,
             ..Default::default()
         };
-        let cc = build_commit_config(&cfg, &[]);
+        let dir = tempfile::tempdir().unwrap();
+        let cc = build_commit_config(&cfg, dir.path(), &[]);
         assert_eq!(
             cc.scopes_line.as_deref(),
             Some("from workspace (required, strict)")
@@ -649,14 +669,47 @@ mod tests {
             strict: false,
             ..Default::default()
         };
-        let cc = build_commit_config(&cfg, &[]);
+        let dir = tempfile::tempdir().unwrap();
+        let cc = build_commit_config(&cfg, dir.path(), &[]);
         assert_eq!(cc.scopes_line.as_deref(), Some("api, cli (optional)"));
+    }
+
+    #[test]
+    fn scope_hint_none_when_scopes_not_configured() {
+        let cfg = config::ProjectConfig::default();
+        let dir = tempfile::tempdir().unwrap();
+        let cc = build_commit_config(&cfg, dir.path(), &["services/foo/main.rs".into()]);
+        assert!(cc.scope_hint.is_none());
+    }
+
+    #[test]
+    fn scope_hint_some_for_auto_unmatched_dir() {
+        let cfg = config::ProjectConfig {
+            scopes: config::ScopesConfig::Auto,
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let cc = build_commit_config(&cfg, dir.path(), &["services/foo/main.rs".into()]);
+        assert_eq!(cc.scope_hint.as_deref(), Some("services"));
+    }
+
+    #[test]
+    fn scope_hint_none_for_auto_matched_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("crates/api")).unwrap();
+        let cfg = config::ProjectConfig {
+            scopes: config::ScopesConfig::Auto,
+            ..Default::default()
+        };
+        let cc = build_commit_config(&cfg, dir.path(), &["crates/api/src/main.rs".into()]);
+        assert!(cc.scope_hint.is_none());
     }
 
     #[test]
     fn refs_required_empty_when_not_configured() {
         let cfg = config::ProjectConfig::default();
-        let cc = build_commit_config(&cfg, &[]);
+        let dir = tempfile::tempdir().unwrap();
+        let cc = build_commit_config(&cfg, dir.path(), &[]);
         assert!(cc.refs_required.is_empty());
     }
 
@@ -666,7 +719,8 @@ mod tests {
             refs_required: vec!["feat".into(), "fix".into()],
             ..Default::default()
         };
-        let cc = build_commit_config(&cfg, &[]);
+        let dir = tempfile::tempdir().unwrap();
+        let cc = build_commit_config(&cfg, dir.path(), &[]);
         assert_eq!(cc.refs_required, vec!["feat", "fix"]);
     }
 

--- a/crates/git-std/src/config/mod.rs
+++ b/crates/git-std/src/config/mod.rs
@@ -4,11 +4,13 @@ use serde::Serialize;
 
 pub(crate) mod deps;
 mod load;
+mod scope_hint;
 mod version_files;
 mod workspace;
 
 pub use load::load;
 pub(crate) use load::load_with_raw;
+pub use scope_hint::unmatched_scope_dir;
 pub(crate) use version_files::resolve_custom_version_files;
 pub(crate) use workspace::discover_packages;
 
@@ -16,7 +18,7 @@ pub(crate) use workspace::discover_packages;
 mod tests;
 
 /// Directory patterns scanned for auto-discovered scopes.
-const SCOPE_DIRS: &[&str] = &["crates", "packages", "modules"];
+pub(crate) const SCOPE_DIRS: &[&str] = &["crates", "packages", "modules"];
 
 /// Discover scope names from workspace directory layout.
 ///

--- a/crates/git-std/src/config/scope_hint.rs
+++ b/crates/git-std/src/config/scope_hint.rs
@@ -1,0 +1,93 @@
+//! Detect staged paths that don't match any resolved commit scope.
+//!
+//! Only meaningful for `ScopesConfig::Auto`: an explicit `List` is a closed
+//! set of scopes by design and isn't expected to auto-expand when a new
+//! top-level directory appears.
+
+use super::SCOPE_DIRS;
+
+/// Top-level directories that are conventionally never commit scopes.
+const NON_SCOPE_DIRS: &[&str] = &[
+    "docs",
+    "scripts",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    "vendor",
+];
+
+/// Return the first staged file's top-level directory that doesn't match any
+/// entry in `resolved_scopes`.
+///
+/// Ignores root-level files (no directory component), dotfiles/dot-directories,
+/// the [`SCOPE_DIRS`] parents (`crates`/`packages`/`modules` themselves aren't
+/// scopes — their children are), and [`NON_SCOPE_DIRS`].
+pub fn unmatched_scope_dir(files: &[String], resolved_scopes: &[String]) -> Option<String> {
+    for file in files {
+        let Some((top, _rest)) = file.split_once('/') else {
+            continue;
+        };
+        if top.starts_with('.') {
+            continue;
+        }
+        if SCOPE_DIRS.contains(&top) || NON_SCOPE_DIRS.contains(&top) {
+            continue;
+        }
+        if resolved_scopes.iter().any(|s| s == top) {
+            continue;
+        }
+        return Some(top.to_string());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn none_when_no_staged_files() {
+        assert_eq!(unmatched_scope_dir(&[], &["api".into()]), None);
+    }
+
+    #[test]
+    fn none_for_root_level_file() {
+        let files = vec!["README.md".to_string()];
+        assert_eq!(unmatched_scope_dir(&files, &["api".into()]), None);
+    }
+
+    #[test]
+    fn none_when_top_dir_already_a_resolved_scope() {
+        let files = vec!["api/src/main.rs".to_string()];
+        assert_eq!(unmatched_scope_dir(&files, &["api".into()]), None);
+    }
+
+    #[test]
+    fn some_when_top_dir_not_a_resolved_scope() {
+        let files = vec!["services/foo/main.rs".to_string()];
+        assert_eq!(
+            unmatched_scope_dir(&files, &["api".into()]),
+            Some("services".to_string())
+        );
+    }
+
+    #[test]
+    fn none_for_known_scope_dir_parents() {
+        // "crates" is the parent scanned by discover_scopes, not a scope itself.
+        let files = vec!["crates/api/src/main.rs".to_string()];
+        assert_eq!(unmatched_scope_dir(&files, &["api".into()]), None);
+    }
+
+    #[test]
+    fn none_for_dotdirs() {
+        let files = vec![".github/workflows/ci.yml".to_string()];
+        assert_eq!(unmatched_scope_dir(&files, &[]), None);
+    }
+
+    #[test]
+    fn none_for_known_non_scope_dirs() {
+        let files = vec!["docs/guide.md".to_string()];
+        assert_eq!(unmatched_scope_dir(&files, &[]), None);
+    }
+}

--- a/crates/git-std/tests/context.rs
+++ b/crates/git-std/tests/context.rs
@@ -304,6 +304,49 @@ fn context_commit_config_scopes_from_workspace() {
         .stdout(contains("Scopes: from workspace (required, strict)"));
 }
 
+#[test]
+fn context_warns_on_unmatched_scope_path() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    std::fs::write(dir.path().join(".git-std.toml"), "scopes = \"auto\"\n").unwrap();
+    commit_file(dir.path(), "a.txt", "chore: init");
+
+    std::fs::create_dir_all(dir.path().join("services/foo")).unwrap();
+    std::fs::write(dir.path().join("services/foo/main.rs"), "fn main() {}").unwrap();
+    git(dir.path(), &["add", "services/foo/main.rs"]);
+
+    git_std()
+        .args(["--context"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(contains("'services/' doesn't match any configured scope"))
+        .stdout(contains(".git-std.toml"));
+}
+
+#[test]
+fn context_no_scope_warning_when_paths_match() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo(dir.path());
+    std::fs::write(dir.path().join(".git-std.toml"), "scopes = \"auto\"\n").unwrap();
+    std::fs::create_dir_all(dir.path().join("crates/api")).unwrap();
+    commit_file(dir.path(), "a.txt", "chore: init");
+
+    std::fs::write(dir.path().join("crates/api/main.rs"), "fn main() {}").unwrap();
+    git(dir.path(), &["add", "crates/api/main.rs"]);
+
+    let assert = git_std()
+        .args(["--context"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        !stdout.contains("doesn't match any configured scope"),
+        "should not warn when staged path matches a resolved scope"
+    );
+}
+
 // ===========================================================================
 // Status states
 // ===========================================================================

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -111,6 +111,14 @@ When scopes is set (either `"auto"` or an array) and
 resolved list. For `git std commit`, the resolved scopes
 populate the interactive scope prompt.
 
+With `scopes = "auto"`, if staged changes touch a top-level
+directory that doesn't match any discovered scope (e.g. a new
+folder outside `crates/`, `packages/`, `modules/`), both
+`git std --context` and the interactive `git std commit` scope
+prompt surface a hint — the prompt offers an "other" choice to
+type the new scope directly, and `.git-std.toml` can be updated
+to add it permanently.
+
 **`release_branch`:** When set, bumping on a different branch
 triggers a confirmation prompt (or an error in non-interactive
 mode unless `--yes` is supplied). When unset, both `main` and


### PR DESCRIPTION
## Summary

`scopes = "auto"` only discovers scopes from `crates/*`, `packages/*`, `modules/*`. When staged changes touch a top-level directory outside those patterns, nothing surfaced the mismatch:

- **Humans**: the interactive commit prompt's `Select` only listed discovered scopes, with no way to type a new one.
- **Agents**: following the `std-commit` skill, `--context` gave no signal, so agents silently fell back to a generic type/scope.

Root cause and options were analyzed in #519; this implements the agreed "fix both surfaces" approach.

## Changes

- `config::unmatched_scope_dir` (new `config/scope_hint.rs`): pure function that finds the first staged file's top-level directory not covered by `crates/packages/modules`, a small non-scope denylist (`docs`, `scripts`, `node_modules`, `target`, `dist`, `build`, `vendor`), or the resolved scopes.
- `--context`: `CommitConfig` gains a `scope_hint` field; `render_text` prints a warning when a staged path doesn't match any configured scope, `render_json` exposes `scope_hint`. Only computed for `ScopesConfig::Auto`.
- Interactive commit prompt: `scope_select_items` appends an "other (type a new scope)" choice when an unmatched dir is detected; selecting it opens a free-text prompt instead of restricting to the discovered list.
- `std-commit` skill: extracts the new warning from `--context`, explains `auto` scope discovery, and instructs *not* to silently fall back -- ask the user whether to add the scope, reuse an existing one, or skip scope.
- `docs/CONFIG.md`: documents the new hint behavior for `scopes = "auto"`.

No change to `ScopesConfig::List` or `ScopesConfig::None` behavior.

## Testing

- Added unit tests for `unmatched_scope_dir` (7 cases), `scope_select_items` (2 cases), `build_commit_config`'s `scope_hint` (3 cases).
- Added 2 integration tests in `crates/git-std/tests/context.rs` covering the end-to-end `--context` warning (and its absence when paths match).
- `just fmt`, `just lint`, `cargo test --workspace --no-fail-fast` all clean -- only the 2 pre-existing `bump_push_*` failures remain, unrelated to this change and present on `main`.

Closes #521
