### PR TITLE
feat(git-std): add root/cross-cutting meta-scope for commit scope discovery

### DIFF
--- a/.agents/skills/std-commit/SKILL.md
+++ b/.agents/skills/std-commit/SKILL.md
@@ -25,6 +25,8 @@ description: Author a conventional commit for staged changes using git std — u
   - Available **Scopes** from context
   - Whether scopes are `(required, strict)` — if so, `--scope` flag is mandatory
   - Any `⚠ Staged path '<dir>/' doesn't match any configured scope` warning
+  - Any `hint: staged files touch root-level or multiple scopes — consider
+    scope '<meta-scope>'` hint
 
 **Step 3: Determine commit type and scope**
 
@@ -32,16 +34,23 @@ description: Author a conventional commit for staged changes using git std — u
 - Scopes are configurable in `.git-std.toml`. In `scopes = "auto"` mode, scopes
   are discovered only from `crates/*`, `packages/*`, `modules/*` — a new
   top-level folder outside those patterns won't appear as a scope on its own.
+  A meta-scope (`default_scope`, `"root"` unless overridden) is also appended
+  to the discovered list for root-only or cross-cutting commits.
 - If `--context` warned about an unmatched scope path, **don't silently fall
   back** to a generic type/scope (e.g. `docs`/`chore`). Ask the user: "Staged
   changes touch `<dir>/`, which isn't a configured scope. Add `<dir>` as a new
   scope in `.git-std.toml` now, use an existing scope instead, or skip the
   scope for this commit?" Only edit `.git-std.toml` if the user agrees.
+- If `--context` printed the meta-scope hint (staged files are root-only, or
+  span two or more discovered scopes), prefer the suggested meta-scope over
+  guessing a single scope from the most-changed path — ask the user to
+  confirm it rather than silently picking one of the touched scopes.
 - Ask user to select from available types
 - If scopes are configured, ask user to select or skip
 - For scope: match changed file paths against workspace package names if
   possible
-  - If diff spans multiple scopes, pick the most-changed one
+  - If diff spans multiple scopes, pick the most-changed one — unless the
+    meta-scope hint fired, in which case prefer the meta-scope
   - If scopes are `(required, strict)` and no scope determined, require user
     selection
 

--- a/crates/git-std/src/cli/commit/prompt.rs
+++ b/crates/git-std/src/cli/commit/prompt.rs
@@ -75,6 +75,15 @@ pub(super) fn prompt_scope(config: &ProjectConfig) -> Result<Option<String>> {
                     crate::ui::hint(&format!(
                         "staged path '{dir}/' doesn't match any configured scope"
                     ));
+                } else {
+                    let meta = config.meta_scope(&cwd);
+                    if discovered.iter().any(|s| s == &meta)
+                        && crate::config::meta_scope_suggested(&staged)
+                    {
+                        crate::ui::hint(&format!(
+                            "staged files touch root-level or multiple scopes — consider `{meta}`"
+                        ));
+                    }
                 }
                 let items = scope_select_items(&discovered, unmatched_dir.as_deref());
                 let item_refs: Vec<&str> = items.iter().map(|s| s.as_str()).collect();

--- a/crates/git-std/src/cli/context.rs
+++ b/crates/git-std/src/cli/context.rs
@@ -191,6 +191,10 @@ struct CommitConfig {
     /// Top-level directory of a staged file that doesn't match any resolved
     /// scope in `Auto` mode. `None` when scopes aren't `Auto` or everything matches.
     scope_hint: Option<String>,
+    /// Meta-scope suggestion for root-only or cross-cutting commits in `Auto`
+    /// mode. `None` when scopes aren't `Auto`, there's an unmatched scope dir
+    /// to flag instead, or the staged files cleanly match a single scope.
+    meta_scope_hint: Option<String>,
 }
 
 enum GitState {
@@ -315,12 +319,22 @@ fn build_commit_config(cfg: &ProjectConfig, repo_root: &Path, files: &[String]) 
         }
     };
 
