### PR TITLE
fix(git-std): keep hook stash after a failed apply

### DIFF
--- a/crates/git-std/src/cli/hook/run.rs
+++ b/crates/git-std/src/cli/hook/run.rs
@@ -278,8 +278,11 @@ pub fn run(hook: &str, args: &[String], format: OutputFormat) -> i32 {
         && !stash::stash_apply(stash_sha)
     {
         ui::error("stash apply failed — working tree has conflicting unstaged changes");
-        ui::hint("commit or stash your unstaged changes first, then retry");
-        stash::stash_drop(stash_sha);
+        ui::hint(&format!(
+            "your original changes are preserved in the stash ({stash_sha}) — resolve \
+             the conflict, inspect it with `git stash show -p {stash_sha}`, then drop it \
+             from `git stash list` once recovered"
+        ));
         print_failure_hints(hook);
         return 1;
     }

--- a/crates/git-std/tests/hooks.rs
+++ b/crates/git-std/tests/hooks.rs
@@ -1246,3 +1246,97 @@ fn hooks_run_fix_mode_isolates_own_stash_from_foreign_stash() {
         "foreign stash contents must not leak into the working tree"
     );
 }
+
+/// #527 — When the hook's own `stash apply` fails, the stash it just
+/// created must not be dropped. Dropping it discards the only recoverable
+/// copy of the pre-stash working tree state, leaving the user with nothing
+/// to recover from beyond the hook's own error message.
+///
+/// `git stash apply` cannot be made to fail against its own immediately
+/// preceding `git stash push` under normal conditions (the round-trip is
+/// designed to be a no-op), so this test shadows `git` on `PATH` with a
+/// thin wrapper that forwards every subcommand to the real binary except
+/// `stash apply`, which it forces to fail — deterministically simulating
+/// the rare conflict/race conditions real users can hit.
+#[test]
+fn hooks_run_fix_mode_keeps_own_stash_when_apply_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    init_hooks_repo(dir.path());
+
+    std::fs::write(dir.path().join("base.txt"), "base\n").unwrap();
+    git(dir.path(), &["add", "base.txt"]);
+    git(dir.path(), &["commit", "-m", "base"]);
+
+    // Any fix-mode command; it must never actually run since apply fails
+    // before the command loop starts.
+    let hooks_dir = dir.path().join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    std::fs::write(hooks_dir.join("pre-commit.hooks"), "~ true\n").unwrap();
+
+    // Real staged change — this is what `stash_push()` will capture.
+    std::fs::write(dir.path().join("staged.txt"), "staged\n").unwrap();
+    git(dir.path(), &["add", "staged.txt"]);
+
+    let path_env = path_with_git_apply_forced_to_fail();
+
+    let assert = Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["--color", "never", "hook", "run", "pre-commit"])
+        .current_dir(dir.path())
+        .env("PATH", &path_env)
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("stash"),
+        "failure message should mention the stash so the user can recover, got:\n{stderr}"
+    );
+
+    // The hook's own stash must still exist — not dropped after the
+    // failed apply.
+    let stash_after = git(dir.path(), &["stash", "list"]);
+    assert!(
+        !stash_after.is_empty(),
+        "the hook's own stash must be preserved after a failed apply, got:\n{stash_after}"
+    );
+}
+
+/// Build a `PATH` whose first entry is a wrapper script shadowing `git`:
+/// it forwards every invocation to the real `git` binary except
+/// `stash apply`, which it forces to fail (exit 1) without doing anything.
+fn path_with_git_apply_forced_to_fail() -> String {
+    let real_git = which_git();
+    let bin_dir = tempfile::tempdir().unwrap();
+    // Leak the tempdir so it outlives this function; test process exit
+    // cleans it up. Fine for a short-lived test binary.
+    let bin_dir = Box::leak(Box::new(bin_dir));
+    let fake_git = bin_dir.path().join("git");
+    std::fs::write(
+        &fake_git,
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = \"stash\" ] && [ \"$2\" = \"apply\" ]; then\n  exit 1\nfi\nexec {real_git} \"$@\"\n"
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    format!(
+        "{}:{}",
+        bin_dir.path().display(),
+        std::env::var("PATH").unwrap_or_default()
+    )
+}
+
+/// Locate the real `git` binary's absolute path via `PATH` lookup.
+fn which_git() -> String {
+    let output = std::process::Command::new("sh")
+        .args(["-c", "command -v git"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "git must be on PATH for this test");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}


### PR DESCRIPTION
Epic: #398
Closes: #527

## Summary

`git std hook run <hook>` in fix mode (stash dance) dropped its own
newly-created stash immediately after a failed `git stash apply`, even
though the conflict was never resolved. The existing #511 safety check in
`stash_drop` only guards against dropping *another worktree's* stash — it
has no concept of "the apply for this exact stash failed, don't drop it".
Since the hook's own stash was still on top at that point, the check
passed and the stash was deleted, leaving the user with unresolved merge
markers on disk and no recoverable copy of their original changes.

## Change

- `crates/git-std/src/cli/hook/run.rs`: removed the `stash::stash_drop(stash_sha)`
  call from the failed-apply branch. The hint message now references the
  stash directly (`git stash show -p <sha>`) so the user can inspect and
  recover their original changes instead of losing them.
- `crates/git-std/tests/hooks.rs`: added a regression test
  (`hooks_run_fix_mode_keeps_own_stash_when_apply_fails`). Since `git stash
  apply` genuinely conflicting against its own immediately-preceding `git
  stash push` doesn't happen under normal conditions (the round-trip is a
  no-op by design), the test shadows `git` on `PATH` with a thin wrapper
  that forwards every subcommand to the real binary except `stash apply`,
  which it forces to fail — deterministically simulating the rare
  conflict/race real users can hit, without flaky timing tricks.

## Testing

- New test fails against the old code (confirmed red before the fix),
  passes after.
- `cargo test --workspace --no-fail-fast`: 100% passing.
- `just fmt` / `just lint`: clean, zero warnings.
