### PR TITLE
fix(git-std): preserve hash in footer issue references

### DIFF
--- a/crates/git-std/src/cli/commit/assemble.rs
+++ b/crates/git-std/src/cli/commit/assemble.rs
@@ -149,8 +149,12 @@ fn parse_trailer(raw: &str) -> Option<(&str, &str)> {
     }
     if let Some(pos) = raw.find(" #") {
         let token = raw[..pos].trim();
-        let value = raw[pos + 2..].trim();
-        if !token.is_empty() && !value.is_empty() {
+        // Keep the '#' itself in the value (start at pos + 1, not pos + 2):
+        // GitHub's issue-closing-keyword parser requires a literal '#'
+        // before the number, so "Closes #525" must parse to value "#525",
+        // not "525" (#526).
+        let value = raw[pos + 1..].trim();
+        if !token.is_empty() && value != "#" && !value.is_empty() {
             return Some((token, value));
         }
     }
@@ -164,4 +168,44 @@ fn resolve_signoff(dir: &std::path::Path) -> Result<String> {
     let email = crate::git::config_value(dir, "user.email")
         .map_err(|e| anyhow::anyhow!("cannot read git user.email: {e}"))?;
     Ok(format!("Signed-off-by: {name} <{email}>"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_trailer;
+
+    #[test]
+    fn parse_trailer_colon_form_returns_token_and_value() {
+        assert_eq!(parse_trailer("Refs: 524"), Some(("Refs", "524")));
+    }
+
+    #[test]
+    fn parse_trailer_hash_form_preserves_hash_in_value() {
+        // #526 — "Closes #525" must keep the '#' in the parsed value, or the
+        // rendered trailer ("Closes: 525") won't be recognised by GitHub's
+        // issue-closing-keyword parser, which requires a literal '#'.
+        assert_eq!(parse_trailer("Closes #525"), Some(("Closes", "#525")));
+    }
+
+    #[test]
+    fn parse_trailer_colon_form_with_hash_preserves_hash() {
+        assert_eq!(parse_trailer("Closes: #525"), Some(("Closes", "#525")));
+    }
+
+    #[test]
+    fn parse_trailer_returns_none_for_missing_separator() {
+        assert_eq!(parse_trailer("not a trailer"), None);
+    }
+
+    #[test]
+    fn parse_trailer_returns_none_for_empty_token() {
+        assert_eq!(parse_trailer(": value"), None);
+        assert_eq!(parse_trailer(" #525"), None);
+    }
+
+    #[test]
+    fn parse_trailer_returns_none_for_empty_value() {
+        assert_eq!(parse_trailer("Closes: "), None);
+        assert_eq!(parse_trailer("Closes #"), None);
+    }
 }

--- a/crates/git-std/tests/commit.rs
+++ b/crates/git-std/tests/commit.rs
@@ -367,6 +367,30 @@ fn commit_dry_run_with_single_footer() {
         .stderr(predicate::str::contains("Co-authored-by: Alice <a@b.com>"));
 }
 
+/// #526 — `--footer "Closes #NNN"` (hash form) must keep the '#' in the
+/// rendered trailer. GitHub's issue-closing-keyword parser requires a
+/// literal '#' before the issue number in every accepted form (`Closes
+/// #10`, `Closes: #10`); a rendered `Closes: 525` (no '#') silently fails
+/// to auto-close the referenced issue on merge.
+#[test]
+fn commit_dry_run_with_hash_form_footer_preserves_hash() {
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args([
+            "commit",
+            "--type",
+            "fix",
+            "-m",
+            "fix bug",
+            "--footer",
+            "Closes #525",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Closes: #525"));
+}
+
 #[test]
 fn commit_dry_run_with_multiple_footers() {
     Command::cargo_bin("git-std")


### PR DESCRIPTION
## Problem

`--footer "Closes #525"` (hash form) silently stripped the `#` when
rendering the trailer, producing `Closes: 525` instead of `Closes: #525`.

GitHub's issue-closing-keyword parser requires a literal `#` before the
issue number in every valid form (`Closes #10`, `Closes: #10`, `CLOSES
#10`, `CLOSES: #10`) — `Closes: 10` is never recognised. This meant a
merged commit using the hash-form footer would **not** auto-close the
referenced issue.

Confirmed via GitHub's docs and a live `--dry-run` repro before fixing:

| Footer input       | Rendered (before) | Rendered (after) |
| ------------------- | ------------------ | ------------------ |
| `Closes #525`       | `Closes: 525` (bug) | `Closes: #525`     |
| `Closes: #525`      | `Closes: #525`      | `Closes: #525`      |

## Root cause

`parse_trailer()` in `crates/git-std/src/cli/commit/assemble.rs` supports
two footer input styles: `"Token: value"` and `"Token #value"`. The hash-form
branch located the `" #"` separator but then sliced the value starting at
`pos + 2`, which skips past the `#` character itself, discarding it.

## Fix

Slice the hash-form value starting at `pos + 1` instead of `pos + 2`, so the
`#` is preserved in the parsed value (e.g. `"Closes #525"` now parses to
`("Closes", "#525")` instead of `("Closes", "525")`). Also tightened the
empty-value guard so a bare `"Closes #"` (no digits after the `#`) is still
correctly rejected as malformed.

`standard-commit`'s footer rendering (`format!("{token}: {value}")`) needed
no change — it already renders whatever string is in `value` verbatim.

## Tests

- New unit tests for `parse_trailer()` covering both forms, both with and
  without a `#`, and malformed/empty-token-or-value edge cases (RED
  confirmed against the pre-fix code, then GREEN after the fix).
- New integration test
  `commit_dry_run_with_hash_form_footer_preserves_hash` in
  `crates/git-std/tests/commit.rs`, exercising the real CLI end-to-end via
  `--dry-run`.

Closes: #526