-    let scope_hint = match &cfg.scopes {
+    let (scope_hint, meta_scope_hint) = match &cfg.scopes {
         ScopesConfig::Auto => {
             let resolved = cfg.resolved_scopes(repo_root, None);
-            config::unmatched_scope_dir(files, &resolved)
+            let scope_hint = config::unmatched_scope_dir(files, &resolved);
+            let meta = cfg.meta_scope(repo_root);
+            let meta_scope_hint = if scope_hint.is_none()
+                && resolved.iter().any(|s| s == &meta)
+                && config::meta_scope_suggested(files)
+            {
+                Some(meta)
+            } else {
+                None
+            };
+            (scope_hint, meta_scope_hint)
         }
-        ScopesConfig::None | ScopesConfig::List(_) => None,
+        ScopesConfig::None | ScopesConfig::List(_) => (None, None),
     };
 
     let refs_required = cfg.refs_required.clone();
@@ -332,6 +346,7 @@ fn build_commit_config(cfg: &ProjectConfig, repo_root: &Path, files: &[String]) 
         refs_required,
         suggested_type,
         scope_hint,
+        meta_scope_hint,
     }
 }
 
@@ -460,6 +475,11 @@ fn render_text(
             "⚠ Staged path '{dir}/' doesn't match any configured scope — consider adding it to `scopes` in `.git-std.toml`"
         );
     }
+    if let Some(meta) = &commit_cfg.meta_scope_hint {
+        println!(
+            "hint: staged files touch root-level or multiple scopes — consider scope `{meta}`"
+        );
+    }
 
     match state {
         GitState::NotBootstrapped => {
@@ -575,6 +595,7 @@ fn render_json(
             "scopes": commit_cfg.scopes_line,
             "refs_required": commit_cfg.refs_required,
             "scope_hint": commit_cfg.scope_hint,
+            "meta_scope_hint": commit_cfg.meta_scope_hint,
         },
         "staged_diff": staged_diff,
         "unstaged_files": unstaged_files,
@@ -703,6 +724,88 @@ mod tests {
         };
         let cc = build_commit_config(&cfg, dir.path(), &["crates/api/src/main.rs".into()]);
         assert!(cc.scope_hint.is_none());
+    }
+
+    #[test]
+    fn meta_scope_hint_none_when_scopes_not_configured() {
+        let cfg = config::ProjectConfig::default();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("crates/api")).unwrap();
+        let cc = build_commit_config(&cfg, dir.path(), &["README.md".into()]);
+        assert!(cc.meta_scope_hint.is_none());
+    }
+
+    #[test]
+    fn meta_scope_hint_none_when_no_scopes_discovered() {
+        // Auto mode but nothing under crates/packages/modules — the
+        // meta-scope isn't appended to resolved_scopes, so it isn't a valid
+        // pick and shouldn't be hinted either.
+        let cfg = config::ProjectConfig {
+            scopes: config::ScopesConfig::Auto,
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let cc = build_commit_config(&cfg, dir.path(), &["README.md".into()]);
+        assert!(cc.meta_scope_hint.is_none());
+    }
+
+    #[test]
+    fn meta_scope_hint_some_for_root_only_files() {
+        let cfg = config::ProjectConfig {
+            scopes: config::ScopesConfig::Auto,
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("crates/api")).unwrap();
+        let cc = build_commit_config(&cfg, dir.path(), &["README.md".into()]);
+        assert_eq!(cc.meta_scope_hint.as_deref(), Some("root"));
+    }
+
+    #[test]
+    fn meta_scope_hint_some_for_files_spanning_multiple_scopes() {
+        let cfg = config::ProjectConfig {
+            scopes: config::ScopesConfig::Auto,
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("crates/api")).unwrap();
+        std::fs::create_dir_all(dir.path().join("crates/auth")).unwrap();
+        let files = vec![
+            "crates/api/src/main.rs".to_string(),
+            "crates/auth/src/lib.rs".to_string(),
+        ];
+        let cc = build_commit_config(&cfg, dir.path(), &files);
+        assert_eq!(cc.meta_scope_hint.as_deref(), Some("root"));
+    }
+
+    #[test]
+    fn meta_scope_hint_none_for_single_matched_scope() {
+        let cfg = config::ProjectConfig {
+            scopes: config::ScopesConfig::Auto,
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("crates/api")).unwrap();
+        let cc = build_commit_config(&cfg, dir.path(), &["crates/api/src/main.rs".into()]);
+        assert!(cc.meta_scope_hint.is_none());
+    }
+
+    #[test]
+    fn meta_scope_hint_none_when_scope_hint_takes_priority() {
+        let cfg = config::ProjectConfig {
+            scopes: config::ScopesConfig::Auto,
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("crates/api")).unwrap();
+        let files = vec![
+            "README.md".to_string(),
+            "crates/api/src/main.rs".to_string(),
+            "somethingnew/x.rs".to_string(),
+        ];
+        let cc = build_commit_config(&cfg, dir.path(), &files);
+        assert_eq!(cc.scope_hint.as_deref(), Some("somethingnew"));
+        assert!(cc.meta_scope_hint.is_none());
     }
 
     #[test]

--- a/crates/git-std/src/config/load.rs
+++ b/crates/git-std/src/config/load.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
 use super::{
-    ChangelogConfig, PackageConfig, ProjectConfig, Scheme, ScopesConfig, VersionFileConfig,
-    VersioningConfig,
+    ChangelogConfig, DEFAULT_META_SCOPE, PackageConfig, ProjectConfig, Scheme, ScopesConfig,
+    VersionFileConfig, VersioningConfig,
 };
 
 /// Config filename.
@@ -34,6 +34,7 @@ pub fn load(dir: &Path) -> ProjectConfig {
             packages: Vec::new(),
             release_branch: None,
             refs_required: Vec::new(),
+            default_scope: DEFAULT_META_SCOPE.to_string(),
         },
     }
 }
