### PR TITLE
test(git-std): use --git-dir for bare remote inspection

### DIFF
--- a/crates/git-std/tests/bump.rs
+++ b/crates/git-std/tests/bump.rs
@@ -1091,10 +1091,20 @@ fn init_remote(local_dir: &Path, remote_dir: &Path, remote_name: &str) {
 }
 
 /// Helper: check whether a tag exists in a bare remote repo.
+///
+/// Uses `--git-dir` explicitly rather than `current_dir()`, since modern git
+/// refuses to operate against a bare repository via cwd alone when
+/// `safe.bareRepository = explicit` is set (a hardening setting some
+/// environments enable globally).
 fn remote_tag_exists(remote_dir: &Path, tag: &str) -> bool {
     std::process::Command::new("git")
-        .current_dir(remote_dir)
-        .args(["rev-parse", "--verify", &format!("refs/tags/{tag}")])
+        .args([
+            "--git-dir",
+            &remote_dir.display().to_string(),
+            "rev-parse",
+            "--verify",
+            &format!("refs/tags/{tag}"),
+        ])
         .output()
         .unwrap()
         .status

--- a/spec/tests/bump.rs
+++ b/spec/tests/bump.rs
@@ -466,9 +466,17 @@ fn bump_push_to_local_remote() {
         .assert()
         .success();
 
+    // Use `--git-dir` explicitly rather than `current_dir()` — modern git
+    // refuses to operate against a bare repository via cwd alone when
+    // `safe.bareRepository = explicit` is set (a hardening setting some
+    // environments enable globally).
     let tag_output = std::process::Command::new("git")
-        .args(["tag", "-l"])
-        .current_dir(remote_dir.path())
+        .args([
+            "--git-dir",
+            remote_dir.path().to_str().unwrap(),
+            "tag",
+            "-l",
+        ])
         .output()
         .expect("git tag -l failed");
     let tags = String::from_utf8_lossy(&tag_output.stdout);


### PR DESCRIPTION
Epic: #398
Closes: #525

## Summary

Fixes `bump_push_default_remote` / `bump_push_named_remote` (and the
analogous e2e test `bump_push_to_local_remote`) which fail deterministically
when the environment sets `safe.bareRepository = explicit` (via
`GIT_CONFIG_KEY_*` / `GIT_CONFIG_VALUE_*` env vars). Modern git refuses to
operate against a bare repository when `current_dir()` points directly at it
without `--git-dir`.

## Change

`remote_tag_exists()` (crates/git-std/tests/bump.rs) and the tag-check helper
in spec/tests/bump.rs now invoke `git --git-dir <path> ...` instead of
relying on `current_dir()`, which is correct regardless of `safe.bareRepository`
and matches how the rest of the test suite already interacts with bare
remotes.

## Testing

- `cargo test --workspace --no-fail-fast`: 100% passing (0 failures) locally,
  including the two previously-flaky tests, run single-threaded and repeatedly.
- `just fmt` / `just lint`: clean, zero warnings.