### PR TITLE
fix(git-std): make restage_deletions survive file-to-directory transitions

### DIFF
--- a/crates/git-std/src/cli/hook/stash.rs
+++ b/crates/git-std/src/cli/hook/stash.rs
@@ -43,9 +43,18 @@ pub(super) fn fetch_staged(filter: &str) -> Vec<String> {
 
 /// Re-apply staged deletions after the stash dance.
 ///
-/// Runs `git rm --cached --quiet -- <files>` to restore the deletion state
-/// in the index without touching the working tree. This undoes the effect
-/// of `stash apply` which restores deleted files.
+/// Runs `git update-index --force-remove -- <files>` to restore the deletion
+/// state in the index without touching the working tree. This undoes the
+/// effect of `stash apply` which restores deleted files.
+///
+/// `update-index --force-remove` is used instead of `git rm --cached`
+/// because it operates on exact index paths rather than resolving each path
+/// against the working tree. `git rm --cached` refuses a path that used to
+/// be a file but is now a directory on disk (e.g. a deleted file replaced
+/// by a same-named directory in the same change) unless given `-r` — and
+/// `-r` would also recursively strip any unrelated staged additions nested
+/// under that directory (#533). `update-index --force-remove` has neither
+/// problem: it is a no-op when the path is already gone from the index.
 ///
 /// Returns `true` on success, `false` if the command fails. A failure means
 /// the user's `git rm` intent would be silently lost — callers must treat
@@ -55,7 +64,7 @@ pub(super) fn restage_deletions(files: &[String]) -> bool {
         return true;
     }
     let mut cmd = Command::new("git");
-    cmd.args(["rm", "--cached", "--quiet", "--force", "--"]);
+    cmd.args(["update-index", "--force-remove", "--"]);
     for f in files {
         cmd.arg(f);
     }
@@ -64,13 +73,13 @@ pub(super) fn restage_deletions(files: &[String]) -> bool {
         Ok(s) => {
             let code = s.code().unwrap_or(-1);
             ui::error(&format!(
-                "git rm --cached failed (exit {code}) — staged deletions may be lost"
+                "git update-index --force-remove failed (exit {code}) — staged deletions may be lost"
             ));
             false
         }
         Err(e) => {
             ui::error(&format!(
-                "git rm --cached failed after fix-mode stash dance: {e}"
+                "git update-index --force-remove failed after fix-mode stash dance: {e}"
             ));
             false
         }

--- a/crates/git-std/tests/hooks.rs
+++ b/crates/git-std/tests/hooks.rs
@@ -624,6 +624,60 @@ fn hooks_run_fix_mode_preserves_staged_deletions() {
     );
 }
 
+/// #533 — Fix mode survives a staged file-to-directory replacement.
+///
+/// When a tracked file is deleted and a directory with the same name (and a
+/// new file inside it) is staged in its place, `restage_deletions` must not
+/// fail. Previously it ran `git rm --cached --force -- <path>` without `-r`,
+/// which errors with "appears as both a file and as a directory" once the
+/// deleted path now exists as a directory in the working tree.
+#[test]
+fn hooks_run_fix_mode_survives_file_to_directory_replacement() {
+    let dir = tempfile::tempdir().unwrap();
+    init_hooks_repo(dir.path());
+
+    // Commit "thing" as a plain file.
+    std::fs::write(dir.path().join("thing"), "old content\n").unwrap();
+    git(dir.path(), &["add", "thing"]);
+    git(dir.path(), &["commit", "-m", "initial"]);
+
+    // Replace "thing" (file) with "thing/" (a directory containing a file),
+    // staging both the deletion and the new nested addition.
+    std::fs::remove_file(dir.path().join("thing")).unwrap();
+    std::fs::create_dir(dir.path().join("thing")).unwrap();
+    std::fs::write(dir.path().join("thing").join("inner.txt"), "new content\n").unwrap();
+    git(dir.path(), &["add", "-A"]);
+
+    let hooks_dir = dir.path().join(".githooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    // A no-op formatter that succeeds without modifying files.
+    std::fs::write(hooks_dir.join("pre-commit.hooks"), "~ true\n").unwrap();
+
+    Command::cargo_bin("git-std")
+        .unwrap()
+        .args(["--color", "never", "hook", "run", "pre-commit"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // The old file path should still be staged as deleted, and the new
+    // nested file should still be staged as added.
+    let status_output = std::process::Command::new("git")
+        .args(["diff", "--cached", "--name-status"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let name_status = String::from_utf8_lossy(&status_output.stdout);
+    assert!(
+        name_status.contains("D\tthing") && !name_status.contains("D\tthing/inner.txt"),
+        "thing should still be staged as deleted, got:\n{name_status}"
+    );
+    assert!(
+        name_status.contains("A\tthing/inner.txt"),
+        "thing/inner.txt should still be staged as added, got:\n{name_status}"
+    );
+}
+
 /// #268 — Deleted files are not passed as $@ to fix commands.
 ///
 /// Files staged for deletion should not appear in the positional parameters


### PR DESCRIPTION
Closes #533

## Problem

`stash::restage_deletions` re-applies staged deletions after the fix-mode
pre-commit stash dance by running:

```
git rm --cached --quiet --force -- <files>
```

without `-r`. When a path that was previously tracked as a **file** is
replaced at the exact same path by a **directory** in the same staged
change (e.g. `.claude/skills/std-bump` going from a symlink to a real
generated directory in #532), git refuses:

```
'<path>' appears as both a file and as a directory
fatal: not removing '<path>' recursively without -r
```

which aborts the commit hook. Working around this required
`GIT_STD_SKIP_HOOKS=1` for #532.

Simply adding `-r` is not a safe fix: `git rm --cached -r -- <path>` would
recursively strip out every index entry nested under that path — including
the unrelated new file(s) staged at `<path>/<new-file>` in the same change.

## Fix

Switch to `git update-index --force-remove -- <files>`. It operates on
exact index paths rather than resolving each path against the working
tree, so it:

- succeeds unconditionally, even when the path is now a directory on disk
- is a no-op when the path is already gone from the index (already the
  case after `stash apply` correctly restores the staged deletion)
- never recurses, so it can't touch unrelated staged additions nested
  under that path

## Testing

- Added `hooks_run_fix_mode_survives_file_to_directory_replacement` in
  `crates/git-std/tests/hooks.rs`, reproducing the exact scenario (a
  tracked file replaced by a same-named directory with a new nested file,
  run through the real `pre-commit` fix-mode stash dance). Confirmed RED
  against the old `git rm --cached` call (`fatal: not removing ...
  recursively without -r`), then GREEN after the fix.
- `cargo test --workspace --no-fail-fast`: all pass.
- `just fmt` / `just lint`: clean.

## Note

While preparing this fix, I discovered the globally-installed `git-std`
binary used to author commits in this repo can lag behind unreleased fixes
on `main` (no release has been cut since v0.11.12 on 2026-05-01, despite
several merged fixes since). The first commit attempt for this PR silently
reproduced the already-fixed #526 footer-hash-stripping bug because it ran
through the stale installed binary instead of a fresh build. Re-authored
with a locally-built binary; no code changes needed for that, just a
process note for future commits in this repo.