@@ -83,6 +84,7 @@ fn default_config() -> ProjectConfig {
         packages: Vec::new(),
         release_branch: None,
         refs_required: Vec::new(),
+        default_scope: DEFAULT_META_SCOPE.to_string(),
     }
 }
 
@@ -148,6 +150,11 @@ fn build_config(table: &toml::Table) -> ProjectConfig {
             .collect(),
         None => Vec::new(),
     };
+    let default_scope = table
+        .get("default_scope")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| DEFAULT_META_SCOPE.to_string());
 
     // Validate calver_format when scheme is calver.
     let versioning = if scheme == Scheme::Calver {
@@ -179,6 +186,7 @@ fn build_config(table: &toml::Table) -> ProjectConfig {
         packages,
         release_branch,
         refs_required,
+        default_scope,
     }
 }
 

--- a/crates/git-std/src/config/mod.rs
+++ b/crates/git-std/src/config/mod.rs
@@ -10,7 +10,7 @@ mod workspace;
 
 pub use load::load;
 pub(crate) use load::load_with_raw;
-pub use scope_hint::unmatched_scope_dir;
+pub use scope_hint::{meta_scope_suggested, unmatched_scope_dir};
 pub(crate) use version_files::resolve_custom_version_files;
 pub(crate) use workspace::discover_packages;
 
@@ -140,8 +140,11 @@ pub struct PackageConfig {
     pub changelog: Option<ChangelogConfig>,
 }
 
+/// Default fallback meta-scope name (see [`ProjectConfig::default_scope`]).
+pub const DEFAULT_META_SCOPE: &str = "root";
+
 /// Project configuration loaded from `.git-std.toml`.
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, Serialize)]
 pub struct ProjectConfig {
     pub types: Vec<String>,
     pub scopes: ScopesConfig,
@@ -162,6 +165,29 @@ pub struct ProjectConfig {
     pub release_branch: Option<String>,
     /// Commit types that require a footer reference (e.g. `feat`, `fix`).
     pub refs_required: Vec<String>,
+    /// Fallback meta-scope used when `scopes = "auto"` (or `monorepo = true`)
+    /// discovery is active and there's no `origin` git remote to derive a
+    /// repo name from. Defaults to `"root"`.
+    pub default_scope: String,
+}
+
+impl Default for ProjectConfig {
+    fn default() -> Self {
+        Self {
+            types: Vec::new(),
+            scopes: ScopesConfig::default(),
+            strict: false,
+            scheme: Scheme::default(),
+            changelog: ChangelogConfig::default(),
+            versioning: VersioningConfig::default(),
+            version_files: Vec::new(),
+            monorepo: false,
+            packages: Vec::new(),
+            release_branch: None,
+            refs_required: Vec::new(),
+            default_scope: DEFAULT_META_SCOPE.to_string(),
+        }
+    }
 }
 
 impl ProjectConfig {
@@ -199,8 +225,15 @@ impl ProjectConfig {
     /// Resolve the effective scope list.
     ///
     /// Returns the explicit list, auto-discovered names, or an empty vec.
-    /// When `monorepo = true`, package names and the project name are always
-    /// appended to the scope list.
+    /// When `monorepo = true`, package names are always appended to the
+    /// scope list.
+    ///
+    /// When scopes are discovered rather than explicitly listed (`scopes =
+    /// "auto"`, or `monorepo = true`) and the result is non-empty, the
+    /// [meta-scope](Self::meta_scope) is appended too — an escape hatch for
+    /// commits that don't cleanly belong to one discovered scope (root-only
+    /// changes, or changes spanning multiple packages). Not applied to an
+    /// explicit `scopes = [...]` list, which is already a curated set.
     ///
     /// When `packages` is `Some`, uses the provided list instead of
     /// re-discovering from disk — avoids redundant filesystem scans.
@@ -209,6 +242,8 @@ impl ProjectConfig {
         repo_root: &Path,
         packages: Option<&[PackageConfig]>,
     ) -> Vec<String> {
+        let is_auto_discovery = matches!(self.scopes, ScopesConfig::Auto) || self.monorepo;
+
         let mut scopes = match &self.scopes {
             ScopesConfig::None if self.monorepo => discover_scopes(repo_root),
             ScopesConfig::None => return Vec::new(),
@@ -230,11 +265,32 @@ impl ProjectConfig {
                     scopes.push(pkg.name.clone());
                 }
             }
+        }
+
+        if is_auto_discovery && !scopes.is_empty() {
+            let meta = self.meta_scope(repo_root);
+            if !scopes.contains(&meta) {
+                scopes.push(meta);
+            }
+        }
+
+        if is_auto_discovery {
             scopes.sort();
             scopes.dedup();
         }
 
         scopes
+    }
+
+    /// Resolve the meta-scope: the repo name from the `origin` git remote,
+    /// or [`default_scope`](Self::default_scope) when there's no remote or
+    /// the URL can't be parsed.
+    ///
+    /// Deriving from the remote (rather than the local checkout directory
+    /// name) keeps the meta-scope stable across git worktrees, which this
+    /// project's own workflow relies on for feature branches.
+    pub fn meta_scope(&self, repo_root: &Path) -> String {
+        crate::git::repo_name_from_remote(repo_root).unwrap_or_else(|| self.default_scope.clone())
     }
 
     /// Resolve the effective package list.
@@ -257,31 +313,17 @@ impl ProjectConfig {
     /// Strict mode is enabled if either the `--strict` CLI flag is passed
     /// or `strict = true` is set in `.git-std.toml`.
     ///
-    /// When `scopes = "auto"`, scopes are discovered from the workspace
-    /// directory layout under `repo_root`. When `monorepo = true`, package
-    /// names are always included regardless of scope mode.
+    /// Scopes are resolved via [`resolved_scopes`](Self::resolved_scopes)
+    /// (explicit list, or discovered from the workspace directory layout /
+    /// monorepo packages, plus the meta-scope where applicable). A scope is
+    /// only required when the resolved list is non-empty.
     pub fn to_lint_config(&self, strict: bool, repo_root: &Path) -> standard_commit::LintConfig {
         if self.strict || strict {
-            let (scopes, require_scope) = if self.monorepo {
-                let resolved = self.resolved_scopes(repo_root, None);
-                if resolved.is_empty() {
-                    (None, false)
-                } else {
-                    (Some(resolved), true)
-                }
+            let resolved = self.resolved_scopes(repo_root, None);
+            let (scopes, require_scope) = if resolved.is_empty() {
+                (None, false)
             } else {
-                match &self.scopes {
-                    ScopesConfig::None => (None, false),
-                    ScopesConfig::Auto => {
-                        let discovered = discover_scopes(repo_root);
-                        if discovered.is_empty() {
-                            (None, false)
-                        } else {
-                            (Some(discovered), true)
-                        }
-                    }
-                    ScopesConfig::List(list) => (Some(list.clone()), true),
-                }
+                (Some(resolved), true)
             };
             // `chore(release)` is the standard commit message produced by
             // `git std bump`. Always allow it so the tool's own commits

--- a/crates/git-std/src/config/scope_hint.rs
+++ b/crates/git-std/src/config/scope_hint.rs
@@ -1,4 +1,5 @@
-//! Detect staged paths that don't match any resolved commit scope.
+//! Detect staged paths that don't match any resolved commit scope, or that
+//! look like a better fit for the meta-scope than any single discovered one.
 //!
 //! Only meaningful for `ScopesConfig::Auto`: an explicit `List` is a closed
 //! set of scopes by design and isn't expected to auto-expand when a new
@@ -40,6 +41,57 @@ pub fn unmatched_scope_dir(files: &[String], resolved_scopes: &[String]) -> Opti
         return Some(top.to_string());
     }
     None
+}
+
+/// Return the candidate scope name for a staged file path, or `None` for a
+/// root-level file (no directory component).
+///
+/// For files under a [`SCOPE_DIRS`] parent (e.g. `crates/api/...`), the
+/// candidate is the child directory name (`api`) — the actual discovered
+/// scope. For any other top-level directory, the candidate is that
+/// directory name itself.
+fn candidate_scope(file: &str) -> Option<String> {
+    let (top, rest) = file.split_once('/')?;
+    if SCOPE_DIRS.contains(&top) {
+        let (child, _) = rest.split_once('/').unwrap_or((rest, ""));
+        if child.is_empty() {
+            None
+        } else {
+            Some(child.to_string())
+        }
+    } else {
+        Some(top.to_string())
+    }
+}
+
+/// Detect whether staged files look like a better fit for the meta-scope
+/// than any single discovered scope: either every file is root-level (no
+/// directory component), or the files' candidate scopes span two or more
+/// distinct entries.
+///
+/// A mix of root-level files and exactly one matched scope is *not*
+/// flagged — the single matched scope is still the more accurate choice.
+pub fn meta_scope_suggested(files: &[String]) -> bool {
+    if files.is_empty() {
+        return false;
+    }
+    let mut candidates: Vec<String> = Vec::new();
+    let mut any_root_level = false;
+    for file in files {
+        match candidate_scope(file) {
+            Some(c) => {
+                if !candidates.contains(&c) {
+                    candidates.push(c);
+                }
+            }
+            None => any_root_level = true,
+        }
+    }
+    if candidates.is_empty() {
+        any_root_level
+    } else {
+        candidates.len() >= 2
+    }
 }
 
 #[cfg(test)]
@@ -89,5 +141,40 @@ mod tests {
     fn none_for_known_non_scope_dirs() {
         let files = vec!["docs/guide.md".to_string()];
         assert_eq!(unmatched_scope_dir(&files, &[]), None);
+    }
+
+    #[test]
+    fn meta_scope_not_suggested_when_no_files() {
+        assert!(!meta_scope_suggested(&[]));
+    }
+
+    #[test]
+    fn meta_scope_suggested_when_all_root_level() {
+        let files = vec!["README.md".to_string(), ".git-std.toml".to_string()];
+        assert!(meta_scope_suggested(&files));
+    }
+
+    #[test]
+    fn meta_scope_suggested_when_spanning_multiple_crates() {
+        let files = vec![
+            "crates/api/src/main.rs".to_string(),
+            "crates/auth/src/lib.rs".to_string(),
+        ];
+        assert!(meta_scope_suggested(&files));
+    }
+
+    #[test]
+    fn meta_scope_not_suggested_for_single_matched_scope() {
+        let files = vec!["crates/api/src/main.rs".to_string()];
+        assert!(!meta_scope_suggested(&files));
+    }
+
+    #[test]
+    fn meta_scope_not_suggested_for_single_scope_plus_root_file() {
+        let files = vec![
+            "README.md".to_string(),
+            "crates/api/src/main.rs".to_string(),
+        ];
+        assert!(!meta_scope_suggested(&files));
     }
 }

--- a/crates/git-std/src/config/tests.rs
+++ b/crates/git-std/src/config/tests.rs
@@ -224,9 +224,16 @@ fn to_lint_config_auto_discovers_scopes() {
         ..Default::default()
     };
     let lint = config.to_lint_config(true, dir.path());
+    // No `origin` remote in this temp dir, so the meta-scope falls back to
+    // the default "root".
     assert_eq!(
         lint.scopes,
-        Some(vec!["api".into(), "auth".into(), "release".into()])
+        Some(vec![
+            "api".into(),
+            "auth".into(),
+            "root".into(),
+            "release".into()
+        ])
     );
     assert!(lint.require_scope);
 }
@@ -252,7 +259,12 @@ fn resolved_scopes_auto() {
         scopes: ScopesConfig::Auto,
         ..Default::default()
     };
-    assert_eq!(config.resolved_scopes(dir.path(), None), vec!["web"]);
+    // No `origin` remote in this temp dir, so the meta-scope falls back to
+    // the default "root".
+    assert_eq!(
+        config.resolved_scopes(dir.path(), None),
+        vec!["root", "web"]
+    );
 }
 
 #[test]
@@ -273,6 +285,111 @@ fn resolved_scopes_none() {
         ..Default::default()
     };
     assert!(config.resolved_scopes(dir.path(), None).is_empty());
+}
+
+/// Initialize a bare git repo with an `origin` remote for meta-scope tests.
+fn init_repo_with_remote(dir: &std::path::Path, remote_url: &str) {
+    let run = |args: &[&str]| {
+        let output = std::process::Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    run(&["init"]);
+    run(&["remote", "add", "origin", remote_url]);
+}
+
+#[test]
+fn resolved_scopes_auto_meta_scope_from_remote() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("crates/api")).unwrap();
+    init_repo_with_remote(dir.path(), "git@github.com:driftsys/git-std.git");
+    let config = ProjectConfig {
+        scopes: ScopesConfig::Auto,
+        ..Default::default()
+    };
+    assert_eq!(
+        config.resolved_scopes(dir.path(), None),
+        vec!["api", "git-std"]
+    );
+}
+
+#[test]
+fn resolved_scopes_auto_meta_scope_custom_default() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("crates/api")).unwrap();
+    let config = ProjectConfig {
+        scopes: ScopesConfig::Auto,
+        default_scope: "meta".into(),
+        ..Default::default()
+    };
+    // No `origin` remote, so the custom `default_scope` is used.
+    assert_eq!(
+        config.resolved_scopes(dir.path(), None),
+        vec!["api", "meta"]
+    );
+}
+
+#[test]
+fn resolved_scopes_auto_no_meta_scope_when_nothing_discovered() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = ProjectConfig {
+        scopes: ScopesConfig::Auto,
+        ..Default::default()
+    };
+    assert!(config.resolved_scopes(dir.path(), None).is_empty());
+}
+
+#[test]
+fn resolved_scopes_list_never_gets_meta_scope() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo_with_remote(dir.path(), "git@github.com:driftsys/git-std.git");
+    let config = ProjectConfig {
+        scopes: ScopesConfig::List(vec!["auth".into()]),
+        ..Default::default()
+    };
+    // Explicit lists are already curated — no implicit meta-scope injection.
+    assert_eq!(config.resolved_scopes(dir.path(), None), vec!["auth"]);
+}
+
+#[test]
+fn meta_scope_prefers_remote_over_default_scope() {
+    let dir = tempfile::tempdir().unwrap();
+    init_repo_with_remote(dir.path(), "https://github.com/driftsys/git-std");
+    let config = ProjectConfig {
+        default_scope: "meta".into(),
+        ..Default::default()
+    };
+    assert_eq!(config.meta_scope(dir.path()), "git-std");
+}
+
+#[test]
+fn meta_scope_falls_back_to_default_scope_without_remote() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = ProjectConfig {
+        default_scope: "meta".into(),
+        ..Default::default()
+    };
+    assert_eq!(config.meta_scope(dir.path()), "meta");
+}
+
+#[test]
+fn default_scope_defaults_to_root() {
+    let config = ProjectConfig::default();
+    assert_eq!(config.default_scope, "root");
+}
+
+#[test]
+fn default_scope_parsed_from_config() {
+    let config = parse_config("default_scope = \"meta\"\n");
+    assert_eq!(config.default_scope, "meta");
 }
 
 #[test]

--- a/crates/git-std/src/git/mod.rs
+++ b/crates/git-std/src/git/mod.rs
@@ -14,7 +14,8 @@ pub use mutate::{
     is_working_tree_dirty, push_follow_tags, stage_files, stage_tracked_modified, workdir,
 };
 pub use query::{
-    commit_date, config_value, current_branch, detect_host, head_oid, resolve_rev, short_status,
-    staged_diff, staged_files, walk_commits, walk_commits_for_path, walk_range,
+    commit_date, config_value, current_branch, detect_host, head_oid, repo_name_from_remote,
+    resolve_rev, short_status, staged_diff, staged_files, walk_commits, walk_commits_for_path,
+    walk_range,
 };
 pub use tag::{collect_tags, find_latest_calver_tag, find_latest_version_tag};

--- a/crates/git-std/src/git/query.rs
+++ b/crates/git-std/src/git/query.rs
@@ -149,6 +149,33 @@ pub fn commit_date(dir: &Path, rev: &str) -> Result<String, GitError> {
     Ok(output[..10].to_string())
 }
 
+/// Parse the repo slug (final path segment) from a git remote URL.
+///
+/// Supports SSH (`git@host:owner/repo.git`) and HTTPS
+/// (`https://host/owner/repo`) forms, stripping a trailing `.git` and/or `/`
+/// if present. Returns `None` for an empty or path-less URL.
+fn repo_slug_from_url(url: &str) -> Option<String> {
+    let trimmed = url.trim();
+    let without_git = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+    let without_slash = without_git.trim_end_matches('/');
+    let slug = without_slash.rsplit(['/', ':']).next()?;
+    if slug.is_empty() {
+        None
+    } else {
+        Some(slug.to_string())
+    }
+}
+
+/// Derive the repo name from the `origin` remote, stable across worktrees
+/// (unlike the local checkout directory name).
+///
+/// Returns `None` when there's no `origin` remote configured or the URL
+/// can't be parsed — callers should fall back to a configured default.
+pub fn repo_name_from_remote(dir: &Path) -> Option<String> {
+    let url = git(dir, &["remote", "get-url", "origin"]).ok()?;
+    repo_slug_from_url(&url)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -400,5 +427,74 @@ mod tests {
             "branch commit must be visible after merge"
         );
         assert_eq!(commits[0].1, "feat: core feature on branch");
+    }
+
+    #[test]
+    fn repo_slug_from_url_ssh() {
+        assert_eq!(
+            repo_slug_from_url("git@github.com:driftsys/git-std.git"),
+            Some("git-std".to_string())
+        );
+    }
+
+    #[test]
+    fn repo_slug_from_url_https() {
+        assert_eq!(
+            repo_slug_from_url("https://github.com/driftsys/git-std"),
+            Some("git-std".to_string())
+        );
+    }
+
+    #[test]
+    fn repo_slug_from_url_https_with_git_suffix() {
+        assert_eq!(
+            repo_slug_from_url("https://github.com/driftsys/git-std.git"),
+            Some("git-std".to_string())
+        );
+    }
+
+    #[test]
+    fn repo_slug_from_url_trailing_slash() {
+        assert_eq!(
+            repo_slug_from_url("https://github.com/driftsys/git-std/"),
+            Some("git-std".to_string())
+        );
+    }
+
+    #[test]
+    fn repo_slug_from_url_empty() {
+        assert_eq!(repo_slug_from_url(""), None);
+    }
+
+    #[test]
+    fn repo_slug_from_url_no_path() {
+        assert_eq!(repo_slug_from_url("git@github.com:"), None);
+    }
+
+    #[test]
+    fn repo_name_from_remote_reads_origin() {
+        let dir = tempfile::tempdir().unwrap();
+        init_repo(dir.path());
+        git(
+            dir.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:driftsys/git-std.git",
+            ],
+        )
+        .unwrap();
+        assert_eq!(
+            repo_name_from_remote(dir.path()),
+            Some("git-std".to_string())
+        );
+    }
+
+    #[test]
+    fn repo_name_from_remote_none_without_remote() {
+        let dir = tempfile::tempdir().unwrap();
+        init_repo(dir.path());
+        assert_eq!(repo_name_from_remote(dir.path()), None);
     }
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1124,7 +1124,9 @@ types = ["feat", "fix", "docs", "style",
          "refactor", "perf", "test",
          "chore", "ci", "build"]
 scopes = ["auth", "api", "ci", "deps"]         # "auto" | string[] | omit
-# "auto" discovers directory names from crates/*/, packages/*/, modules/*/
+# "auto" discovers directory names from crates/*/, packages/*/, modules/*/,
+# plus a meta-scope for root-only or cross-cutting commits (see default_scope)
+default_scope = "root"                         # meta-scope; falls back here when no git remote
 strict = true                                  # enforce types/scopes without --strict flag
 monorepo = false                               # per-package versioning
 
@@ -1160,21 +1162,22 @@ regex = '<version>(.*)</version>'
 
 **Defaults when `.git-std.toml` is absent:**
 
-| Field                       | Default                                                                                      |
-| --------------------------- | -------------------------------------------------------------------------------------------- |
-| `scheme`                    | `semver`                                                                                     |
-| `types`                     | `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert` |
-| `scopes`                    | None (no scope validation)                                                                   |
-| `strict`                    | `false`                                                                                      |
-| `monorepo`                  | `false`                                                                                      |
-| `versioning.tag_prefix`     | `v`                                                                                          |
-| `versioning.prerelease_tag` | `rc`                                                                                         |
-| `versioning.calver_format`  | `YYYY.MM.PATCH`                                                                              |
-| `versioning.tag_template`   | `{name}@{version}`                                                                           |
-| `changelog.hidden`          | `chore`, `ci`, `build`, `style`, `test`                                                      |
-| `changelog.sections`        | Sensible defaults for each type                                                              |
-| `version_files`             | `[]` (empty — built-in files are always auto-detected)                                       |
-| `packages`                  | `[]` (auto-discovered from workspace manifests when `monorepo = true`)                       |
+| Field                       | Default                                                                                       |
+| --------------------------- | --------------------------------------------------------------------------------------------- |
+| `scheme`                    | `semver`                                                                                      |
+| `types`                     | `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`  |
+| `scopes`                    | None (no scope validation)                                                                    |
+| `default_scope`             | `"root"` (meta-scope suggested for root-only or cross-cutting commits when `scopes = "auto"`) |
+| `strict`                    | `false`                                                                                       |
+| `monorepo`                  | `false`                                                                                       |
+| `versioning.tag_prefix`     | `v`                                                                                           |
+| `versioning.prerelease_tag` | `rc`                                                                                          |
+| `versioning.calver_format`  | `YYYY.MM.PATCH`                                                                               |
+| `versioning.tag_template`   | `{name}@{version}`                                                                            |
+| `changelog.hidden`          | `chore`, `ci`, `build`, `style`, `test`                                                       |
+| `changelog.sections`        | Sensible defaults for each type                                                               |
+| `version_files`             | `[]` (empty — built-in files are always auto-detected)                                        |
+| `packages`                  | `[]` (auto-discovered from workspace manifests when `monorepo = true`)                        |
 
 **Inferred (not configurable):**
 
@@ -1356,7 +1359,12 @@ git std lint --range main..HEAD --format json
    Three-way: not set (default, no validation),
    `scopes = "auto"` (discover from `crates/*/`, `packages/*/`,
    `modules/*/` directory names), or `scopes = ["auth", "api"]`
-   (explicit allowlist).
+   (explicit allowlist). In `"auto"` mode, a meta-scope
+   (`default_scope`, defaulting to `"root"`) is appended to the
+   discovered list and proactively suggested when staged changes
+   are root-only or span two or more discovered scopes — this
+   covers root-level and cross-cutting commits that don't map
+   cleanly to a single crate/package/module directory.
 
 3. **Monorepo version sync.** Post-bump, validate that
    workspace-inherited versions resolve correctly?


### PR DESCRIPTION
Epic: #398
Closes: #524

## Summary

`scopes = "auto"` discovers scopes only from `crates/*/`, `packages/*/`, and
`modules/*/` directory names. Commits that touch only root-level files (e.g.
`README.md`, `.git-std.toml`) or span multiple discovered scopes at once had
no good scope to pick — forcing users to either force-fit an unrelated
crate/package scope or skip scope validation entirely.

This adds a curated meta-scope for exactly that case.

## Change

- New `default_scope` config field (`.git-std.toml`), defaulting to `"root"`.
  In `scopes = "auto"` mode, this meta-scope is appended to the discovered
  scope list whenever at least one real scope was discovered.
- `meta_scope_suggested()` (`config/scope_hint.rs`) classifies staged files
  and returns `true` when either all files are root-level, or they span two
  or more distinct discovered scopes. A single matched scope mixed with some
  root-level files is deliberately **not** flagged — the single scope is
  still the more accurate pick.
- `git std --context` and the interactive `git std commit` scope prompt now
  proactively hint the meta-scope when `meta_scope_suggested()` fires,
  unless the existing "unmatched new directory" hint already applies (that
  signal takes priority as more actionable).
- `docs/SPEC.md` and `.agents/skills/std-commit/SKILL.md` updated to
  document the meta-scope and its hint.

## Testing

- New unit tests in `config/scope_hint.rs` (6) and `cli/context.rs` (6)
  covering root-only files, multi-scope spans, single-scope-plus-root
  (not flagged), no scopes configured, and hint-priority ordering.
- `cargo test --workspace --no-fail-fast`: 100% passing.
- `just fmt` / `just lint`: clean, zero warnings.
